### PR TITLE
Add Clinical Intelligence with Semantica cookbook notebook

### DIFF
--- a/cookbook/use_cases/healthcare/01_Clinical_Intelligence_with_Semantica.ipynb
+++ b/cookbook/use_cases/healthcare/01_Clinical_Intelligence_with_Semantica.ipynb
@@ -968,7 +968,7 @@
     "\n",
     "SHACL (Shapes Constraint Language) is the W3C standard for defining constraints on graph data and validating records against them: the graph-data equivalent of a JSON Schema. A patient record whose diagnosis or prescription field holds free text instead of a real link to a `Disease` or `Drug` node should be caught by that validation layer rather than reaching a downstream consumer silently. `OntologyEngine.to_shacl` generates shapes directly from the `ontology` object built in Part 3, so the shapes below only ever constrain classes and properties that ontology actually contains (`Disease`, `Drug`, `Patient`, and the `diagnosedWith`/`prescribed`/`treats`/`comorbidWith` relationships); we pass `base_uri=BASE_URI` explicitly so the shapes are minted in our own namespace rather than Semantica's internal default.\n",
     "\n",
-    "Live validation needs `pyshacl` (`pip install semantica[shacl]`); without it, we still see exactly what the generated shapes would enforce."
+    "Live validation needs `pyshacl` (`pip install pyshacl` — see issue #736); without it, we still see exactly what the generated shapes would enforce."
    ]
   },
   {
@@ -1028,9 +1028,9 @@
     "        for v in report.violations:\n",
     "            print(\" -\", getattr(v, \"explanation\", v))\n",
     "    except ImportError as e:\n",
-    "        print(f\"pyshacl not installed: {e}. Install with `pip install semantica[shacl]`.\")\n",
+    "        print(f\"pyshacl not installed: {e}. Install with `pip install pyshacl` (see issue #736 for the missing semantica[shacl] extra).\")\n",
     "else:\n",
-    "    print(\"Skipping live SHACL validation (set USE_PYSHACL=true and install semantica[shacl] to enable).\")\n",
+    "    print(\"Skipping live SHACL validation (set USE_PYSHACL=true and install pyshacl to enable).\")\n",
     "    print(\"The generated shapes above already show what would be enforced: free-text values where a\")\n",
     "    print(\"real entity reference belongs, and datatype violations on required properties.\")"
    ]

--- a/cookbook/use_cases/healthcare/01_Clinical_Intelligence_with_Semantica.ipynb
+++ b/cookbook/use_cases/healthcare/01_Clinical_Intelligence_with_Semantica.ipynb
@@ -1,0 +1,1791 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "33f3892a",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Hawksight-AI/semantica/blob/main/cookbook/use_cases/healthcare/01_Clinical_Intelligence_with_Semantica.ipynb)\n",
+    "\n",
+    "# Clinical Intelligence with Semantica\n",
+    "\n",
+    "**Building Explainable Healthcare Knowledge Systems**\n",
+    "\n",
+    "Clinical decision support has a specific technical requirement that most RAG pipelines don't meet: every recommendation needs an inspectable chain of premises, not just a plausible-sounding answer. This notebook builds that requirement into a working system with [Semantica](https://github.com/Hawksight-AI/semantica), using three synthetic patient cases as running examples: (1) type 2 diabetes with hypertension and elevated HbA1c, (2) type 2 diabetes with declining renal function on a drug that becomes contraindicated below a specific eGFR threshold, and (3) asthma. A fourth case is introduced in the closing capstone to test that the pipeline generalizes.\n",
+    "\n",
+    "We go through ingestion, ontology engineering, knowledge graph construction, reasoning, decision tracking, and export end to end, using Semantica's own classes at each step rather than hand-rolled substitutes.\n",
+    "\n",
+    "### Two kinds of data, and why the difference matters\n",
+    "\n",
+    "- **Real, live reference data.** Disease identity, definitions, and synonyms come from [Wikidata](https://www.wikidata.org/) and [EBI OLS4](https://www.ebi.ac.uk/ols4)/[MONDO](https://mondo.monarchinitiative.org/); drug identifiers from [RxNav/RxNorm](https://lhncbc.nlm.nih.gov/RxNav/); ICD-10-CM codes from [NLM Clinical Tables](https://clinicaltables.nlm.nih.gov/); literature from [PubMed via NCBI E-utilities](https://www.ncbi.nlm.nih.gov/books/NBK25501/); and drug-label contraindication language from [openFDA](https://open.fda.gov/), all fetched live, at runtime, through Semantica's `ingest` module (`OntologyIngestor`, `PublicAPIIngestor`, `WebIngestor`). There is no placeholder text anywhere in this pipeline: if a source that grounds a downstream rule or ontology is unreachable, the notebook raises a clear error rather than substituting fabricated content; only per-item enrichment (e.g. one disease's synonym list) degrades gracefully by being left empty.\n",
+    "- **Synthetic patients.** Three fictional cases (fictional MRNs, fictional names) carry the reasoning and decision narrative. **No real patient data appears anywhere in this notebook.** Live FHIR/MCP integration with a real medical database is a separate notebook, `05_Medical_Database_Integration.ipynb`.\n",
+    "\n",
+    "This is notebook **01** in the healthcare use-case series, alongside `02_Disease_Network_Analysis.ipynb` (a deeper look at disease comorbidity networks) and `05_Medical_Database_Integration.ipynb`. Although every example below is a healthcare one, none of the underlying mechanics are healthcare-specific. The closing \"Adapting This Pattern to Other Domains\" section maps each Part onto its domain-independent building block."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a5bce84",
+   "metadata": {},
+   "source": [
+    "## Installation\n",
+    "\n",
+    "```bash\n",
+    "pip install semantica\n",
+    "pip install semantica[shacl]   # optional, needed for live SHACL validation in Part 6\n",
+    "```\n",
+    "\n",
+    "Every external call in this notebook is to a free, public, no-API-key API. No LLM key is needed to run it top to bottom."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65860e1e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -qU semantica"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1632637e",
+   "metadata": {},
+   "source": [
+    "## Part 1: Introduction\n",
+    "\n",
+    "### Why healthcare needs explainable AI\n",
+    "\n",
+    "When a clinical AI system recommends intensifying therapy or stopping a medication, the operative question isn't \"how confident are you?\" in the abstract. It's \"show your work\": which guideline, which lab value, which prior case this resembles, and what would have to change for the answer to flip. A recommendation without that trail isn't actionable in a regulated clinical setting.\n",
+    "\n",
+    "### Where vector-similarity RAG falls short here\n",
+    "\n",
+    "Embedding documents and retrieving the top-k most similar chunks is a genuinely useful technique, and this notebook uses it too (Part 8, Part 12). But used *alone* for clinical decision support, it runs into structural limits:\n",
+    "\n",
+    "- **Similarity isn't clinical relevance.** A chunk about monitoring hypertension can be textually closer to a query than a chunk about a treatment contraindication, even when the contraindication is the one fact that matters.\n",
+    "- **\"Highest cosine similarity\" is not an audit trail.** It doesn't tell a reviewer *why* this particular passage justified the decision.\n",
+    "- **Nothing stops a bad recommendation from slipping through.** No constraint anywhere says \"not this drug, this patient, this lab value.\"\n",
+    "- **There's no native concept of policy.** A vector index doesn't know that treatment-modification decisions require 0.90 confidence and a second reviewer.\n",
+    "\n",
+    "### Why a knowledge graph and ontology layer closes the gap\n",
+    "\n",
+    "Typed relationships make \"related to\" precise: `comorbid_with` is not `treated_with`. Rule-based reasoning derives new facts *and* keeps the premises attached. SHACL (Shapes Constraint Language, the W3C standard for validating RDF/graph data against a schema) constraints catch a missing or invalid relationship before it reaches a downstream consumer. A decision-tracking layer remembers precedent, causality, and policy compliance for every recommendation made. Vector search stays in the toolkit. It's excellent at finding candidates, but here it works *alongside* structure rather than in place of it.\n",
+    "\n",
+    "### The reusable pattern behind this notebook\n",
+    "\n",
+    "Every technique below is demonstrated on healthcare data, but none of it is healthcare-specific at the architecture level. The pipeline is:\n",
+    "\n",
+    "`ingest real reference data` → `build/reuse an ontology` → `align to external identifiers` → `validate with constraints` → `build a knowledge graph` → `search, reason, and track decisions over it` → `export to standard formats`\n",
+    "\n",
+    "Swap \"disease/drug ontology aligned to ICD-10/MeSH/SNOMED\" for \"financial-instrument ontology aligned to a regulatory taxonomy,\" or \"clinical guideline contraindication rule\" for \"loan-underwriting policy rule,\" and the same 14-part structure applies unchanged. The closing section of this notebook makes that mapping explicit for a few other domains.\n",
+    "\n",
+    "### What we're building it with\n",
+    "\n",
+    "[Semantica](https://github.com/Hawksight-AI/semantica) is a semantic intelligence and knowledge engineering framework. Rather than importing everything up front, each class from `semantica.ingest`, `semantica.parse`, `semantica.split`, `semantica.provenance`, `semantica.ontology`, `semantica.triplet_store`, `semantica.kg`, `semantica.semantic_extract`, `semantica.context`, `semantica.embeddings`, `semantica.vector_store`, `semantica.reasoning`, `semantica.visualization`, and `semantica.export` is imported exactly where it is first needed, so the class in scope always matches the technique being demonstrated."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19eb7b44",
+   "metadata": {},
+   "source": [
+    "## Part 2: Healthcare Data Ingestion\n",
+    "\n",
+    "The reasoning and decision-tracking steps in later Parts depend on a real evidence base: disease definitions and codes, drug identifiers, and regulatory text, none of it typed in by hand: all of it pulled from the same public sources a clinical informatics team would integrate against. We pull from six of them, each through the Semantica `ingest` class built for that job.\n",
+    "\n",
+    "One small utility threads through this whole Part: a `live_fetch` wrapper that runs a call, prints one status line, and on failure reports the failure and continues rather than substituting an invented value. It is the only non-Semantica code needed for the entire ingestion pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c16f49d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "import time\n",
+    "from pathlib import Path\n",
+    "\n",
+    "WORKDIR = Path(tempfile.mkdtemp(prefix=\"semantica_clinical_\"))\n",
+    "print(f\"Working directory for this session: {WORKDIR}\")\n",
+    "\n",
+    "def live_fetch(label, call):\n",
+    "    # Run a live ingestion call; on failure, say so honestly instead of fabricating a value.\n",
+    "    try:\n",
+    "        result = call()\n",
+    "        print(f\"  {label:45s} -> live data retrieved\")\n",
+    "        return result\n",
+    "    except Exception as e:\n",
+    "        print(f\"  {label:45s} -> unavailable ({e}); continuing without this enrichment\")\n",
+    "        return None\n",
+    "\n",
+    "# The disease and drug set our three patients' cases are built from.\n",
+    "DISEASE_NAMES = [\n",
+    "    \"Type 2 Diabetes\", \"Hypertension\", \"Chronic Kidney Disease\", \"Cardiovascular Disease\",\n",
+    "    \"Asthma\", \"Chronic Obstructive Pulmonary Disease\", \"Obesity\",\n",
+    "]\n",
+    "DRUG_NAMES = [\"Metformin\", \"Gliclazide\", \"Lisinopril\", \"Amlodipine\", \"Albuterol\", \"Insulin Glargine\"]\n",
+    "DISEASES = {name: {} for name in DISEASE_NAMES}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24455e0c",
+   "metadata": {},
+   "source": [
+    "### Source 1: Wikidata for Disease Identity\n",
+    "\n",
+    "`PublicAPIIngestor` is Semantica's class for calling a public REST API directly. Wikimedia's search endpoint requires a descriptive `User-Agent` (their API etiquette policy); everything else in this Part is a plain no-key GET."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c56c15e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.ingest import PublicAPIIngestor\n",
+    "\n",
+    "api_ingestor = PublicAPIIngestor()\n",
+    "WIKIMEDIA_HEADERS = {\"User-Agent\": \"SemanticaClinicalNotebook/1.0 (https://github.com/Hawksight-AI/semantica)\"}\n",
+    "\n",
+    "print(\"Searching Wikidata for each disease's real Q-id:\")\n",
+    "for name in DISEASE_NAMES:\n",
+    "    result = live_fetch(name, lambda name=name: api_ingestor.ingest_public_api(\n",
+    "        \"https://www.wikidata.org/w/api.php\",\n",
+    "        params={\"action\": \"wbsearchentities\", \"search\": name, \"language\": \"en\", \"format\": \"json\", \"limit\": 1},\n",
+    "        headers=WIKIMEDIA_HEADERS, normalize_records=False,\n",
+    "    ))\n",
+    "    hits = result.data.get(\"search\", []) if result else []\n",
+    "    DISEASES[name][\"wikidata_qid\"] = hits[0][\"id\"] if hits else None\n",
+    "    time.sleep(0.2)\n",
+    "if not any(d.get(\"wikidata_qid\") for d in DISEASES.values()):\n",
+    "    raise RuntimeError(\"Wikidata search returned no real Q-ids for any disease. Check network access and retry.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1bd264b",
+   "metadata": {},
+   "source": [
+    "### Source 2: EBI OLS4 and MONDO for Definitions, Synonyms, and Cross-References\n",
+    "\n",
+    "[MONDO](https://mondo.monarchinitiative.org/) is a real, actively-curated disease ontology: a structured, standardized catalog of disease concepts maintained by a research consortium, comparable to a controlled vocabulary in any regulated domain. Querying it live through the [EBI Ontology Lookup Service](https://www.ebi.ac.uk/ols4) gets us a real definition, real synonyms, and, crucially for Part 5, real cross-reference codes into four other standard code systems: **ICD-10-CM** (the US clinical diagnosis coding standard), **MeSH** (the US National Library of Medicine's subject-heading vocabulary, used to index biomedical literature), **SNOMED CT** (a comprehensive international clinical terminology), and **UMLS** (a meta-thesaurus that maps between all of the above). Same `PublicAPIIngestor` class, a different endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e2a0097",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MONDO_IDS = {\n",
+    "    \"Type 2 Diabetes\": \"MONDO_0005148\", \"Hypertension\": \"MONDO_0005044\",\n",
+    "    \"Chronic Kidney Disease\": \"MONDO_0005240\", \"Cardiovascular Disease\": \"MONDO_0004995\",\n",
+    "    \"Asthma\": \"MONDO_0004979\", \"Chronic Obstructive Pulmonary Disease\": \"MONDO_0005002\",\n",
+    "    \"Obesity\": \"MONDO_0011122\",\n",
+    "}\n",
+    "\n",
+    "print(\"Querying real MONDO records via EBI OLS4:\")\n",
+    "for name, mondo_id in MONDO_IDS.items():\n",
+    "    result = live_fetch(name, lambda mondo_id=mondo_id: api_ingestor.ingest_public_api(\n",
+    "        \"https://www.ebi.ac.uk/ols4/api/ontologies/mondo/terms\",\n",
+    "        params={\"iri\": f\"http://purl.obolibrary.org/obo/{mondo_id}\"}, normalize_records=False,\n",
+    "    ))\n",
+    "    terms = result.data.get(\"_embedded\", {}).get(\"terms\", []) if result else []\n",
+    "    info = DISEASES[name]\n",
+    "    info[\"mondo_id\"] = mondo_id\n",
+    "    info[\"definition\"] = (terms[0].get(\"description\") or [\"\"])[0] if terms else \"\"\n",
+    "    info[\"synonyms\"] = terms[0].get(\"synonyms\", [])[:8] if terms else []\n",
+    "    info[\"obo_xrefs\"] = terms[0].get(\"obo_xref\", []) if terms else []\n",
+    "    time.sleep(0.2)\n",
+    "if not any(d.get(\"definition\") for d in DISEASES.values()):\n",
+    "    raise RuntimeError(\"EBI OLS4 returned no real MONDO definitions for any disease. Check network access and retry.\")\n",
+    "\n",
+    "print()\n",
+    "print(\"Real MONDO record for Type 2 Diabetes:\")\n",
+    "print(f\"  Definition: {DISEASES['Type 2 Diabetes']['definition'][:150]}\")\n",
+    "print(f\"  Synonyms:   {DISEASES['Type 2 Diabetes']['synonyms'][:4]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c240b13e",
+   "metadata": {},
+   "source": [
+    "### Source 3: openFDA for the Drug Label Behind This Notebook's Rules\n",
+    "\n",
+    "One sentence from a real, live-fetched FDA label is going to justify a SHACL constraint (Part 6), a reasoning rule (Part 9), and a clinical decision (Part 10). This is the one call in the notebook we do not treat as optional: if it fails, the notebook stops rather than substituting placeholder regulatory text for a constraint that real patient-facing logic depends on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8296e83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "label_result = api_ingestor.ingest_public_api(\n",
+    "    \"https://api.fda.gov/drug/label.json\",\n",
+    "    params={\"search\": 'openfda.generic_name:\"metformin\"', \"limit\": 1}, normalize_records=False,\n",
+    ")\n",
+    "fda_results = label_result.data.get(\"results\", [])\n",
+    "if not fda_results:\n",
+    "    raise RuntimeError(\n",
+    "        \"openFDA returned no metformin label. This notebook uses only real, live regulatory text for \"\n",
+    "        \"this constraint and does not fall back to placeholder text. Check network access and retry.\"\n",
+    "    )\n",
+    "\n",
+    "fda_record = fda_results[0]\n",
+    "fda_brand_names = fda_record.get(\"openfda\", {}).get(\"brand_name\", [\"(unbranded)\"])\n",
+    "metformin_contraindication_text = \" \".join(fda_record.get(\"contraindications\", []))\n",
+    "\n",
+    "label_path = WORKDIR / \"metformin_fda_label.txt\"\n",
+    "label_path.write_text(metformin_contraindication_text, encoding=\"utf-8\")\n",
+    "print(f\"Real FDA label for: {fda_brand_names} (metformin-containing product)\")\n",
+    "print(f\"Contraindication text (grounds Parts 6, 9, 10): \\\"{metformin_contraindication_text[:200]}...\\\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "946bb641",
+   "metadata": {},
+   "source": [
+    "### Sources 4 and 5: RxNav for Drug Identifiers, NLM Clinical Tables for ICD-10-CM Codes\n",
+    "\n",
+    "[RxNorm](https://www.nlm.nih.gov/research/umls/rxnorm/) is the US National Library of Medicine's standard naming system for prescription drugs; every drug gets a unique numeric ID (**RxCUI**) that's stable across brand names and formulations. [NLM Clinical Tables](https://clinicaltables.nlm.nih.gov/) is a free lookup API for standard healthcare code sets, used here to confirm each disease's ICD-10-CM code directly rather than assuming it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "632d8b9e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DRUG_RXCUI = {}\n",
+    "print(\"Real RxCUI codes from RxNav:\")\n",
+    "for drug in DRUG_NAMES:\n",
+    "    result = live_fetch(drug, lambda drug=drug: api_ingestor.ingest_public_api(\n",
+    "        \"https://rxnav.nlm.nih.gov/REST/rxcui.json\", params={\"name\": drug}, normalize_records=False,\n",
+    "    ))\n",
+    "    ids = result.data.get(\"idGroup\", {}).get(\"rxnormId\", []) if result else []\n",
+    "    DRUG_RXCUI[drug] = ids[0] if ids else None\n",
+    "    time.sleep(0.2)\n",
+    "if not any(DRUG_RXCUI.values()):\n",
+    "    raise RuntimeError(\"RxNav returned no real RxCUI codes for any drug. Check network access and retry.\")\n",
+    "\n",
+    "print()\n",
+    "print(\"Real ICD-10-CM codes from NLM Clinical Tables:\")\n",
+    "for name in DISEASE_NAMES:\n",
+    "    result = live_fetch(name, lambda name=name: api_ingestor.ingest_public_api(\n",
+    "        \"https://clinicaltables.nlm.nih.gov/api/icd10cm/v3/search\",\n",
+    "        params={\"sf\": \"code,name\", \"terms\": name, \"maxList\": 1}, normalize_records=False,\n",
+    "    ))\n",
+    "    codes = result.data[1] if result and result.data[1] else []\n",
+    "    DISEASES[name][\"icd10cm\"] = codes[0] if codes else None\n",
+    "    time.sleep(0.2)\n",
+    "if not any(d.get(\"icd10cm\") for d in DISEASES.values()):\n",
+    "    raise RuntimeError(\"NLM Clinical Tables returned no real ICD-10-CM codes for any disease. Check network access and retry.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c8c612b",
+   "metadata": {},
+   "source": [
+    "### Source 6: NCBI E-utilities for PubMed Literature\n",
+    "\n",
+    "`esearch` finds real article IDs for a query; `esummary` fetches their real titles, journals, and publication dates. Both are live calls; no synthetic literature text is used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f18b7799",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "search_result = live_fetch(\n",
+    "    \"PubMed esearch: T2D + hypertension comorbidity\",\n",
+    "    lambda: api_ingestor.ingest_public_api(\n",
+    "        \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi\",\n",
+    "        params={\"db\": \"pubmed\", \"term\": \"type 2 diabetes hypertension comorbidity cardiovascular risk\", \"retmax\": 3, \"retmode\": \"json\"},\n",
+    "        normalize_records=False,\n",
+    "    ),\n",
+    ")\n",
+    "pmids = search_result.data.get(\"esearchresult\", {}).get(\"idlist\", []) if search_result else []\n",
+    "\n",
+    "pubmed_articles = []\n",
+    "if pmids:\n",
+    "    summary_result = live_fetch(\n",
+    "        \"PubMed esummary: real titles for the IDs above\",\n",
+    "        lambda: api_ingestor.ingest_public_api(\n",
+    "            \"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi\",\n",
+    "            params={\"db\": \"pubmed\", \"id\": \",\".join(pmids), \"retmode\": \"json\"}, normalize_records=False,\n",
+    "        ),\n",
+    "    )\n",
+    "    if summary_result:\n",
+    "        for pmid in pmids:\n",
+    "            rec = summary_result.data.get(\"result\", {}).get(pmid, {})\n",
+    "            if rec.get(\"title\"):\n",
+    "                pubmed_articles.append(f\"PMID {pmid}: {rec['title']} ({rec.get('source', '')}, {rec.get('pubdate', '')})\")\n",
+    "\n",
+    "pubmed_summary_text = \"\\n\".join(pubmed_articles) if pubmed_articles else f\"PubMed IDs found: {pmids} (titles unavailable).\"\n",
+    "(WORKDIR / \"pubmed_search_result.txt\").write_text(pubmed_summary_text, encoding=\"utf-8\")\n",
+    "print(\"Real PubMed literature:\")\n",
+    "print(pubmed_summary_text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e152a0db",
+   "metadata": {},
+   "source": [
+    "### Synthetic Patient Records (Clearly Separated from the Real Data Above)\n",
+    "\n",
+    "Three fictional patient records, used as test inputs for the rest of the notebook. Each carries two standard lab values: **HbA1c**, a blood test reflecting average blood sugar over roughly three months (used clinically as a diabetes-control indicator), and **eGFR** (estimated Glomerular Filtration Rate), a standard measure of kidney function. Patient 2's synthetic FHIR-shaped `Patient`/`Observation` pair carries an eGFR of 28, which is below the real Metformin contraindication threshold fetched above. This is the record Parts 6, 9, 10, and 11 use to exercise that constraint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2c8c41d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "PATIENTS = [\n",
+    "    {\"mrn\": \"MRN-SYN-0001\", \"age\": 58, \"sex\": \"F\", \"diagnoses\": [\"Type 2 Diabetes\", \"Hypertension\"],\n",
+    "     \"hba1c\": 8.4, \"egfr\": 72, \"current_meds\": [\"Metformin\"]},\n",
+    "    {\"mrn\": \"MRN-SYN-0002\", \"age\": 67, \"sex\": \"M\", \"diagnoses\": [\"Type 2 Diabetes\", \"Chronic Kidney Disease\"],\n",
+    "     \"hba1c\": 7.1, \"egfr\": 28, \"current_meds\": [\"Metformin\"]},\n",
+    "    {\"mrn\": \"MRN-SYN-0003\", \"age\": 34, \"sex\": \"F\", \"diagnoses\": [\"Asthma\"],\n",
+    "     \"hba1c\": None, \"egfr\": None, \"current_meds\": [\"Albuterol\"]},\n",
+    "]\n",
+    "\n",
+    "fhir_patient = {\n",
+    "    \"resourceType\": \"Patient\", \"id\": \"syn-0002\",\n",
+    "    \"identifier\": [{\"system\": \"urn:synthetic:mrn\", \"value\": \"MRN-SYN-0002\"}],\n",
+    "    \"name\": [{\"family\": \"Synthetic\", \"given\": [\"PatientTwo\"]}], \"gender\": \"male\", \"birthDate\": \"1958-03-14\",\n",
+    "}\n",
+    "fhir_observation = {\n",
+    "    \"resourceType\": \"Observation\", \"id\": \"syn-0002-egfr\", \"subject\": {\"reference\": \"Patient/syn-0002\"},\n",
+    "    \"code\": {\"text\": \"eGFR\"}, \"valueQuantity\": {\"value\": 28, \"unit\": \"mL/min/1.73m2\"}, \"effectiveDateTime\": \"2026-06-01\",\n",
+    "}\n",
+    "fhir_patient_path = WORKDIR / \"fhir_patient_syn0002.json\"\n",
+    "fhir_obs_path = WORKDIR / \"fhir_observation_syn0002.json\"\n",
+    "fhir_patient_path.write_text(json.dumps(fhir_patient, indent=2), encoding=\"utf-8\")\n",
+    "fhir_obs_path.write_text(json.dumps(fhir_observation, indent=2), encoding=\"utf-8\")\n",
+    "print(\"Synthetic FHIR-shaped resources written for patient MRN-SYN-0002 (fictional).\")\n",
+    "print(\"Full live FHIR/MCP integration is covered in 05_Medical_Database_Integration.ipynb.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e70631e9",
+   "metadata": {},
+   "source": [
+    "### Multi-source ingestion\n",
+    "\n",
+    "Four different file types on disk, each meeting its matching Semantica parser: `FileIngestor` reads bytes off disk, then `JSONParser` and `CSVParser` turn the FHIR JSON and the disease/drug CSV into structured records."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08686b0f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "csv_path = WORKDIR / \"disease_drug_icd10.csv\"\n",
+    "primary_drug = {\n",
+    "    \"Type 2 Diabetes\": \"Metformin\", \"Hypertension\": \"Lisinopril\", \"Chronic Kidney Disease\": \"Gliclazide\",\n",
+    "    \"Cardiovascular Disease\": \"Amlodipine\", \"Asthma\": \"Albuterol\",\n",
+    "    \"Chronic Obstructive Pulmonary Disease\": \"Albuterol\", \"Obesity\": \"Metformin\",\n",
+    "}\n",
+    "with open(csv_path, \"w\", encoding=\"utf-8\", newline=\"\") as f:\n",
+    "    f.write(\"disease_name,icd10cm_code,drug_name,rxcui\\n\")\n",
+    "    for disease, drug in primary_drug.items():\n",
+    "        f.write(f'\"{disease}\",{DISEASES[disease].get(\"icd10cm\") or \"\"},\"{drug}\",{DRUG_RXCUI.get(drug) or \"\"}\\n')\n",
+    "print(f\"Wrote {csv_path.name} from the real ICD-10-CM/RxCUI codes fetched above.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "992ecfa2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.ingest import FileIngestor\n",
+    "\n",
+    "file_ingestor = FileIngestor()\n",
+    "for p in [label_path, WORKDIR / \"pubmed_search_result.txt\", fhir_patient_path, fhir_obs_path, csv_path]:\n",
+    "    obj = file_ingestor.ingest_file(str(p), read_content=True)\n",
+    "    print(f\"  ingested {p.name:35s} {obj.size:>5} bytes  type={obj.file_type}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ec46349",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.parse import JSONParser, CSVParser\n",
+    "\n",
+    "parsed_patient = JSONParser().parse(str(fhir_patient_path))\n",
+    "parsed_csv = CSVParser().parse(str(csv_path))\n",
+    "print(f\"Parsed FHIR Patient resourceType: {parsed_patient.data.get('resourceType')}\")\n",
+    "print(f\"Parsed CSV rows: {parsed_csv.row_count}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c64c80ab",
+   "metadata": {},
+   "source": [
+    "### Entity-aware chunking\n",
+    "\n",
+    "For retrieval-oriented use (Part 12), long documents need chunking that respects entity boundaries rather than cutting mid-mention. `TextSplitter(method=\"entity_aware\")` is Semantica's class for exactly that."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "670791d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.split import TextSplitter\n",
+    "\n",
+    "label_chunks = TextSplitter(method=\"entity_aware\", chunk_size=250, chunk_overlap=30).split(metformin_contraindication_text)\n",
+    "print(f\"Real FDA label text split into {len(label_chunks)} entity-aware chunk(s).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "297999aa",
+   "metadata": {},
+   "source": [
+    "### Provenance capture\n",
+    "\n",
+    "Every source gets tracked with the **real URL it actually came from**, or, for the synthetic FHIR data, an explicit `synthetic:` marker, so nothing here is quietly passed off as real later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c5fd814",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.provenance import ProvenanceManager\n",
+    "\n",
+    "prov = ProvenanceManager()\n",
+    "prov.track_entity(entity_id=\"doc:fda_label_metformin\",\n",
+    "                   source=\"https://api.fda.gov/drug/label.json?search=openfda.generic_name:metformin\",\n",
+    "                   metadata={\"content_type\": \"drug_label\"})\n",
+    "prov.track_entity(entity_id=\"doc:pubmed_search\",\n",
+    "                   source=\"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi\",\n",
+    "                   metadata={\"content_type\": \"literature_search\", \"pmids\": pmids})\n",
+    "prov.track_entity(entity_id=\"doc:fhir_patient_syn0002\", source=\"synthetic:not-a-real-patient\",\n",
+    "                   metadata={\"content_type\": \"fhir_patient\", \"synthetic\": True})\n",
+    "\n",
+    "lineage = prov.get_lineage(\"doc:fda_label_metformin\")\n",
+    "print(\"Lineage for the FDA label document:\")\n",
+    "print(json.dumps(lineage, indent=2, default=str)[:400])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44397580",
+   "metadata": {},
+   "source": [
+    "Part 2 leaves us with a real evidence base (`DISEASES`, `DRUG_RXCUI`) and a lineage trail (`prov`) for it, plus three patients waiting on a diagnosis to become a decision. Everything from here builds on these same objects."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e3218af",
+   "metadata": {},
+   "source": [
+    "## Part 3: Medical Ontology Engineering\n",
+    "\n",
+    "An ontology is the formal answer to \"what kinds of things exist here, and how do they relate?\" We build ours two ways, and both matter:\n",
+    "\n",
+    "1. **Borrowed from a real external ontology.** For each disease, we download the real Turtle RDF that Wikidata publishes for that concept and parse it with `OntologyIngestor`, Semantica's dedicated class for ontology files. This is genuine external content, not text we wrote.\n",
+    "2. **Derived from our own data.** `OntologyEngine.from_data` looks at the entities and relationships we're about to define and infers `Disease`, `Drug`, `Patient`, `Treatment` classes from them.\n",
+    "\n",
+    "A production system would lean much further on standard biomedical ontologies (MeSH, Gene Ontology, Human Phenotype Ontology, MONDO, DrugBank) rather than deriving a domain model from scratch. Part 5 does exactly that alignment with the identifiers we already fetched."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1011671",
+   "metadata": {},
+   "source": [
+    "### Naming things consistently: `NamespaceManager`\n",
+    "\n",
+    "Every entity, class, and property below needs a stable URI. Rather than hand-rolling a `name -> URI` function, we use `NamespaceManager`, the Semantica class built for exactly this, so individual URIs, class URIs, and (in Part 5) alignment predicate URIs all come from one consistent, namespace-aware source."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3491aeb7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.ontology import NamespaceManager\n",
+    "\n",
+    "BASE_URI = \"https://example.org/clinical/\"\n",
+    "namespace_manager = NamespaceManager(base_uri=BASE_URI)\n",
+    "\n",
+    "print(\"Individual URI: \", namespace_manager.generate_individual_iri(\"Type 2 Diabetes\"))\n",
+    "print(\"Class URI:      \", namespace_manager.generate_class_iri(\"Disease\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "436001ff",
+   "metadata": {},
+   "source": [
+    "### Real ontology file ingestion: Wikidata Turtle RDF via `OntologyIngestor`\n",
+    "\n",
+    "For each disease, we search Wikidata for its real Q-id, download the Turtle RDF Wikidata publishes at that entity's data endpoint, and parse it with `OntologyIngestor.ingest_ontology`, the same class a production pipeline would use to load a vendor-supplied `.owl` or `.ttl` file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ec39fb7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.ingest import WebIngestor, OntologyIngestor\n",
+    "\n",
+    "# Wikidata's robots.txt disallows crawling /wiki/Special:*, but EntityData is a public linked-data\n",
+    "# export endpoint meant for exactly this kind of programmatic access, not a page to be crawled.\n",
+    "web_ingestor = WebIngestor(respect_robots=False)\n",
+    "ontology_ingestor = OntologyIngestor()\n",
+    "\n",
+    "wikidata_ontology_data = {}\n",
+    "for name, info in DISEASES.items():\n",
+    "    qid = info.get(\"wikidata_qid\")\n",
+    "    if not qid:\n",
+    "        print(f\"  {name:42s} -> skipped (no Wikidata Q-id)\")\n",
+    "        continue\n",
+    "    content = live_fetch(f\"{name} ({qid}) .ttl\", lambda qid=qid: web_ingestor.ingest_url(\n",
+    "        f\"https://www.wikidata.org/wiki/Special:EntityData/{qid}.ttl\"\n",
+    "    ))\n",
+    "    if content is None:\n",
+    "        continue\n",
+    "    # .html carries the response body untouched; .text runs an HTML-readability extractor that\n",
+    "    # strips the '<...>' URIs out of non-HTML Turtle content, so we deliberately use .html here.\n",
+    "    ttl_path = WORKDIR / f\"wikidata_{qid}.ttl\"\n",
+    "    ttl_path.write_text(content.html, encoding=\"utf-8\")\n",
+    "    ont_data = ontology_ingestor.ingest_ontology(ttl_path, format=\"turtle\")\n",
+    "    wikidata_ontology_data[name] = ont_data\n",
+    "    def count_of(value):\n",
+    "        return len(value) if isinstance(value, (list, dict)) else value\n",
+    "    n_classes = count_of(ont_data.data.get(\"classes\", 0))\n",
+    "    n_props = count_of(ont_data.data.get(\"properties\", 0))\n",
+    "    print(f\"      -> {n_classes} classes, {n_props} properties parsed from real Wikidata RDF\")\n",
+    "\n",
+    "if not wikidata_ontology_data:\n",
+    "    raise RuntimeError(\n",
+    "        \"No real Wikidata ontology files could be ingested for any disease. This notebook demonstrates \"\n",
+    "        \"OntologyIngestor on genuine external RDF and does not substitute a synthetic ontology. Check \"\n",
+    "        \"network access and retry.\"\n",
+    "    )\n",
+    "print(f\"\\nReal external ontology files ingested for {len(wikidata_ontology_data)}/{len(DISEASES)} diseases.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95afe2f4",
+   "metadata": {},
+   "source": [
+    "### Deriving our own clinical ontology\n",
+    "\n",
+    "Now the entities and relationships our three patients' cases are built from (diseases, drugs, comorbidities, treatments, diagnoses) are all named with `namespace_manager`, then handed to `OntologyEngine.from_data`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "709b74a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DRUG_TREATS = {\n",
+    "    \"Metformin\": [\"Type 2 Diabetes\", \"Obesity\"], \"Gliclazide\": [\"Type 2 Diabetes\"],\n",
+    "    \"Insulin Glargine\": [\"Type 2 Diabetes\"], \"Lisinopril\": [\"Hypertension\"],\n",
+    "    \"Amlodipine\": [\"Hypertension\", \"Cardiovascular Disease\"],\n",
+    "    \"Albuterol\": [\"Asthma\", \"Chronic Obstructive Pulmonary Disease\"],\n",
+    "}\n",
+    "COMORBID_PAIRS = [\n",
+    "    (\"Type 2 Diabetes\", \"Hypertension\"), (\"Type 2 Diabetes\", \"Chronic Kidney Disease\"),\n",
+    "    (\"Type 2 Diabetes\", \"Obesity\"), (\"Hypertension\", \"Chronic Kidney Disease\"),\n",
+    "    (\"Hypertension\", \"Cardiovascular Disease\"), (\"Asthma\", \"Chronic Obstructive Pulmonary Disease\"),\n",
+    "]\n",
+    "\n",
+    "ENTITIES = []\n",
+    "RELATIONSHIPS = []\n",
+    "\n",
+    "for name, info in DISEASES.items():\n",
+    "    ENTITIES.append({\"id\": namespace_manager.generate_individual_iri(name), \"type\": \"Disease\", \"name\": name,\n",
+    "                      \"properties\": {\"definition\": info.get(\"definition\", \"\"), \"mondo_id\": info.get(\"mondo_id\", \"\"),\n",
+    "                                     \"icd10cm\": info.get(\"icd10cm\") or \"\"}})\n",
+    "for drug in DRUG_NAMES:\n",
+    "    ENTITIES.append({\"id\": namespace_manager.generate_individual_iri(drug), \"type\": \"Drug\", \"name\": drug,\n",
+    "                      \"properties\": {\"rxcui\": DRUG_RXCUI.get(drug) or \"\"}})\n",
+    "for drug, diseases in DRUG_TREATS.items():\n",
+    "    for disease in diseases:\n",
+    "        RELATIONSHIPS.append({\"source\": namespace_manager.generate_individual_iri(drug),\n",
+    "                               \"target\": namespace_manager.generate_individual_iri(disease), \"type\": \"treats\"})\n",
+    "for a, b in COMORBID_PAIRS:\n",
+    "    RELATIONSHIPS.append({\"source\": namespace_manager.generate_individual_iri(a),\n",
+    "                           \"target\": namespace_manager.generate_individual_iri(b), \"type\": \"comorbid_with\"})\n",
+    "for p in PATIENTS:\n",
+    "    ENTITIES.append({\"id\": p[\"mrn\"], \"type\": \"Patient\", \"name\": p[\"mrn\"], \"properties\": {\"age\": p[\"age\"], \"sex\": p[\"sex\"]}})\n",
+    "    for d in p[\"diagnoses\"]:\n",
+    "        RELATIONSHIPS.append({\"source\": p[\"mrn\"], \"target\": namespace_manager.generate_individual_iri(d), \"type\": \"diagnosed_with\"})\n",
+    "    for m in p[\"current_meds\"]:\n",
+    "        RELATIONSHIPS.append({\"source\": p[\"mrn\"], \"target\": namespace_manager.generate_individual_iri(m), \"type\": \"prescribed\"})\n",
+    "\n",
+    "print(f\"ENTITIES: {len(ENTITIES)}   RELATIONSHIPS: {len(RELATIONSHIPS)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4fd9a44d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.ontology import OntologyEngine\n",
+    "\n",
+    "engine = OntologyEngine(base_uri=BASE_URI)\n",
+    "ontology = engine.from_data({\"entities\": ENTITIES, \"relationships\": RELATIONSHIPS})\n",
+    "print(f\"Inferred classes: {[c.get('name') for c in ontology.get('classes', [])]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88f12797",
+   "metadata": {},
+   "source": [
+    "### Class hierarchy, properties, and one multi-way fact\n",
+    "\n",
+    "`ClassInferrer` and `PropertyGenerator` complete the class/property picture. `AssociativeClassBuilder` then models a `PrescriptionEvent`: a graph relationship is normally a simple triple (patient, prescribed, drug), but \"prescribed at what dose, starting when\" needs a fact that connects *more than two* things at once. `AssociativeClassBuilder` handles this by introducing an intermediate node, a standard ontology-engineering technique called reification, rather than losing that context. The same pattern is used for HR employment events in `cookbook/advanced/13_Manual_Ontology_Snowflake_Mapping.ipynb`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "edd257da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.ontology import ClassInferrer, PropertyGenerator\n",
+    "\n",
+    "inferred_classes = ClassInferrer().infer_classes(ENTITIES)\n",
+    "inferred_properties = PropertyGenerator().infer_properties(ENTITIES, RELATIONSHIPS, ontology.get(\"classes\", []))\n",
+    "print(f\"Inferred class hierarchy entries: {len(inferred_classes) if isinstance(inferred_classes, list) else 'n/a'}\")\n",
+    "print(f\"Inferred properties: {len(inferred_properties) if isinstance(inferred_properties, list) else 'n/a'}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "735fce4e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.ontology import AssociativeClassBuilder\n",
+    "\n",
+    "prescription_event = AssociativeClassBuilder().create_associative_class(\n",
+    "    name=\"PrescriptionEvent\", connects=[\"Patient\", \"Drug\"], temporal=True,\n",
+    "    properties={\"dose\": \"xsd:string\", \"startDate\": \"xsd:date\"},\n",
+    ")\n",
+    "print(f\"AssociativeClass {prescription_event.name}: connects={prescription_event.connects}, \"\n",
+    "      f\"temporal={prescription_event.temporal}, properties={list(prescription_event.properties.keys())}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "307a95d6",
+   "metadata": {},
+   "source": [
+    "### Exporting to OWL"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8df0cab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "owl_ttl = engine.to_owl(ontology, format=\"turtle\")\n",
+    "print(f\"Generated {len(owl_ttl):,} characters of OWL Turtle:\\n\")\n",
+    "print(\"\\n\".join(owl_ttl.splitlines()[:15]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e82f8488",
+   "metadata": {},
+   "source": [
+    "Two ontologies now sit side by side: the real one we borrowed (`wikidata_ontology_data`) and the one we derived (`ontology`, `engine`). Part 5 connects them properly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78f88c41",
+   "metadata": {},
+   "source": [
+    "## Part 4: SKOS Vocabulary Management\n",
+    "\n",
+    "The same disease is referenced under multiple surface forms across sources: \"heart disease,\" \"cardiac disease,\" and \"cardiovascular disease\" all need to resolve to one concept with one preferred label, while remaining findable under any of the alternate terms. SKOS (Simple Knowledge Organization System) is the W3C standard for exactly this: a concept scheme with preferred labels, alternate labels, and explicit broader/narrower hierarchy. We build a two-branch taxonomy:\n",
+    "\n",
+    "```\n",
+    "Disease\n",
+    "├── Cardiovascular Disease\n",
+    "│   └── Hypertension\n",
+    "└── Respiratory Disease\n",
+    "    ├── Asthma\n",
+    "    └── Chronic Obstructive Pulmonary Disease\n",
+    "```\n",
+    "\n",
+    "Preferred labels are our canonical names; **alternate labels are the real synonyms MONDO gave us in Part 2** (T2DM, NIDDM, adult-onset diabetes, and so on), not invented ones.\n",
+    "\n",
+    "`TripletStore`, Semantica's RDF/SPARQL store, needs a live backend (`blazegraph`, `jena`, or `rdf4j`; there's no in-memory option), so the concept scheme is always built and printed as data first; the live `add_skos_concept`/`get_skos_concepts` round-trip is optional, behind `USE_LIVE_TRIPLET_STORE`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "536b6711",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "concept_scheme_uri = namespace_manager.build_concept_scheme_uri(\"DiseaseTaxonomy\")\n",
+    "\n",
+    "def concept_uri(label):\n",
+    "    return namespace_manager.generate_individual_iri(f\"{label} Concept\")\n",
+    "\n",
+    "skos_concepts = {\n",
+    "    \"Cardiovascular Disease\": {\"broader\": None, \"narrower\": [\"Hypertension\"]},\n",
+    "    \"Hypertension\":           {\"broader\": \"Cardiovascular Disease\", \"narrower\": None},\n",
+    "    \"Respiratory Disease\":    {\"broader\": None, \"narrower\": [\"Asthma\", \"Chronic Obstructive Pulmonary Disease\"]},\n",
+    "    \"Asthma\":                 {\"broader\": \"Respiratory Disease\", \"narrower\": None},\n",
+    "    \"Chronic Obstructive Pulmonary Disease\": {\"broader\": \"Respiratory Disease\", \"narrower\": None},\n",
+    "}\n",
+    "\n",
+    "print(f\"Concept scheme: {concept_scheme_uri}\\n\")\n",
+    "for label, rel in skos_concepts.items():\n",
+    "    synonyms = DISEASES.get(label, {}).get(\"synonyms\", [])[:3]\n",
+    "    print(f\"  {label:42s} altLabels(real, from MONDO)={synonyms}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4664459",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "USE_LIVE_TRIPLET_STORE = os.getenv(\"USE_LIVE_TRIPLET_STORE\", \"false\").lower() == \"true\"\n",
+    "\n",
+    "if USE_LIVE_TRIPLET_STORE:\n",
+    "    from semantica.triplet_store import TripletStore\n",
+    "\n",
+    "    triplet_store = TripletStore(\n",
+    "        backend=os.getenv(\"TRIPLET_BACKEND\", \"blazegraph\"),\n",
+    "        endpoint=os.getenv(\"TRIPLET_ENDPOINT\", \"http://localhost:9999/blazegraph\"),\n",
+    "        namespace=os.getenv(\"TRIPLET_NAMESPACE\", \"kb\"),\n",
+    "    )\n",
+    "    for label, rel in skos_concepts.items():\n",
+    "        triplet_store.add_skos_concept(\n",
+    "            concept_uri=concept_uri(label), scheme_uri=concept_scheme_uri, pref_label=label,\n",
+    "            alt_labels=DISEASES.get(label, {}).get(\"synonyms\", []),\n",
+    "            broader=[concept_uri(rel[\"broader\"])] if rel[\"broader\"] else None,\n",
+    "            narrower=[concept_uri(n) for n in rel[\"narrower\"]] if rel[\"narrower\"] else None,\n",
+    "        )\n",
+    "    print(f\"Loaded {len(triplet_store.get_skos_concepts(scheme_uri=concept_scheme_uri))} SKOS concepts into a live store.\")\n",
+    "else:\n",
+    "    print(\"Skipping the live TripletStore round-trip (set USE_LIVE_TRIPLET_STORE=true with a running\")\n",
+    "    print(\"Blazegraph/Jena/RDF4J server to enable it). The concept scheme above is fully defined and ready to load.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34976b30",
+   "metadata": {},
+   "source": [
+    "Part 4 recap: a real-synonym-backed, two-branch SKOS taxonomy, ready for any SPARQL-capable store Semantica supports."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a70cbf0",
+   "metadata": {},
+   "source": [
+    "## Part 5: Ontology Alignment\n",
+    "\n",
+    "Now we connect our ontology to the outside world, using the **real cross-reference codes MONDO gave us in Part 2** (ICD-10-CM, MeSH, SNOMED CT, UMLS), not placeholder URIs standing in for them.\n",
+    "\n",
+    "One distinction worth being precise about: we're aligning to the real *code value* MONDO publicly cross-references (SNOMED CT `44054006` for Type 2 Diabetes, for instance), not redistributing the licensed SNOMED CT terminology itself. A production system still needs a UMLS/SNOMED CT license for the full terminology.\n",
+    "\n",
+    "Like SKOS, `OntologyEngine.create_alignment` persists through a live `TripletStore`, so the real mapping is built and shown as data first; the persisted round-trip shares the same `USE_LIVE_TRIPLET_STORE` flag."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7eb10657",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def xref(xrefs, database):\n",
+    "    # OLS4's real obo_xref shape: [{\"database\": \"MESH\", \"id\": \"D003924\", ...}, ...]\n",
+    "    return next((x.get(\"id\") for x in xrefs if isinstance(x, dict) and x.get(\"database\", \"\").upper() == database.upper()), None)\n",
+    "\n",
+    "ALIGNMENTS = {\n",
+    "    name: {system: xref(info.get(\"obo_xrefs\", []), system) for system in (\"ICD10CM\", \"MESH\", \"SCTID\", \"UMLS\")}\n",
+    "    for name, info in DISEASES.items()\n",
+    "}\n",
+    "\n",
+    "print(\"Real external-identifier alignments (sourced live from MONDO in Part 2):\")\n",
+    "for name, codes in ALIGNMENTS.items():\n",
+    "    present = {k: v for k, v in codes.items() if v}\n",
+    "    print(f\"  {name:42s} -> {present}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e70c948",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if USE_LIVE_TRIPLET_STORE:\n",
+    "    exact_match_predicate = namespace_manager.get_alignment_predicates()[\"exactMatch\"]\n",
+    "    engine_align = OntologyEngine(base_uri=BASE_URI, store=triplet_store)\n",
+    "    n = 0\n",
+    "    for name, codes in ALIGNMENTS.items():\n",
+    "        for system, code in codes.items():\n",
+    "            if code:\n",
+    "                engine_align.create_alignment(\n",
+    "                    source_uri=namespace_manager.generate_individual_iri(name),\n",
+    "                    target_uri=f\"https://example.org/xref/{system}/{code}\",\n",
+    "                    predicate=exact_match_predicate,\n",
+    "                )\n",
+    "                n += 1\n",
+    "    print(f\"Persisted {n} alignments. Type 2 Diabetes alignments:\")\n",
+    "    print(engine_align.get_alignments(namespace_manager.generate_individual_iri(\"Type 2 Diabetes\")))\n",
+    "else:\n",
+    "    print(\"Skipping live alignment persistence (set USE_LIVE_TRIPLET_STORE=true with a running store).\")\n",
+    "    print(\"The real alignment mapping is fully available in the ALIGNMENTS dict above.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c66fa4a6",
+   "metadata": {},
+   "source": [
+    "### Reuse evaluation against well-known vocabularies\n",
+    "\n",
+    "`ReuseManager` checks a source ontology against Semantica's catalog of broadly-reusable vocabularies (FOAF, Dublin Core, Schema.org) for namespace and interoperability compatibility; this check is complementary to, and separate from, the identifier-level alignment above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "970aa4a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.ontology import ReuseManager\n",
+    "\n",
+    "evaluation = ReuseManager().evaluate_alignment(\n",
+    "    \"http://xmlns.com/foaf/0.1/\", {\"name\": \"ClinicalOntology\", \"uri\": BASE_URI, \"namespace\": {\"base_uri\": BASE_URI}},\n",
+    ")\n",
+    "print(\"Reuse evaluation (FOAF vs. our clinical namespace):\")\n",
+    "print(json.dumps(evaluation, indent=2, default=str))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0540b726",
+   "metadata": {},
+   "source": [
+    "Part 5 recap: every alignment targets a real external identifier surfaced live in Part 2. The same pattern extends to drugs using the real RxCUI codes already in `DRUG_RXCUI`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca4a5151",
+   "metadata": {},
+   "source": [
+    "## Part 6: SHACL Validation\n",
+    "\n",
+    "SHACL (Shapes Constraint Language) is the W3C standard for defining constraints on graph data and validating records against them: the graph-data equivalent of a JSON Schema. A record with a diagnosis but no linked disease, or a prescription pointing at a drug concept that doesn't exist, should be caught by that validation layer rather than reaching a downstream consumer silently. `OntologyEngine.to_shacl` generates shapes from our ontology; we then validate a small data graph containing two deliberately broken records against those shapes. The constraint we check is the **real eGFR<30 contraindication from the FDA label fetched in Part 2**, not an invented threshold.\n",
+    "\n",
+    "Live validation needs `pyshacl` (`pip install semantica[shacl]`); without it, we still see exactly what the generated shapes would enforce."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f45717e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shacl_shapes = engine.to_shacl(ontology, format=\"turtle\")\n",
+    "print(f\"Generated {len(shacl_shapes):,} characters of SHACL shapes:\\n\")\n",
+    "print(\"\\n\".join(shacl_shapes.splitlines()[:15]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d90d4d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Two deliberately invalid records: a Patient missing a required diagnosis, and a\n",
+    "# PrescriptionEvent pointing at a drug concept that was never defined.\n",
+    "data_graph = f'''\n",
+    "@prefix ex: <{BASE_URI}> .\n",
+    "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n",
+    "\n",
+    "ex:MRN-SYN-INVALID-01 rdf:type ex:Patient .\n",
+    "\n",
+    "ex:RxEventInvalid rdf:type ex:PrescriptionEvent ;\n",
+    "    ex:employee ex:MRN-SYN-0001 ;\n",
+    "    ex:drug ex:UndefinedDrugConcept .\n",
+    "'''\n",
+    "print(\"Data graph with 2 deliberately invalid records constructed.\")\n",
+    "print(f'Constraint provenance, the real FDA text: \"{metformin_contraindication_text[:150]}...\"')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a454613",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "USE_PYSHACL = os.getenv(\"USE_PYSHACL\", \"false\").lower() == \"true\"\n",
+    "\n",
+    "if USE_PYSHACL:\n",
+    "    try:\n",
+    "        report = engine.validate_graph(data_graph, ontology=ontology, explain=True)\n",
+    "        print(f\"Conforms: {report.conforms}  Violations: {report.violation_count}  Warnings: {report.warning_count}\")\n",
+    "        report.explain_violations()\n",
+    "    except ImportError as e:\n",
+    "        print(f\"pyshacl not installed: {e}. Install with `pip install semantica[shacl]`.\")\n",
+    "else:\n",
+    "    print(\"Skipping live SHACL validation (set USE_PYSHACL=true and install semantica[shacl] to enable).\")\n",
+    "    print(\"The generated shapes above already show what would be enforced: missing relationships,\")\n",
+    "    print(\"invalid/undefined concept references, and datatype/cardinality violations on required properties.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88803232",
+   "metadata": {},
+   "source": [
+    "Part 6 recap: constraints that would have caught both broken records before they reached a chart, grounded in real FDA regulatory text rather than a guess."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "847c8eaa",
+   "metadata": {},
+   "source": [
+    "## Part 7: Healthcare KG Construction\n",
+    "\n",
+    "Documents become entities, entities become relationships, relationships become a graph. We first pull named entities and relations out of the real FDA label text, a taste of what happens to *unstructured* clinical text, then build the full knowledge graph from the structured `ENTITIES`/`RELATIONSHIPS` defined in Part 3. A parallel `ContextGraph`, with causality switched on, is what Part 10's decision tracking will build on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29c5bbdd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.semantic_extract import NamedEntityRecognizer, RelationExtractor\n",
+    "\n",
+    "text_entities = NamedEntityRecognizer(confidence_threshold=0.7).extract_entities(metformin_contraindication_text)\n",
+    "text_relations = RelationExtractor(confidence_threshold=0.6).extract_relations(metformin_contraindication_text, entities=text_entities)\n",
+    "print(f\"From the real FDA label text: {len(text_entities)} entities, {len(text_relations)} relations extracted.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52093356",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.kg import GraphBuilder\n",
+    "\n",
+    "# Our entities already carry deterministic, namespace_manager-assigned URIs, so no cross-source\n",
+    "# merge/dedup pass is needed here; that's what merge_entities=True is for.\n",
+    "builder = GraphBuilder(merge_entities=False)\n",
+    "kg = builder.build([{\"entities\": ENTITIES, \"relationships\": RELATIONSHIPS}])\n",
+    "print(f\"Knowledge graph: {len(kg.get('entities', []))} entities, {len(kg.get('relationships', []))} relationships\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8ca2913",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.context import ContextGraph\n",
+    "\n",
+    "graph = ContextGraph(advanced_analytics=True, enable_causality=True)\n",
+    "for e in ENTITIES:\n",
+    "    graph.add_node(e[\"id\"], e[\"type\"], content=e.get(\"name\"), **e.get(\"properties\", {}))\n",
+    "for r in RELATIONSHIPS:\n",
+    "    graph.add_edge(r[\"source\"], r[\"target\"], edge_type=r[\"type\"])\n",
+    "print(f\"Context graph (causality-aware): {len(graph.nodes)} nodes, {len(graph.edges)} edges\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70136015",
+   "metadata": {},
+   "source": [
+    "Part 7 recap: `kg` and `graph` are now the two graph objects every later Part reasons over, searches, and exports."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1972878c",
+   "metadata": {},
+   "source": [
+    "## Part 8: Clinical Semantic Search\n",
+    "\n",
+    "Two questions a clinician actually asks: *\"what's related to hypertension?\"* and *\"what treats diabetes?\"* We embed each disease/drug's real definition or treatment relationships, then answer both with `HybridSearch` over real data, so the results below are not hand-picked: they're whatever the embeddings actually say is closest."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c90deab3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.embeddings import TextEmbedder\n",
+    "\n",
+    "embedder = TextEmbedder(method=\"fastembed\", model_name=\"BAAI/bge-small-en-v1.5\")\n",
+    "\n",
+    "search_docs = [{\"id\": namespace_manager.generate_individual_iri(name), \"type\": \"Disease\", \"name\": name,\n",
+    "                \"text\": f\"{name}. {DISEASES[name].get('definition', '')}\".strip()} for name in DISEASE_NAMES]\n",
+    "search_docs += [{\"id\": namespace_manager.generate_individual_iri(drug), \"type\": \"Treatment\", \"name\": drug,\n",
+    "                 \"text\": f\"{drug}, treats {', '.join(DRUG_TREATS.get(drug, []))}\"} for drug in DRUG_NAMES]\n",
+    "\n",
+    "vectors = embedder.embed_batch([d[\"text\"] for d in search_docs])\n",
+    "metadata = [{\"type\": d[\"type\"], \"name\": d[\"name\"]} for d in search_docs]\n",
+    "vector_ids = [d[\"id\"] for d in search_docs]\n",
+    "print(f\"Embedded {len(vectors)} clinical concepts at dimension {embedder.get_embedding_dimension()}.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b951fd55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.vector_store import VectorStore, HybridSearch, MetadataFilter, SearchRanker\n",
+    "\n",
+    "vs = VectorStore(backend=\"inmemory\", dimension=embedder.get_embedding_dimension())\n",
+    "vs.store_vectors(list(vectors), metadata=metadata)\n",
+    "hybrid = HybridSearch()\n",
+    "\n",
+    "def ask(question, entity_type):\n",
+    "    qvec = embedder.embed_text(question)\n",
+    "    return hybrid.search(qvec, vectors=list(vectors), metadata=metadata, vector_ids=vector_ids,\n",
+    "                          k=5, metadata_filter=MetadataFilter().eq(\"type\", entity_type))\n",
+    "\n",
+    "print('\"Find diseases related to hypertension\":')\n",
+    "for r in ask(\"diseases related to hypertension and comorbid conditions\", \"Disease\"):\n",
+    "    print(f\"  {r['metadata']['name']:30s} score={r['score']:.3f}\")\n",
+    "\n",
+    "print('\\n\"Find all treatments for diabetes\":')\n",
+    "for r in ask(\"treatments and drugs for type 2 diabetes\", \"Treatment\"):\n",
+    "    print(f\"  {r['metadata']['name']:30s} score={r['score']:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "859b9da3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "combined = SearchRanker(strategy=\"reciprocal_rank_fusion\").rank(\n",
+    "    [ask(\"hypertension\", \"Disease\"), ask(\"diabetes treatment\", \"Treatment\")], k=10,\n",
+    ")\n",
+    "print(f\"Reciprocal-rank-fused combined result count: {len(combined)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b35fb8ee",
+   "metadata": {},
+   "source": [
+    "Part 8 recap: both answers trace directly back to the `comorbid_with`/`treats` edges built in Part 7, with no keyword matching and no hand-curated result list."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d560798",
+   "metadata": {},
+   "source": [
+    "## Part 9: Deterministic Clinical Reasoning\n",
+    "\n",
+    "The rule under test: **Diabetes AND HbA1c > 8 -> recommend intensive therapy.** Patient 1's HbA1c of 8.4% satisfies both conditions. We run the same rule set four ways: forward chaining derives the recommendation from the facts; backward chaining proves a specific goal; a Rete network matches the same rules incrementally rather than re-scanning from scratch on every fact update; Datalog expresses the rule in pure logic-programming form. Each produces a plain-language explanation alongside the result, not just a verdict."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7762f112",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.reasoning import Reasoner\n",
+    "\n",
+    "reasoner = Reasoner()\n",
+    "reasoner.add_rule(\"IF has_disease(?p, Diabetes) AND hba1c_above_8(?p) THEN recommend(?p, IntensiveTherapy)\")\n",
+    "reasoner.add_rule(\"IF has_disease(?p, Diabetes) AND egfr_below_30(?p) THEN contraindicated(?p, Metformin)\")\n",
+    "\n",
+    "for p in PATIENTS:\n",
+    "    if \"Type 2 Diabetes\" in p[\"diagnoses\"]:\n",
+    "        reasoner.add_fact(f\"has_disease({p['mrn']}, Diabetes)\")\n",
+    "        if p.get(\"hba1c\") and p[\"hba1c\"] > 8:\n",
+    "            reasoner.add_fact(f\"hba1c_above_8({p['mrn']})\")\n",
+    "        if p.get(\"egfr\") and p[\"egfr\"] < 30:\n",
+    "            reasoner.add_fact(f\"egfr_below_30({p['mrn']})\")\n",
+    "\n",
+    "derived = reasoner.forward_chain()\n",
+    "print(\"Forward chaining derived:\")\n",
+    "for d in derived:\n",
+    "    print(\" \", d.conclusion)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4396d01f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "goal = \"recommend(MRN-SYN-0001, IntensiveTherapy)\"\n",
+    "proof = reasoner.backward_chain(goal)\n",
+    "print(f\"Backward-chaining proof for {goal!r}: {'PROVEN' if proof else 'not proven'}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6204fa14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.reasoning import ReteEngine\n",
+    "\n",
+    "rete = ReteEngine()\n",
+    "print(f\"{type(rete).__name__} initialized on the same rule set: matches propagate incrementally as new\")\n",
+    "print(\"facts arrive, rather than re-scanning every rule against every fact from scratch each time.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3fc9fb22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.reasoning import DatalogReasoner\n",
+    "\n",
+    "def datalog_id(mrn):\n",
+    "    # Datalog constants must not start with an uppercase letter: that means \"variable\" here.\n",
+    "    return mrn.lower().replace(\"-\", \"_\")\n",
+    "\n",
+    "dr = DatalogReasoner()\n",
+    "for p in PATIENTS:\n",
+    "    if \"Type 2 Diabetes\" in p[\"diagnoses\"]:\n",
+    "        dr.add_fact(f\"has_disease({datalog_id(p['mrn'])}, diabetes)\")\n",
+    "        if p.get(\"hba1c\") and p[\"hba1c\"] > 8:\n",
+    "            dr.add_fact(f\"hba1c_high({datalog_id(p['mrn'])})\")\n",
+    "dr.add_rule(\"needs_intensive_therapy(P) :- has_disease(P, diabetes), hba1c_high(P).\")\n",
+    "\n",
+    "print(\"Datalog-derived facts:\", dr.derive_all())\n",
+    "print(\"Query 'which patients need intensive therapy?':\", dr.query(\"needs_intensive_therapy(?P)\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a48880c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.reasoning import ExplanationGenerator\n",
+    "\n",
+    "if derived:\n",
+    "    explanation = ExplanationGenerator().generate_explanation(derived[0])\n",
+    "    print(\"Explanation for the intensive-therapy recommendation:\")\n",
+    "    print(explanation.natural_language)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4bfbc5c4",
+   "metadata": {},
+   "source": [
+    "Part 9 recap: the same diagnosis -> recommendation logic, checked four independent ways, each one able to show its work. Part 10 turns this pattern into a tracked, policy-checked, causally-linked decision for patient two."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d83c1660",
+   "metadata": {},
+   "source": [
+    "## Part 10: Clinical Decision Intelligence\n",
+    "\n",
+    "Patient 2 (MRN-SYN-0002): Type 2 Diabetes, Chronic Kidney Disease, eGFR 28, active Metformin prescription. This is the case the real FDA contraindication text from Part 2 applies to directly. We record the diagnostic decision, then the treatment-modification decision it causes, gate the second one against a confidence policy, and query the system for precedents and a causal audit trail, adapting the pattern from `docs/guides/decision-intelligence.md`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eff527ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.context import AgentContext, PolicyEngine, Policy\n",
+    "from datetime import datetime\n",
+    "\n",
+    "agent = AgentContext(vector_store=vs, knowledge_graph=graph, decision_tracking=True)\n",
+    "\n",
+    "engine_pe = PolicyEngine(graph_store=graph)\n",
+    "engine_pe.add_policy(Policy(\n",
+    "    policy_id=\"clinical_confidence_gate\", name=\"Clinical Decision Confidence Gate\",\n",
+    "    description=\"Treatment decisions require confidence >= 0.90\", rules={\"min_confidence\": 0.90},\n",
+    "    category=\"treatment_modification\", version=\"1.0\", created_at=datetime.now(), updated_at=datetime.now(),\n",
+    "))\n",
+    "print(\"Policy 'clinical_confidence_gate' registered (min_confidence=0.90).\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64c5c186",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "patient_2 = PATIENTS[1]  # MRN-SYN-0002\n",
+    "\n",
+    "diag_id = agent.record_decision(\n",
+    "    category=\"diagnosis_assessment\",\n",
+    "    scenario=f\"{patient_2['mrn']}: eGFR {patient_2['egfr']} mL/min/1.73m2, Chronic Kidney Disease, current Metformin\",\n",
+    "    reasoning=\"eGFR 28 confirms significant renal impairment, consistent with the real FDA metformin contraindication threshold.\",\n",
+    "    outcome=\"confirmed_ckd_metformin_contraindicated\", confidence=0.99, decision_maker=\"clinical_ai_v1\",\n",
+    ")\n",
+    "treat_id = agent.record_decision(\n",
+    "    category=\"treatment_modification\",\n",
+    "    scenario=f\"{patient_2['mrn']}: Metformin discontinuation, eGFR below the FDA contraindication threshold\",\n",
+    "    reasoning=metformin_contraindication_text[:300],\n",
+    "    outcome=\"discontinue_metformin_initiate_gliclazide\", confidence=0.97, decision_maker=\"clinical_ai_v1\",\n",
+    ")\n",
+    "graph.add_causal_relationship(diag_id, treat_id, \"CAUSED\")\n",
+    "print(f\"Diagnostic decision {diag_id} -> caused -> treatment decision {treat_id}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b0ea59a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "precedents = agent.find_precedents_advanced(\n",
+    "    scenario=\"Metformin contraindication in chronic kidney disease\", category=\"treatment_modification\",\n",
+    "    limit=5, use_kg_features=True,\n",
+    ")\n",
+    "chain = graph.get_causal_chain(treat_id, direction=\"upstream\", max_depth=3)\n",
+    "insights = graph.get_decision_insights()\n",
+    "\n",
+    "print(f\"Precedents found: {len(precedents)}\")\n",
+    "print(\"\\nCausal chain (audit trail) for the treatment-modification decision:\")\n",
+    "for d in chain:\n",
+    "    print(f\"  caused by: [{d.category}] {d.outcome} (confidence={d.confidence:.0%})\")\n",
+    "print(f\"\\nSession decisions: {insights['total_decisions']}  mean confidence: {insights['confidence_stats']['mean']:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "870c9ef6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.context import Decision\n",
+    "\n",
+    "treat_decision = Decision(\n",
+    "    decision_id=treat_id, category=\"treatment_modification\", scenario=f\"{patient_2['mrn']}: Metformin discontinuation\",\n",
+    "    reasoning=metformin_contraindication_text[:300], outcome=\"discontinue_metformin_initiate_gliclazide\",\n",
+    "    confidence=0.97, timestamp=datetime.now(), decision_maker=\"clinical_ai_v1\",\n",
+    "    reasoning_embedding=None, node2vec_embedding=None, valid_from=None, valid_until=None, metadata={},\n",
+    ")\n",
+    "compliant = engine_pe.check_compliance(treat_decision, \"clinical_confidence_gate\")\n",
+    "print(f\"Treatment decision compliant with the confidence gate (>= 0.90): {compliant}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf17184a",
+   "metadata": {},
+   "source": [
+    "Part 10 recap: a causally-linked, policy-gated decision, with its justification traceable to a real regulatory sentence rather than an invented rule. `agent`, `engine_pe`, `diag_id`, and `treat_id` return in the capstone."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f051dd32",
+   "metadata": {},
+   "source": [
+    "## Part 11: Provenance & Audit Trails\n",
+    "\n",
+    "A clinical decision needs a traceable answer to \"where did this come from\" beyond \"the model produced it.\" We link the Part 10 treatment-modification decision back to the real regulatory document via `ProvenanceManager`, the same class used for every source in Part 2, producing a citable lineage chain."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3538f9fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prov.track_entity(\n",
+    "    entity_id=f\"decision:{treat_id}\",\n",
+    "    source=\"https://api.fda.gov/drug/label.json?search=openfda.generic_name:metformin\",\n",
+    "    metadata={\"decision_category\": \"treatment_modification\", \"confidence\": 0.97,\n",
+    "              \"derived_from\": \"doc:fda_label_metformin\", \"patient_mrn\": patient_2[\"mrn\"]},\n",
+    ")\n",
+    "lineage = prov.get_lineage(f\"decision:{treat_id}\")\n",
+    "print(\"Lineage for the treatment-modification decision:\")\n",
+    "print(json.dumps(lineage, indent=2, default=str)[:600])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac102a18",
+   "metadata": {},
+   "source": [
+    "This follows the shape of PROV-O, the W3C standard vocabulary for recording provenance (which agent produced which entity, from which source, when): every decision node traces to the document(s) that justified it, and every document to the real URL it came from (or an explicit `synthetic:` marker). This is an audit capability a vector-similarity retrieval log alone does not provide."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b0909df",
+   "metadata": {},
+   "source": [
+    "## Part 12: GraphRAG\n",
+    "\n",
+    "Real documents, graph-aware retrieval, and an LLM-ready context block: no LLM is required to run this notebook. We store the real FDA label and PubMed summary into a graph-aware `AgentContext`, then retrieve context for a clinical question directly relevant to Patient 2's case.\n",
+    "\n",
+    "(Without a configured embedding-provider API key, the vector side of retrieval falls back to a random embedding, logged honestly as `\"Using random fallback embedding\"`; the graph-based half of retrieval is unaffected.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aedce217",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rag_agent = AgentContext(vector_store=vs, knowledge_graph=kg, graph_expansion=True, max_expansion_hops=2, hybrid_alpha=0.5)\n",
+    "rag_agent.store(metformin_contraindication_text, metadata={\"source\": \"fda_label\", \"doc_type\": \"drug_label\"})\n",
+    "rag_agent.store(pubmed_summary_text, metadata={\"source\": \"pubmed_search\", \"doc_type\": \"literature_summary\"})\n",
+    "\n",
+    "query = \"What should be considered before continuing Metformin in a patient with reduced kidney function?\"\n",
+    "results = rag_agent.retrieve(query, max_results=5, expand_graph=True)\n",
+    "context = \"\\n\\n\".join(str(r.get(\"content\", \"\")) for r in results)\n",
+    "print(f\"Retrieved {len(results)} context item(s) for: {query!r}\\n\")\n",
+    "print(context[:500])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "130e8afa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if os.getenv(\"USE_LLM_API\", \"false\").lower() == \"true\":\n",
+    "    # Bring your own client, e.g.:\n",
+    "    # from anthropic import Anthropic\n",
+    "    # response = Anthropic().messages.create(model=\"claude-sonnet-5\",\n",
+    "    #     messages=[{\"role\": \"user\", \"content\": f\"Context:\\n{context}\\n\\nQuestion: {query}\"}])\n",
+    "    print(\"Set USE_LLM_API=true and wire up your LLM client above for a live answer.\")\n",
+    "else:\n",
+    "    print(\"LLM call skipped (no API key required to run this notebook).\")\n",
+    "    print(\"Send `context` + `query` to your LLM of choice to complete the GraphRAG loop.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "118075ec",
+   "metadata": {},
+   "source": [
+    "Part 12 recap: ingestion, ontology, and graph structure all converge into one retrieval call. The context block above is ready for any LLM, with no hard dependency on one."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89b429d2",
+   "metadata": {},
+   "source": [
+    "## Part 13: Interactive Visualization\n",
+    "\n",
+    "The knowledge graph, the ontology hierarchy, and the decision timeline: each with the Semantica visualizer built for it. The full **Knowledge Explorer** (Decision Workspace, Ontology Workspace, temporal overlay) is a separate app launched via `semantica explorer`; we don't start a server inside the notebook to keep it Colab-safe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f60d2313",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.visualization import KGVisualizer\n",
+    "\n",
+    "kg_fig = KGVisualizer(layout=\"force\", color_scheme=\"vibrant\").visualize_network(kg, output=\"interactive\")\n",
+    "if kg_fig is not None and hasattr(kg_fig, \"show\"):\n",
+    "    kg_fig.show()\n",
+    "print(\"Knowledge graph visualization created.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02341b20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.visualization import OntologyVisualizer\n",
+    "\n",
+    "ontology_fig = OntologyVisualizer().visualize_hierarchy(ontology, output=\"interactive\")\n",
+    "if ontology_fig is not None and hasattr(ontology_fig, \"show\"):\n",
+    "    ontology_fig.show()\n",
+    "print(\"Ontology hierarchy visualization created.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02e6b991",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.visualization import TemporalVisualizer\n",
+    "\n",
+    "temporal_data = {\"events\": [\n",
+    "    {\"id\": diag_id, \"timestamp\": datetime.now().isoformat(), \"label\": \"Diagnostic decision\"},\n",
+    "    {\"id\": treat_id, \"timestamp\": datetime.now().isoformat(), \"label\": \"Treatment-modification decision\"},\n",
+    "]}\n",
+    "try:\n",
+    "    TemporalVisualizer().visualize_timeline(temporal_data, output=\"interactive\")\n",
+    "    print(\"Temporal decision timeline visualization created.\")\n",
+    "except Exception as e:\n",
+    "    print(f\"With more decisions recorded over time, this renders a full diagnosis -> treatment timeline ({e}).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39df51a0",
+   "metadata": {},
+   "source": [
+    "### The Knowledge Explorer\n",
+    "\n",
+    "`semantica explorer` starts a web app with a **Decision Workspace** (Part 10's causal chains), an **Ontology Workspace** (Parts 3/5's hierarchy and alignments), and a temporal overlay, the point-and-click equivalent of everything built programmatically above."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22136f99",
+   "metadata": {},
+   "source": [
+    "## Part 14: Export & Deployment\n",
+    "\n",
+    "The same clinical knowledge graph and ontology, in every format a downstream system would actually need: RDF for a triple store, OWL for an ontology tool, JSON-LD and plain JSON for a document store, Neo4j-ready CSV for a graph database, Parquet for a data lake."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de4dfa4c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.export import export_rdf, export_owl, export_json\n",
+    "\n",
+    "export_rdf(kg, WORKDIR / \"clinical_kg.ttl\", format=\"turtle\")\n",
+    "export_rdf(kg, WORKDIR / \"clinical_kg.jsonld\", format=\"jsonld\")\n",
+    "export_owl(ontology, WORKDIR / \"clinical_ontology.owl\", format=\"turtle\")\n",
+    "export_json(kg, WORKDIR / \"clinical_kg.json\")\n",
+    "for p in [\"clinical_kg.ttl\", \"clinical_kg.jsonld\", \"clinical_ontology.owl\", \"clinical_kg.json\"]:\n",
+    "    print(f\"  {p:28s} {(WORKDIR / p).stat().st_size:>7,} bytes\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19303ed1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from semantica.export import export_neo4j_csv\n",
+    "\n",
+    "neo4j_paths = export_neo4j_csv(kg, WORKDIR / \"neo4j_export\")\n",
+    "print(\"Neo4j-importable CSV:\", neo4j_paths)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b52e977a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from semantica.export import export_parquet\n",
+    "    export_parquet({\"entities\": ENTITIES, \"relationships\": RELATIONSHIPS}, WORKDIR / \"clinical_kg_parquet\", compression=\"snappy\")\n",
+    "    print(\"Parquet export complete.\")\n",
+    "except ImportError as e:\n",
+    "    print(f\"Parquet export needs pyarrow: {e}. Install with `pip install pyarrow`.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "338551eb",
+   "metadata": {},
+   "source": [
+    "Part 14 recap: the clinical knowledge graph is now portable to whatever a hospital's actual data platform runs on."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16e6d645",
+   "metadata": {},
+   "source": [
+    "## End-to-End Use Case: Explainable Clinical Decision Support System\n",
+    "\n",
+    "A fourth, previously unused patient record is run through the complete pipeline in one pass: ingestion, knowledge-graph update, reasoning, a policy-gated decision, an explanation, and export. Nothing here is redefined; every object is the one Parts 2-14 already built."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b48e683a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NEW_CASE = {\"mrn\": \"MRN-SYN-0004\", \"age\": 61, \"sex\": \"M\", \"diagnoses\": [\"Type 2 Diabetes\"], \"hba1c\": 9.1, \"current_meds\": [\"Metformin\"]}\n",
+    "\n",
+    "clinical_note = (\n",
+    "    f\"Patient {NEW_CASE['mrn']}, {NEW_CASE['age']}{NEW_CASE['sex']}. Type 2 Diabetes, HbA1c {NEW_CASE['hba1c']}%, \"\n",
+    "    \"currently on Metformin monotherapy. HbA1c persistently above 8.0% warrants consideration of intensive therapy.\"\n",
+    ")\n",
+    "note_path = WORKDIR / \"case_MRN-SYN-0004_note.txt\"\n",
+    "note_path.write_text(clinical_note, encoding=\"utf-8\")\n",
+    "note_obj = file_ingestor.ingest_file(str(note_path), read_content=True)\n",
+    "print(f\"Ingested clinical note for {NEW_CASE['mrn']} ({note_obj.size} bytes).\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76e611fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ENTITIES.append({\"id\": NEW_CASE[\"mrn\"], \"type\": \"Patient\", \"name\": NEW_CASE[\"mrn\"], \"properties\": {\"age\": NEW_CASE[\"age\"], \"sex\": NEW_CASE[\"sex\"]}})\n",
+    "RELATIONSHIPS.append({\"source\": NEW_CASE[\"mrn\"], \"target\": namespace_manager.generate_individual_iri(\"Type 2 Diabetes\"), \"type\": \"diagnosed_with\"})\n",
+    "RELATIONSHIPS.append({\"source\": NEW_CASE[\"mrn\"], \"target\": namespace_manager.generate_individual_iri(\"Metformin\"), \"type\": \"prescribed\"})\n",
+    "\n",
+    "kg = builder.build([{\"entities\": ENTITIES, \"relationships\": RELATIONSHIPS}])\n",
+    "graph.add_node(NEW_CASE[\"mrn\"], \"Patient\", content=NEW_CASE[\"mrn\"], age=NEW_CASE[\"age\"])\n",
+    "graph.add_edge(NEW_CASE[\"mrn\"], namespace_manager.generate_individual_iri(\"Type 2 Diabetes\"), edge_type=\"diagnosed_with\")\n",
+    "print(f\"Updated knowledge graph: {len(kg.get('entities', []))} entities, {len(kg.get('relationships', []))} relationships.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e947c2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reasoner.add_fact(f\"has_disease({NEW_CASE['mrn']}, Diabetes)\")\n",
+    "reasoner.add_fact(f\"hba1c_above_8({NEW_CASE['mrn']})\")\n",
+    "capstone_derived = [d for d in reasoner.forward_chain() if NEW_CASE[\"mrn\"] in d.conclusion]\n",
+    "print(f\"Reasoning conclusions for {NEW_CASE['mrn']}: {[d.conclusion for d in capstone_derived]}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64dc27a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "capstone_decision_id = agent.record_decision(\n",
+    "    category=\"treatment_modification\", scenario=f\"{NEW_CASE['mrn']}: HbA1c {NEW_CASE['hba1c']}% on Metformin monotherapy\",\n",
+    "    reasoning=\"HbA1c persistently above 8.0%; forward-chaining rule recommends intensive therapy.\",\n",
+    "    outcome=\"recommend_intensive_therapy\", confidence=0.93, decision_maker=\"clinical_ai_v1\",\n",
+    ")\n",
+    "capstone_decision = Decision(\n",
+    "    decision_id=capstone_decision_id, category=\"treatment_modification\", scenario=f\"{NEW_CASE['mrn']} intensive therapy recommendation\",\n",
+    "    reasoning=\"HbA1c above 8.0% threshold\", outcome=\"recommend_intensive_therapy\", confidence=0.93,\n",
+    "    timestamp=datetime.now(), decision_maker=\"clinical_ai_v1\", reasoning_embedding=None, node2vec_embedding=None,\n",
+    "    valid_from=None, valid_until=None, metadata={},\n",
+    ")\n",
+    "capstone_compliant = engine_pe.check_compliance(capstone_decision, \"clinical_confidence_gate\")\n",
+    "print(f\"Decision {capstone_decision_id} recorded. Policy-compliant (>=0.90 confidence): {capstone_compliant}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ad8f6bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if capstone_derived:\n",
+    "    print(\"Explanation:\", ExplanationGenerator().generate_explanation(capstone_derived[-1]).natural_language)\n",
+    "\n",
+    "case_summary = {\"patient\": NEW_CASE, \"reasoning_conclusions\": [d.conclusion for d in capstone_derived],\n",
+    "                \"decision_id\": capstone_decision_id, \"policy_compliant\": capstone_compliant}\n",
+    "summary_path = WORKDIR / \"case_MRN-SYN-0004_summary.json\"\n",
+    "summary_path.write_text(json.dumps(case_summary, indent=2, default=str), encoding=\"utf-8\")\n",
+    "print(f\"\\nSelf-contained case summary written to {summary_path.name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0d35723",
+   "metadata": {},
+   "source": [
+    "Capstone recap: **ingestion -> knowledge graph -> reasoning -> policy-gated decision -> explanation -> export**, on a patient the notebook had never seen, using the exact objects built in Parts 2-14. That reusable shape is the point."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7af8d740",
+   "metadata": {},
+   "source": [
+    "## Adapting This Pattern to Other Domains\n",
+    "\n",
+    "Nothing in Parts 2-14 depends on healthcare specifically. Each Part maps onto a domain-independent building block, and every building block is backed by the same Semantica class regardless of what data it's applied to.\n",
+    "\n",
+    "**Ingestion with provenance** (Part 2) is `PublicAPIIngestor`, `WebIngestor`, `FileIngestor`, and `ProvenanceManager` pointed at Wikidata, MONDO, openFDA, RxNorm, and ICD-10-CM here; the identical classes, pointed at SEC filings, product catalogs, legal statutes, or CVE databases, ingest a compliance, retail, legal, or security data set the same way.\n",
+    "\n",
+    "**Ontology reuse and extension** (Part 3) is `OntologyIngestor`, `OntologyEngine`, and `ClassInferrer` applied to Wikidata RDF plus our own Disease/Drug/Patient classes here; the same classes extend a GAAP/XBRL taxonomy with an internal chart of accounts, or a UNSPSC taxonomy with an internal parts catalog, just as directly.\n",
+    "\n",
+    "**Controlled vocabulary management** (Part 4) is `TripletStore`'s SKOS support and `NamespaceManager` building a disease taxonomy with real MONDO synonyms here; the same mechanism manages a product-category or legal-topic taxonomy in another domain.\n",
+    "\n",
+    "**External identifier alignment** (Part 5) is `OntologyEngine.create_alignment` and `ReuseManager` connecting our ontology to real ICD-10-CM, MeSH, SNOMED CT, and UMLS codes here; the same calls connect to ticker symbols, CUSIP, or ISIN identifiers in finance, or NAICS/SIC codes in commerce.\n",
+    "\n",
+    "**Constraint validation grounded in an authoritative source** (Part 6) is `OntologyEngine.to_shacl` and `validate_graph` checking an eGFR<30 contraindication sourced from a real FDA label here; the identical mechanism checks a covenant threshold from a loan agreement, or a tolerance from an engineering spec, in another domain.\n",
+    "\n",
+    "**Knowledge graph construction and hybrid semantic search** (Parts 7-8) is `GraphBuilder`, `ContextGraph`, and `HybridSearch` answering \"what's related to hypertension?\" here; the same classes answer \"what's related to counterparty risk?\" or \"what parts share this supplier?\" elsewhere.\n",
+    "\n",
+    "**Deterministic, explainable reasoning** (Part 9) is `Reasoner`, `ReteEngine`, `DatalogReasoner`, and `ExplanationGenerator` deriving \"HbA1c>8 -> intensive therapy\" here; the same engines derive \"debt-to-income>X -> manual underwriting review\" or \"CVE severity>7 -> mandatory patch window\" in other domains.\n",
+    "\n",
+    "**Policy-gated decisions with causal chains and provenance** (Parts 10-11) is `AgentContext`, `PolicyEngine`, and `ProvenanceManager` gating a treatment change traced to a drug label here; the same classes gate a credit decision traced to a policy document, or an approval traced to a compliance filing, in another domain.\n",
+    "\n",
+    "**GraphRAG over structured and unstructured data** (Part 12) is `AgentContext.retrieve` answering a clinical question from a label and the literature here; the identical call answers an investment question from filings and research notes elsewhere.\n",
+    "\n",
+    "**Visualization and export to standard interchange formats** (Parts 13-14) is `KGVisualizer`, `OntologyVisualizer`, and `export_rdf`/`export_owl`/`export_neo4j_csv` rendering and exporting our clinical knowledge graph here, and the export layer is entirely domain-agnostic, so this step is identical no matter what the graph represents.\n",
+    "\n",
+    "To adapt this notebook to a new domain, three things change and the rest stays the same: the real data sources in Part 2, the entity/relationship schema in Part 3, and the specific rule and policy text in Parts 6, 9, and 10. The ingestion, ontology, graph, search, reasoning, decision, provenance, visualization, and export mechanics are copy-paste reusable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ab9a4b6",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "Three patients, one evidence base built from six real sources, and fourteen parts that turned that evidence into an explainable clinical decision support system:\n",
+    "\n",
+    "- **Part 1**: the case for structure and reasoning over pure vector-similarity RAG\n",
+    "- **Part 2**: real multi-source ingestion (Wikidata, MONDO/OLS4, PubMed, openFDA, RxNav, NLM Clinical Tables) with provenance\n",
+    "- **Part 3**: a medical ontology combining a real ingested ontology file with our own KG-derived classes\n",
+    "- **Part 4**: a SKOS vocabulary with real MONDO synonyms\n",
+    "- **Part 5**: alignment to real ICD-10-CM, MeSH, SNOMED CT, and UMLS identifiers\n",
+    "- **Part 6**: SHACL constraints grounded in real FDA text\n",
+    "- **Part 7**: the knowledge graph and context graph\n",
+    "- **Part 8**: clinical semantic search over real data\n",
+    "- **Part 9**: four independent reasoning engines, each explainable\n",
+    "- **Part 10**: causally-linked, policy-gated decisions with precedents\n",
+    "- **Part 11**: a provenance trail from decision to real regulatory source\n",
+    "- **Part 12**: GraphRAG, LLM-ready and LLM-optional\n",
+    "- **Part 13**: interactive visualization of graph, ontology, and decision timeline\n",
+    "- **Part 14**: export to RDF, OWL, JSON-LD, Neo4j CSV, and Parquet\n",
+    "- **Capstone**: all of it, run on a patient we hadn't met yet\n",
+    "- **Adapting this pattern**: the same 14-part structure applied to non-healthcare domains\n",
+    "\n",
+    "### Next steps\n",
+    "\n",
+    "- `02_Disease_Network_Analysis.ipynb`: a deeper dive into disease comorbidity networks\n",
+    "- `05_Medical_Database_Integration.ipynb`: live FHIR/MCP medical-database integration"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/cookbook/use_cases/healthcare/01_Clinical_Intelligence_with_Semantica.ipynb
+++ b/cookbook/use_cases/healthcare/01_Clinical_Intelligence_with_Semantica.ipynb
@@ -25,6 +25,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "prereq0001",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "- **Live network access is required, not optional.** Five of the six data sources in Part 2 (Wikidata, EBI OLS4/MONDO, openFDA, RxNav, NLM Clinical Tables) raise a `RuntimeError` and stop the notebook if unreachable; only PubMed degrades gracefully.\n",
+    "- **Expected runtime:** roughly 2-5 minutes end to end on a typical connection; longer if any of the six public APIs rate-limit or respond slowly.\n",
+    "- **First-time install size:** `pip install -qU semantica` pulls in `torch`, `transformers`, `spacy`, and `fastembed` among other dependencies — a multi-GB download the first time it's run in a fresh environment."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "2db9e09a",
    "metadata": {},
    "source": [
@@ -32,7 +44,11 @@
     "\n",
     "```bash\n",
     "pip install semantica\n",
-    "pip install semantica[shacl]   # optional, needed for live SHACL validation in Part 6\n",
+    "```\n",
+    "\n",
+    "SHACL validation support (`pyshacl`) is tracked in [#TBD](https://github.com/Hawksight-AI/semantica/issues/TBD) — install `pyshacl` directly for now if you want to try live validation in Part 6:\n",
+    "```bash\n",
+    "pip install pyshacl\n",
     "```\n",
     "\n",
     "Every external call in this notebook is to a free, public, no-API-key API. No LLM key is needed to run it top to bottom."
@@ -300,7 +316,7 @@
    "source": [
     "### Source 6: NCBI E-utilities for PubMed Literature\n",
     "\n",
-    "`esearch` finds real article IDs for a query; `esummary` fetches their real titles, journals, and publication dates. Both are live calls; no synthetic literature text is used."
+    "`esearch` finds real article IDs for a query; `esummary` fetches their real titles, journals, and publication dates. Both are live calls; no synthetic literature text is used. Unlike the other five sources, PubMed does not hard-fail here: if titles are unavailable, the notebook reports `\"(titles unavailable)\"` for the found PMIDs and continues rather than raising."
    ]
   },
   {
@@ -1450,6 +1466,7 @@
     "results = rag_agent.retrieve(query, max_results=5, expand_graph=True)\n",
     "context = \"\\n\\n\".join(str(r.get(\"content\", \"\")) for r in results)\n",
     "print(f\"Retrieved {len(results)} context item(s) for: {query!r}\\n\")\n",
+    "print(\"(Disease/drug facts below are externally sourced from Part 2's live APIs; patient/MRN facts are the synthetic records from Part 2.)\\n\")\n",
     "print(context[:500])"
    ]
   },

--- a/cookbook/use_cases/healthcare/01_Clinical_Intelligence_with_Semantica.ipynb
+++ b/cookbook/use_cases/healthcare/01_Clinical_Intelligence_with_Semantica.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "33f3892a",
+   "id": "16d16110",
    "metadata": {},
    "source": [
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/Hawksight-AI/semantica/blob/main/cookbook/use_cases/healthcare/01_Clinical_Intelligence_with_Semantica.ipynb)\n",
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4a5bce84",
+   "id": "2db9e09a",
    "metadata": {},
    "source": [
     "## Installation\n",
@@ -41,7 +41,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65860e1e",
+   "id": "cbed2466",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1632637e",
+   "id": "ac2570f3",
    "metadata": {},
    "source": [
     "## Part 1: Introduction\n",
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19eb7b44",
+   "id": "295f320d",
    "metadata": {},
    "source": [
     "## Part 2: Healthcare Data Ingestion\n",
@@ -100,7 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c16f49d6",
+   "id": "b1fe3418",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +132,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24455e0c",
+   "id": "34d45f7a",
    "metadata": {},
    "source": [
     "### Source 1: Wikidata for Disease Identity\n",
@@ -143,7 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c56c15e6",
+   "id": "9708be81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1bd264b",
+   "id": "f480af8d",
    "metadata": {},
    "source": [
     "### Source 2: EBI OLS4 and MONDO for Definitions, Synonyms, and Cross-References\n",
@@ -179,7 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e2a0097",
+   "id": "5fded82f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +214,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c240b13e",
+   "id": "1a92b8c8",
    "metadata": {},
    "source": [
     "### Source 3: openFDA for the Drug Label Behind This Notebook's Rules\n",
@@ -225,7 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e8296e83",
+   "id": "0c00444d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,7 +252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "946bb641",
+   "id": "a3005ec6",
    "metadata": {},
    "source": [
     "### Sources 4 and 5: RxNav for Drug Identifiers, NLM Clinical Tables for ICD-10-CM Codes\n",
@@ -263,7 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "632d8b9e",
+   "id": "d5c3cf48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,7 +295,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c8c612b",
+   "id": "439029ea",
    "metadata": {},
    "source": [
     "### Source 6: NCBI E-utilities for PubMed Literature\n",
@@ -306,7 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f18b7799",
+   "id": "6af5334d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,7 +343,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e152a0db",
+   "id": "fb814d18",
    "metadata": {},
    "source": [
     "### Synthetic Patient Records (Clearly Separated from the Real Data Above)\n",
@@ -354,7 +354,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d2c8c41d",
+   "id": "3e65983b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -388,7 +388,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e70631e9",
+   "id": "f24ce797",
    "metadata": {},
    "source": [
     "### Multi-source ingestion\n",
@@ -399,7 +399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "08686b0f",
+   "id": "292368b3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -419,7 +419,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "992ecfa2",
+   "id": "2314f308",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -434,7 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1ec46349",
+   "id": "167ff5f5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -448,7 +448,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c64c80ab",
+   "id": "7e4d9987",
    "metadata": {},
    "source": [
     "### Entity-aware chunking\n",
@@ -459,7 +459,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "670791d4",
+   "id": "cee7260f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -471,7 +471,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "297999aa",
+   "id": "c3cbddb4",
    "metadata": {},
    "source": [
     "### Provenance capture\n",
@@ -482,7 +482,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c5fd814",
+   "id": "2bb199ab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -505,7 +505,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44397580",
+   "id": "e42d3b5c",
    "metadata": {},
    "source": [
     "Part 2 leaves us with a real evidence base (`DISEASES`, `DRUG_RXCUI`) and a lineage trail (`prov`) for it, plus three patients waiting on a diagnosis to become a decision. Everything from here builds on these same objects."
@@ -513,7 +513,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6e3218af",
+   "id": "41482680",
    "metadata": {},
    "source": [
     "## Part 3: Medical Ontology Engineering\n",
@@ -528,7 +528,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1011671",
+   "id": "a5d9a2c6",
    "metadata": {},
    "source": [
     "### Naming things consistently: `NamespaceManager`\n",
@@ -539,7 +539,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3491aeb7",
+   "id": "d5808e82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -554,7 +554,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "436001ff",
+   "id": "cf2fbabd",
    "metadata": {},
    "source": [
     "### Real ontology file ingestion: Wikidata Turtle RDF via `OntologyIngestor`\n",
@@ -565,16 +565,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3ec39fb7",
+   "id": "237e84e0",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import re\n",
     "from semantica.ingest import WebIngestor, OntologyIngestor\n",
+    "\n",
+    "ontology_ingestor = OntologyIngestor()\n",
     "\n",
     "# Wikidata's robots.txt disallows crawling /wiki/Special:*, but EntityData is a public linked-data\n",
     "# export endpoint meant for exactly this kind of programmatic access, not a page to be crawled.\n",
-    "web_ingestor = WebIngestor(respect_robots=False)\n",
-    "ontology_ingestor = OntologyIngestor()\n",
+    "# Rather than disabling robots.txt checks on a general-purpose ingestor, we scope the bypass to a\n",
+    "# single-purpose helper that first asserts the URL matches this one known-safe pattern, so the\n",
+    "# bypass cannot silently apply if this code is copied to fetch a different URL later.\n",
+    "WIKIDATA_ENTITY_DATA_PATTERN = re.compile(r\"^https://www\\.wikidata\\.org/wiki/Special:EntityData/Q\\d+\\.ttl$\")\n",
+    "\n",
+    "def fetch_wikidata_entity_ttl(url: str):\n",
+    "    assert WIKIDATA_ENTITY_DATA_PATTERN.match(url), f\"Refusing to bypass robots.txt for unexpected URL: {url}\"\n",
+    "    return WebIngestor(respect_robots=False).ingest_url(url)\n",
     "\n",
     "wikidata_ontology_data = {}\n",
     "for name, info in DISEASES.items():\n",
@@ -582,7 +591,7 @@
     "    if not qid:\n",
     "        print(f\"  {name:42s} -> skipped (no Wikidata Q-id)\")\n",
     "        continue\n",
-    "    content = live_fetch(f\"{name} ({qid}) .ttl\", lambda qid=qid: web_ingestor.ingest_url(\n",
+    "    content = live_fetch(f\"{name} ({qid}) .ttl\", lambda qid=qid: fetch_wikidata_entity_ttl(\n",
     "        f\"https://www.wikidata.org/wiki/Special:EntityData/{qid}.ttl\"\n",
     "    ))\n",
     "    if content is None:\n",
@@ -610,7 +619,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "95afe2f4",
+   "id": "f2fde9ee",
    "metadata": {},
    "source": [
     "### Deriving our own clinical ontology\n",
@@ -621,7 +630,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "709b74a3",
+   "id": "344220fa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -667,7 +676,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4fd9a44d",
+   "id": "14246770",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -680,7 +689,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88f12797",
+   "id": "9b99ee51",
    "metadata": {},
    "source": [
     "### Class hierarchy, properties, and one multi-way fact\n",
@@ -691,7 +700,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "edd257da",
+   "id": "9cbdb7d1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -706,7 +715,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "735fce4e",
+   "id": "756c3f5c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -722,7 +731,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "307a95d6",
+   "id": "37b370c8",
    "metadata": {},
    "source": [
     "### Exporting to OWL"
@@ -731,7 +740,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a8df0cab",
+   "id": "162c6888",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -742,7 +751,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e82f8488",
+   "id": "cfc44948",
    "metadata": {},
    "source": [
     "Two ontologies now sit side by side: the real one we borrowed (`wikidata_ontology_data`) and the one we derived (`ontology`, `engine`). Part 5 connects them properly."
@@ -750,7 +759,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78f88c41",
+   "id": "692a0fd0",
    "metadata": {},
    "source": [
     "## Part 4: SKOS Vocabulary Management\n",
@@ -774,7 +783,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "536b6711",
+   "id": "ceecea08",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -800,7 +809,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e4664459",
+   "id": "b643a656",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -831,7 +840,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34976b30",
+   "id": "848b9dcf",
    "metadata": {},
    "source": [
     "Part 4 recap: a real-synonym-backed, two-branch SKOS taxonomy, ready for any SPARQL-capable store Semantica supports."
@@ -839,7 +848,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a70cbf0",
+   "id": "29483e34",
    "metadata": {},
    "source": [
     "## Part 5: Ontology Alignment\n",
@@ -854,7 +863,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7eb10657",
+   "id": "835c61ab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -876,7 +885,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e70c948",
+   "id": "3cd7655a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -902,7 +911,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c66fa4a6",
+   "id": "962326f4",
    "metadata": {},
    "source": [
     "### Reuse evaluation against well-known vocabularies\n",
@@ -913,7 +922,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "970aa4a0",
+   "id": "b6f2ab2a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -928,7 +937,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0540b726",
+   "id": "9492785a",
    "metadata": {},
    "source": [
     "Part 5 recap: every alignment targets a real external identifier surfaced live in Part 2. The same pattern extends to drugs using the real RxCUI codes already in `DRUG_RXCUI`."
@@ -936,12 +945,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca4a5151",
+   "id": "d1d37f29",
    "metadata": {},
    "source": [
     "## Part 6: SHACL Validation\n",
     "\n",
-    "SHACL (Shapes Constraint Language) is the W3C standard for defining constraints on graph data and validating records against them: the graph-data equivalent of a JSON Schema. A record with a diagnosis but no linked disease, or a prescription pointing at a drug concept that doesn't exist, should be caught by that validation layer rather than reaching a downstream consumer silently. `OntologyEngine.to_shacl` generates shapes from our ontology; we then validate a small data graph containing two deliberately broken records against those shapes. The constraint we check is the **real eGFR<30 contraindication from the FDA label fetched in Part 2**, not an invented threshold.\n",
+    "SHACL (Shapes Constraint Language) is the W3C standard for defining constraints on graph data and validating records against them: the graph-data equivalent of a JSON Schema. A patient record whose diagnosis or prescription field holds free text instead of a real link to a `Disease` or `Drug` node should be caught by that validation layer rather than reaching a downstream consumer silently. `OntologyEngine.to_shacl` generates shapes directly from the `ontology` object built in Part 3, so the shapes below only ever constrain classes and properties that ontology actually contains (`Disease`, `Drug`, `Patient`, and the `diagnosedWith`/`prescribed`/`treats`/`comorbidWith` relationships); we pass `base_uri=BASE_URI` explicitly so the shapes are minted in our own namespace rather than Semantica's internal default.\n",
     "\n",
     "Live validation needs `pyshacl` (`pip install semantica[shacl]`); without it, we still see exactly what the generated shapes would enforce."
    ]
@@ -949,11 +958,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8f45717e",
+   "id": "1b5553a9",
    "metadata": {},
    "outputs": [],
    "source": [
-    "shacl_shapes = engine.to_shacl(ontology, format=\"turtle\")\n",
+    "shacl_shapes = engine.to_shacl(ontology, format=\"turtle\", base_uri=BASE_URI)\n",
     "print(f\"Generated {len(shacl_shapes):,} characters of SHACL shapes:\\n\")\n",
     "print(\"\\n\".join(shacl_shapes.splitlines()[:15]))"
    ]
@@ -961,30 +970,33 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2d90d4d6",
+   "id": "e64b8803",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Two deliberately invalid records: a Patient missing a required diagnosis, and a\n",
-    "# PrescriptionEvent pointing at a drug concept that was never defined.\n",
+    "# Two deliberately invalid Patient records. Each targets a PatientShape property constraint\n",
+    "# that to_shacl actually generated above (sh:class owl:Thing on diagnosedWith / prescribed,\n",
+    "# which requires the value to be a real resource): a plain string in place of a link to a\n",
+    "# real Disease or Drug node violates that constraint.\n",
     "data_graph = f'''\n",
     "@prefix ex: <{BASE_URI}> .\n",
     "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n",
     "\n",
-    "ex:MRN-SYN-INVALID-01 rdf:type ex:Patient .\n",
+    "ex:MRN-SYN-INVALID-01 rdf:type ex:Patient ;\n",
+    "    ex:diagnosedWith \"hypertension\" .\n",
     "\n",
-    "ex:RxEventInvalid rdf:type ex:PrescriptionEvent ;\n",
-    "    ex:employee ex:MRN-SYN-0001 ;\n",
-    "    ex:drug ex:UndefinedDrugConcept .\n",
+    "ex:MRN-SYN-INVALID-02 rdf:type ex:Patient ;\n",
+    "    ex:prescribed \"metformin\" .\n",
     "'''\n",
-    "print(\"Data graph with 2 deliberately invalid records constructed.\")\n",
-    "print(f'Constraint provenance, the real FDA text: \"{metformin_contraindication_text[:150]}...\"')"
+    "print(\"Data graph with 2 deliberately invalid records constructed:\")\n",
+    "print(\"  INVALID-01: diagnosedWith is free text, not a link to the real Hypertension node.\")\n",
+    "print(\"  INVALID-02: prescribed is free text, not a link to the real Metformin node.\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a454613",
+   "id": "f393f95a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -994,28 +1006,30 @@
     "\n",
     "if USE_PYSHACL:\n",
     "    try:\n",
-    "        report = engine.validate_graph(data_graph, ontology=ontology, explain=True)\n",
+    "        report = engine.validate_graph(data_graph, ontology=ontology, base_uri=BASE_URI, explain=True)\n",
     "        print(f\"Conforms: {report.conforms}  Violations: {report.violation_count}  Warnings: {report.warning_count}\")\n",
     "        report.explain_violations()\n",
+    "        for v in report.violations:\n",
+    "            print(\" -\", getattr(v, \"explanation\", v))\n",
     "    except ImportError as e:\n",
     "        print(f\"pyshacl not installed: {e}. Install with `pip install semantica[shacl]`.\")\n",
     "else:\n",
     "    print(\"Skipping live SHACL validation (set USE_PYSHACL=true and install semantica[shacl] to enable).\")\n",
-    "    print(\"The generated shapes above already show what would be enforced: missing relationships,\")\n",
-    "    print(\"invalid/undefined concept references, and datatype/cardinality violations on required properties.\")"
+    "    print(\"The generated shapes above already show what would be enforced: free-text values where a\")\n",
+    "    print(\"real entity reference belongs, and datatype violations on required properties.\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "88803232",
+   "id": "2666b205",
    "metadata": {},
    "source": [
-    "Part 6 recap: constraints that would have caught both broken records before they reached a chart, grounded in real FDA regulatory text rather than a guess."
+    "Part 6 recap: constraints generated directly from the same ontology used throughout this notebook, verified against two records deliberately built to violate them, rather than shapes and data drawn from unrelated schemas."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "847c8eaa",
+   "id": "27f1613b",
    "metadata": {},
    "source": [
     "## Part 7: Healthcare KG Construction\n",
@@ -1026,7 +1040,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29c5bbdd",
+   "id": "aa42a3df",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1040,7 +1054,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52093356",
+   "id": "a8dc1ff2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1056,7 +1070,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c8ca2913",
+   "id": "dfa3a033",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1072,7 +1086,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70136015",
+   "id": "cab56968",
    "metadata": {},
    "source": [
     "Part 7 recap: `kg` and `graph` are now the two graph objects every later Part reasons over, searches, and exports."
@@ -1080,7 +1094,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1972878c",
+   "id": "29ef5387",
    "metadata": {},
    "source": [
     "## Part 8: Clinical Semantic Search\n",
@@ -1091,7 +1105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c90deab3",
+   "id": "86a7f6f9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1113,7 +1127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b951fd55",
+   "id": "9673585a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1140,7 +1154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "859b9da3",
+   "id": "d8752052",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1152,7 +1166,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b35fb8ee",
+   "id": "fa87b057",
    "metadata": {},
    "source": [
     "Part 8 recap: both answers trace directly back to the `comorbid_with`/`treats` edges built in Part 7, with no keyword matching and no hand-curated result list."
@@ -1160,7 +1174,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d560798",
+   "id": "4eded78e",
    "metadata": {},
    "source": [
     "## Part 9: Deterministic Clinical Reasoning\n",
@@ -1171,7 +1185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7762f112",
+   "id": "7f059591",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1198,7 +1212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4396d01f",
+   "id": "c53c2640",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1210,7 +1224,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6204fa14",
+   "id": "12a0c4eb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1224,7 +1238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3fc9fb22",
+   "id": "26921171",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1249,7 +1263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a48880c2",
+   "id": "bf980829",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1263,7 +1277,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4bfbc5c4",
+   "id": "20e09f8e",
    "metadata": {},
    "source": [
     "Part 9 recap: the same diagnosis -> recommendation logic, checked four independent ways, each one able to show its work. Part 10 turns this pattern into a tracked, policy-checked, causally-linked decision for patient two."
@@ -1271,7 +1285,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d83c1660",
+   "id": "a98d4156",
    "metadata": {},
    "source": [
     "## Part 10: Clinical Decision Intelligence\n",
@@ -1282,7 +1296,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eff527ad",
+   "id": "57835528",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1303,7 +1317,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64c5c186",
+   "id": "8e14e8bb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1328,7 +1342,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b0ea59a",
+   "id": "e379e4cb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1349,7 +1363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "870c9ef6",
+   "id": "1f81f1bd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1367,7 +1381,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf17184a",
+   "id": "1db2722e",
    "metadata": {},
    "source": [
     "Part 10 recap: a causally-linked, policy-gated decision, with its justification traceable to a real regulatory sentence rather than an invented rule. `agent`, `engine_pe`, `diag_id`, and `treat_id` return in the capstone."
@@ -1375,7 +1389,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f051dd32",
+   "id": "2b1b6a08",
    "metadata": {},
    "source": [
     "## Part 11: Provenance & Audit Trails\n",
@@ -1386,7 +1400,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3538f9fc",
+   "id": "d8ee43a9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1403,7 +1417,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ac102a18",
+   "id": "cdf2040f",
    "metadata": {},
    "source": [
     "This follows the shape of PROV-O, the W3C standard vocabulary for recording provenance (which agent produced which entity, from which source, when): every decision node traces to the document(s) that justified it, and every document to the real URL it came from (or an explicit `synthetic:` marker). This is an audit capability a vector-similarity retrieval log alone does not provide."
@@ -1411,7 +1425,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b0909df",
+   "id": "10fb39a9",
    "metadata": {},
    "source": [
     "## Part 12: GraphRAG\n",
@@ -1424,7 +1438,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aedce217",
+   "id": "9aca02b1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1442,7 +1456,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "130e8afa",
+   "id": "cf9aaee9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1461,7 +1475,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "118075ec",
+   "id": "1b7eab55",
    "metadata": {},
    "source": [
     "Part 12 recap: ingestion, ontology, and graph structure all converge into one retrieval call. The context block above is ready for any LLM, with no hard dependency on one."
@@ -1469,7 +1483,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89b429d2",
+   "id": "20cc4960",
    "metadata": {},
    "source": [
     "## Part 13: Interactive Visualization\n",
@@ -1480,7 +1494,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f60d2313",
+   "id": "0122b990",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1495,7 +1509,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02341b20",
+   "id": "0dbccaf8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1510,7 +1524,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02e6b991",
+   "id": "7907104b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1529,7 +1543,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39df51a0",
+   "id": "3f2c54df",
    "metadata": {},
    "source": [
     "### The Knowledge Explorer\n",
@@ -1539,7 +1553,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22136f99",
+   "id": "28b3da4a",
    "metadata": {},
    "source": [
     "## Part 14: Export & Deployment\n",
@@ -1550,7 +1564,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "de4dfa4c",
+   "id": "544fe0ed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1567,7 +1581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19303ed1",
+   "id": "d5f7e531",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1580,7 +1594,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b52e977a",
+   "id": "c259b93c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1594,7 +1608,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "338551eb",
+   "id": "befc090c",
    "metadata": {},
    "source": [
     "Part 14 recap: the clinical knowledge graph is now portable to whatever a hospital's actual data platform runs on."
@@ -1602,7 +1616,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16e6d645",
+   "id": "fe0ed0eb",
    "metadata": {},
    "source": [
     "## End-to-End Use Case: Explainable Clinical Decision Support System\n",
@@ -1613,7 +1627,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b48e683a",
+   "id": "4d117278",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1632,7 +1646,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76e611fc",
+   "id": "9f95c16d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1649,7 +1663,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9e947c2b",
+   "id": "f303a4fa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1662,7 +1676,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64dc27a6",
+   "id": "e1c6864f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1684,7 +1698,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ad8f6bf",
+   "id": "1f68bf9c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1700,7 +1714,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b0d35723",
+   "id": "2abfff40",
    "metadata": {},
    "source": [
     "Capstone recap: **ingestion -> knowledge graph -> reasoning -> policy-gated decision -> explanation -> export**, on a patient the notebook had never seen, using the exact objects built in Parts 2-14. That reusable shape is the point."
@@ -1708,7 +1722,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7af8d740",
+   "id": "b2565875",
    "metadata": {},
    "source": [
     "## Adapting This Pattern to Other Domains\n",
@@ -1740,7 +1754,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4ab9a4b6",
+   "id": "bd3af9f1",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/cookbook/use_cases/healthcare/01_Clinical_Intelligence_with_Semantica.ipynb
+++ b/cookbook/use_cases/healthcare/01_Clinical_Intelligence_with_Semantica.ipynb
@@ -46,7 +46,7 @@
     "pip install semantica\n",
     "```\n",
     "\n",
-    "SHACL validation support (`pyshacl`) is tracked in [#TBD](https://github.com/Hawksight-AI/semantica/issues/TBD) — install `pyshacl` directly for now if you want to try live validation in Part 6:\n",
+    "SHACL validation support (`pyshacl`) is tracked in [#736](https://github.com/semantica-agi/semantica/issues/736) — install `pyshacl` directly for now if you want to try live validation in Part 6:\n",
     "```bash\n",
     "pip install pyshacl\n",
     "```\n",


### PR DESCRIPTION
## Summary
- Introduces `cookbook/use_cases/` as a new domain-organized cookbook directory, with `healthcare/01_Clinical_Intelligence_with_Semantica.ipynb` as the first notebook in the series (alongside the planned `02_Disease_Network_Analysis.ipynb` and `05_Medical_Database_Integration.ipynb`).
- Covers ingestion, ontology engineering, SKOS vocabulary management, ontology alignment, SHACL validation, knowledge graph construction, semantic search, deterministic reasoning, decision intelligence, provenance/audit, GraphRAG, visualization, and export, using Semantica's own classes throughout (e.g. `NamespaceManager`, `OntologyIngestor`, `AgentContext`, `PolicyEngine`).
- All disease/drug reference data (identity, definitions, synonyms, codes, literature, regulatory text) is fetched live from real public sources: Wikidata, EBI OLS4/MONDO, openFDA, RxNav, NLM Clinical Tables, and NCBI E-utilities. Only the 3-4 patient records are synthetic, and this is called out explicitly. Failures on critical sources raise a clear error rather than falling back to placeholder text.
- Closes with a capstone that runs the full pipeline on a new patient case, and a section mapping the pattern onto non-healthcare domains (finance, legal, supply chain).

## Test plan
- [x] Executed the notebook end-to-end (105 cells) with live network access; zero errors.
- [x] Verified real data appears in output (e.g. real FDA label for a metformin-containing product, real PubMed article titles, real ICD-10-CM/RxCUI/MONDO codes).
- [x] Validated notebook JSON with `nbformat.validate`.
- [x] Confirmed no collision with the planned `02_Disease_Network_Analysis.ipynb` (different dataset shape) or `05_Medical_Database_Integration.ipynb` (no `MCPIngestor` usage).