### PR TITLE
feat(doctor): surface embedding backend health instead of reporting green

### DIFF
--- a/semantica/cli.py
+++ b/semantica/cli.py
@@ -773,6 +773,15 @@ def changelog(cli_ctx: CLIContext, local_json: bool) -> None:
     _run_with_error_handling(_action)
 
 
+class _DeepEmbeddingFailure(Exception):
+    """A deep-probe failure from doctor's embedding checks.
+
+    Marks failures that happened AFTER the backend imported cleanly — model
+    load, probe, or runtime problems — so the check's hint can point at the
+    real remediation instead of `pip install`.
+    """
+
+
 @main.command()
 @click.option("--json", "local_json", is_flag=True, default=False)
 @click.option("--deep-embeddings", "deep_embeddings", is_flag=True, default=False,
@@ -790,6 +799,16 @@ def doctor(cli_ctx: CLIContext, local_json: bool, deep_embeddings: bool) -> None
         try:
             note = fn()
             return label, "ok", note, None
+        except _DeepEmbeddingFailure as exc:
+            # A deep-probe failure means the package IMPORTED fine: the pip
+            # hint would be the wrong remediation for what is actually a
+            # runtime/model-load problem (broken torch, failed model
+            # download, missing shared libs).
+            return label, "fail", str(exc), (
+                "runtime/model-load failure — reinstalling the package usually "
+                "does not help; check the warnings above (torch install, model "
+                "download, disk space)"
+            )
         except Exception as exc:
             return label, "fail", str(exc), hint
 
@@ -837,7 +856,7 @@ def doctor(cli_ctx: CLIContext, local_json: bool, deep_embeddings: bool) -> None
         # SEMANTICA_DOCTOR_DEEP_EMBEDDINGS=1) instantiates the backend through
         # TextEmbedder and embeds a probe, which is the only level that
         # catches a backend that imports cleanly but cannot actually load.
-        deep = deep_embeddings or os.environ.get("SEMANTICA_DOCTOR_DEEP_EMBEDDINGS", "") in ("1", "true", "yes")
+        deep = deep_embeddings or os.environ.get("SEMANTICA_DOCTOR_DEEP_EMBEDDINGS", "").strip().lower() in ("1", "true", "yes", "on")
 
         def _embedding_backend(method: str) -> str:
             if method == "sentence_transformers":
@@ -848,14 +867,19 @@ def doctor(cli_ctx: CLIContext, local_json: bool, deep_embeddings: bool) -> None
                 note = f"importable ({importlib.metadata.version('fastembed')})"
             if not deep:
                 return note
-            from .embeddings import TextEmbedder
-            embedder = TextEmbedder(method=method)
-            if embedder.model is None and embedder.fastembed_model is None:
-                raise RuntimeError(
-                    "model failed to load — the hash fallback is active "
-                    "(see warnings above); embedding quality is degraded"
-                )
-            probe = embedder.embed_text("semantica doctor embedding probe")
+            try:
+                from .embeddings import TextEmbedder
+                embedder = TextEmbedder(method=method)
+                if embedder.model is None and embedder.fastembed_model is None:
+                    raise RuntimeError(
+                        "model failed to load — the hash fallback is active "
+                        "(see warnings above); embedding quality is degraded"
+                    )
+                probe = embedder.embed_text("semantica doctor embedding probe")
+            except _DeepEmbeddingFailure:
+                raise
+            except Exception as exc:
+                raise _DeepEmbeddingFailure(str(exc)) from exc
             return f"{note}; deep probe ok ({len(probe)}-dim)"
 
         checks.append(_check(

--- a/semantica/cli.py
+++ b/semantica/cli.py
@@ -775,8 +775,11 @@ def changelog(cli_ctx: CLIContext, local_json: bool) -> None:
 
 @main.command()
 @click.option("--json", "local_json", is_flag=True, default=False)
+@click.option("--deep-embeddings", "deep_embeddings", is_flag=True, default=False,
+              help="Also instantiate the local embedding backends and embed a probe "
+                   "text (catches backends that import cleanly but cannot load).")
 @click.pass_obj
-def doctor(cli_ctx: CLIContext, local_json: bool) -> None:
+def doctor(cli_ctx: CLIContext, local_json: bool, deep_embeddings: bool) -> None:
     """Run a health check on all Semantica components and backends."""
     import importlib.metadata
     cli_ctx = _require_ctx(cli_ctx)
@@ -826,6 +829,45 @@ def doctor(cli_ctx: CLIContext, local_json: bool) -> None:
                 import faiss  # noqa: F401
             return f"{backend} importable"
         checks.append(_check("Vector store", _vector, hint="pip install semantica[vectorstore-…]"))
+
+        # Embedding backends (#994): `doctor` used to report all green while
+        # every local embedding backend was non-functional — import success
+        # says nothing about model loading. Default checks stay cheap
+        # (import + version); --deep-embeddings (or
+        # SEMANTICA_DOCTOR_DEEP_EMBEDDINGS=1) instantiates the backend through
+        # TextEmbedder and embeds a probe, which is the only level that
+        # catches a backend that imports cleanly but cannot actually load.
+        deep = deep_embeddings or os.environ.get("SEMANTICA_DOCTOR_DEEP_EMBEDDINGS", "") in ("1", "true", "yes")
+
+        def _embedding_backend(method: str) -> str:
+            if method == "sentence_transformers":
+                import sentence_transformers  # noqa: F401
+                note = f"importable ({importlib.metadata.version('sentence-transformers')})"
+            else:
+                import fastembed  # noqa: F401
+                note = f"importable ({importlib.metadata.version('fastembed')})"
+            if not deep:
+                return note
+            from .embeddings import TextEmbedder
+            embedder = TextEmbedder(method=method)
+            if embedder.model is None and embedder.fastembed_model is None:
+                raise RuntimeError(
+                    "model failed to load — the hash fallback is active "
+                    "(see warnings above); embedding quality is degraded"
+                )
+            probe = embedder.embed_text("semantica doctor embedding probe")
+            return f"{note}; deep probe ok ({len(probe)}-dim)"
+
+        checks.append(_check(
+            "Embeddings (sentence-transformers)",
+            lambda: _embedding_backend("sentence_transformers"),
+            hint="pip install sentence-transformers",
+        ))
+        checks.append(_check(
+            "Embeddings (fastembed)",
+            lambda: _embedding_backend("fastembed"),
+            hint="pip install fastembed",
+        ))
 
         # LLM provider keys
         for provider, var in [("OpenAI", "OPENAI_API_KEY"), ("Anthropic", "ANTHROPIC_API_KEY"),

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1921,3 +1921,48 @@ class TestDoctorEmbeddings:
         st = checks["Embeddings (sentence-transformers)"]
         assert st["status"] == "fail"
         assert "hash fallback" in st["note"]
+
+
+class TestDoctorEmbeddingHintsAndEnv:
+    """Review follow-ups: deep failures must not carry the pip-install hint,
+    and the env toggle tolerates case/whitespace variants."""
+
+    def _doctor_checks(self, runner, *extra):
+        result = runner.invoke(cli_module.main, ["doctor", "--json", *extra])
+        _ok(result)
+        import json as _json
+        return {c["check"]: c for c in _json.loads(result.output)}
+
+    def _with_fake_st(self, monkeypatch):
+        fake_st = _fake_module(
+            __version__="9.9.9",
+            SentenceTransformer=object,
+        )
+        monkeypatch.setitem(__import__("sys").modules, "sentence_transformers", fake_st)
+
+    def test_deep_failure_hint_is_not_pip_install(self, runner, monkeypatch):
+        self._with_fake_st(monkeypatch)
+        fake_embedder = types.SimpleNamespace(model=None, fastembed_model=None)
+        fake_emb_mod = _fake_module(TextEmbedder=lambda **k: fake_embedder)
+        monkeypatch.setitem(__import__("sys").modules, "semantica.embeddings", fake_emb_mod)
+
+        checks = self._doctor_checks(runner, "--deep-embeddings")
+        st = checks["Embeddings (sentence-transformers)"]
+        assert st["status"] == "fail"
+        assert "pip install" not in (st["hint"] or ""), (
+            "a deep probe failure means the package imported fine — pointing "
+            "users at pip sends them to reinstall for a runtime/model problem"
+        )
+        assert "runtime/model-load" in st["hint"]
+
+    def test_env_var_tolerates_case_and_whitespace(self, runner, monkeypatch):
+        monkeypatch.setenv("SEMANTICA_DOCTOR_DEEP_EMBEDDINGS", "  TRUE ")
+        self._with_fake_st(monkeypatch)
+        fake_embedder = types.SimpleNamespace(model=None, fastembed_model=None)
+        fake_emb_mod = _fake_module(TextEmbedder=lambda **k: fake_embedder)
+        monkeypatch.setitem(__import__("sys").modules, "semantica.embeddings", fake_emb_mod)
+
+        checks = self._doctor_checks(runner)
+        st = checks["Embeddings (sentence-transformers)"]
+        assert st["status"] == "fail"
+        assert "hash fallback" in st["note"], "padded/caps env value must enable deep mode"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1851,3 +1851,73 @@ class TestExitCodes:
             assert "Traceback" not in result.output, (
                 f"Traceback found for {argv}: {result.output}"
             )
+
+
+class TestDoctorEmbeddings:
+    """#994: doctor must surface non-functional embedding backends instead of
+    reporting all green. Default = import-level check; --deep-embeddings (or
+    SEMANTICA_DOCTOR_DEEP_EMBEDDINGS=1) instantiates via TextEmbedder."""
+
+    def _doctor_checks(self, runner, *extra):
+        result = runner.invoke(cli_module.main, ["doctor", "--json", *extra])
+        _ok(result)
+        import json as _json
+        return {c["check"]: c for c in _json.loads(result.output)}
+
+    def _with_fake_st(self, monkeypatch, **embedder_attrs):
+        fake_st = _fake_module(
+            __version__="9.9.9",
+            SentenceTransformer=object,
+        )
+        monkeypatch.setitem(__import__("sys").modules, "sentence_transformers", fake_st)
+
+    def test_doctor_reports_embedding_checks(self, runner):
+        checks = self._doctor_checks(runner)
+        assert "Embeddings (sentence-transformers)" in checks
+        assert "Embeddings (fastembed)" in checks
+
+    def test_import_failure_is_fail_status_with_hint(self, runner):
+        checks = self._doctor_checks(runner)
+        st = checks["Embeddings (sentence-transformers)"]
+        if st["status"] == "fail":
+            assert st["hint"] == "pip install sentence-transformers"
+
+    def test_deep_probe_detects_fallback_active(self, runner, monkeypatch):
+        self._with_fake_st(monkeypatch)
+        fake_embedder = types.SimpleNamespace(model=None, fastembed_model=None)
+
+        fake_emb_mod = _fake_module(TextEmbedder=lambda **k: fake_embedder)
+        monkeypatch.setitem(__import__("sys").modules, "semantica.embeddings", fake_emb_mod)
+
+        checks = self._doctor_checks(runner, "--deep-embeddings")
+        st = checks["Embeddings (sentence-transformers)"]
+        assert st["status"] == "fail"
+        assert "hash fallback" in st["note"]
+
+    def test_deep_probe_ok_when_model_loads(self, runner, monkeypatch):
+        self._with_fake_st(monkeypatch)
+        import numpy as np
+        fake_embedder = types.SimpleNamespace(
+            model=object(),
+            fastembed_model=None,
+            embed_text=lambda text: np.zeros(384, dtype=np.float32),
+        )
+        fake_emb_mod = _fake_module(TextEmbedder=lambda **k: fake_embedder)
+        monkeypatch.setitem(__import__("sys").modules, "semantica.embeddings", fake_emb_mod)
+
+        checks = self._doctor_checks(runner, "--deep-embeddings")
+        st = checks["Embeddings (sentence-transformers)"]
+        assert st["status"] == "ok"
+        assert "384-dim" in st["note"]
+
+    def test_env_var_enables_deep_mode(self, runner, monkeypatch):
+        monkeypatch.setenv("SEMANTICA_DOCTOR_DEEP_EMBEDDINGS", "1")
+        self._with_fake_st(monkeypatch)
+        fake_embedder = types.SimpleNamespace(model=None, fastembed_model=None)
+        fake_emb_mod = _fake_module(TextEmbedder=lambda **k: fake_embedder)
+        monkeypatch.setitem(__import__("sys").modules, "semantica.embeddings", fake_emb_mod)
+
+        checks = self._doctor_checks(runner)
+        st = checks["Embeddings (sentence-transformers)"]
+        assert st["status"] == "fail"
+        assert "hash fallback" in st["note"]


### PR DESCRIPTION
Addresses the `semantica doctor` gap called out in #994's Additional Context: "doctor reports everything green except missing LLM API keys — it does not catch that the local embedding backends are non-functional, so there's no signal short of actually running `embed generate`".

## What

Two new checks, `Embeddings (sentence-transformers)` and `Embeddings (fastembed)`:

- **Default (cheap)**: import the backend and report its version. An uninstalled backend is now a `fail` row with a `pip install ...` hint instead of invisible.
- **`--deep-embeddings` (or `SEMANTICA_DOCTOR_DEEP_EMBEDDINGS=1`)**: additionally instantiate the backend through `TextEmbedder` and embed a probe text. If the model fails to load, `TextEmbedder` silently degrades to the hash fallback — the deep probe detects exactly that (`model is None and fastembed_model is None` -> `fail` with a "hash fallback is active" note). This is the only check level that catches a backend which imports cleanly but cannot actually load, which is the #994 failure mode.

Deep mode is opt-in because it downloads/loads real models; the default stays fast for routine `doctor` runs.

Smoke-tested against a real broken environment: doctor now reports the corrupted local torch install (`c10_cuda.dll` load failure) and missing fastembed as `fail` rows where it previously showed all green.

## Validation

- `python -m pytest tests/test_cli_commands.py::TestDoctorEmbeddings` — 5 passed (checks present; import failure yields fail+hint; deep probe flags hash-fallback-active as fail; deep probe passes with a loaded model and reports the probe dimension; env-var toggle equals the flag)
- Manual: `python -m semantica.cli doctor --json` on this sandbox shows both backends' real state
- AST parse of the patched cli.py

## AI-assisted development disclosure

ZCode assisted with implementing the checks and regressions from the issue's Additional Context. I reviewed the final diff, ran the validation above, and take responsibility for the submitted change.