### PR TITLE
perf: route all spaCy model loads through the process-wide cache

### DIFF
--- a/semantica/semantic_extract/ner_extractor.py
+++ b/semantica/semantic_extract/ner_extractor.py
@@ -139,12 +139,15 @@ class NERExtractor:
         if not self.progress_tracker.enabled:
             self.progress_tracker.enabled = True
 
-        # Initialize spaCy model if ML method is used
+        # Initialize spaCy model if ML method is used. Route through the
+        # process-wide cache (#997): every NERExtractor instance used to pay
+        # spacy.load() on construction, and spaCy model loads are 1-3s each.
         self.nlp = None
         self._ml_runtime_usable = True
         if "ml" in self.method and SPACY_AVAILABLE:
             try:
-                self.nlp = spacy.load(self.model_name)
+                from .methods import load_spacy_model
+                self.nlp = load_spacy_model(self.model_name)
             except OSError:
                 self.logger.warning(
                     f"spaCy model {self.model_name} not found. ML method will fallback."

--- a/semantica/split/methods.py
+++ b/semantica/split/methods.py
@@ -333,10 +333,12 @@ def split_by_sentences(
     Returns:
         List of chunks
     """
-    # Try spaCy first
+    # Try spaCy first. Route through the process-wide cache (#997/#998):
+    # every split call used to pay spacy.load(), which is 1-3s per load.
     if SPACY_AVAILABLE and kwargs.get("use_spacy", True):
         try:
-            nlp = spacy.load("en_core_web_sm")
+            from ..semantic_extract.methods import load_spacy_model
+            nlp = load_spacy_model("en_core_web_sm")
             doc = nlp(text)
             sentences = [sent.text for sent in doc.sents]
         except Exception:

--- a/semantica/split/semantic_chunker.py
+++ b/semantica/split/semantic_chunker.py
@@ -79,7 +79,9 @@ class SemanticChunker:
         if SPACY_AVAILABLE:
             model_name = config.get("model", "en_core_web_sm")
             try:
-                self.nlp = spacy.load(model_name)
+                # Route through the process-wide cache (#997/#998).
+                from ..semantic_extract.methods import load_spacy_model
+                self.nlp = load_spacy_model(model_name)
             except OSError:
                 self.logger.warning(
                     f"spaCy model {model_name} not found. Using fallback chunking."


### PR DESCRIPTION
Fixes #997. Also fixes the `split/` half of #998.

## Summary

`methods.py` already has a process-wide `load_spacy_model()` cache (added for the extraction path), but three other files still called raw `spacy.load()` on every invocation, paying 1-3s per model load:

| file | trigger | load per |
|---|---|---|
| `semantic_extract/ner_extractor.py:147` | every `NERExtractor()` construction | instance |
| `split/methods.py:339` | every `split_text(method="sentence")` call | call |
| `split/semantic_chunker.py:82` | every `SemanticChunker()` construction | instance |

All three now import and call `load_spacy_model()` from `semantic_extract.methods` — the first call loads the model, every subsequent call returns the cached instance keyed by model name (with the spacy-module guard the cache already carries for test isolation).

The `OSError` fallback behavior ("model not found, falling back") is unchanged: `load_spacy_model` re-raises whatever `spacy.load` raises.

## Validation

- `python -c "import ast; ast.parse(...)"` on all three patched files
- `python -m pytest tests/test_seed_manager.py tests/seed/test_seed_manager.py` — 25 passed
- No raw `spacy.load(` remains outside `methods.py`'s cache and the docstring
- spaCy itself is not installed in this sandbox; the cached-loader path is exercised in CI where spaCy is present

## AI-assisted development disclosure

ZCode assisted with routing the three load sites and the validation. I reviewed the final diff, ran the validation above, and take responsibility for the submitted change.