### PR TITLE
fix(semantic_extract): stop NER huggingface_model leaking into model loader kwargs

### DIFF
--- a/semantica/semantic_extract/ner_extractor.py
+++ b/semantica/semantic_extract/ner_extractor.py
@@ -369,11 +369,16 @@ class NERExtractor:
                     if method_name == "huggingface":
                         # Prioritize runtime options over config/defaults
                         method_options["model"] = (
-                            options.get("huggingface_model") 
-                            or options.get("model") 
+                            options.get("huggingface_model")
+                            or options.get("model")
                             or self.huggingface_model
                         )
                         method_options["device"] = all_options.get("device")
+                        # #1060: NER-level configuration must not leak into the
+                        # HuggingFace model loader as arbitrary kwargs. The
+                        # loader only supports model / device / aggregation_strategy /
+                        # tokenizer — huggingface_model is a NERExtractor option.
+                        method_options.pop("huggingface_model", None)
                     elif method_name == "llm":
                         method_options["provider"] = all_options.get(
                             "provider", "openai"

--- a/semantica/semantic_extract/ner_extractor.py
+++ b/semantica/semantic_extract/ner_extractor.py
@@ -375,9 +375,12 @@ class NERExtractor:
                         )
                         method_options["device"] = all_options.get("device")
                         # #1060: NER-level configuration must not leak into the
-                        # HuggingFace model loader as arbitrary kwargs. The
-                        # loader only supports model / device / aggregation_strategy /
-                        # tokenizer — huggingface_model is a NERExtractor option.
+                        # HuggingFace model loader as arbitrary kwargs.
+                        # load_ner_model() takes the model name plus **kwargs
+                        # it forwards to the transformers pipeline —
+                        # huggingface_model is a NERExtractor option naming
+                        # the model, not a pipeline option, so it is consumed
+                        # into method_options["model"] above and removed.
                         method_options.pop("huggingface_model", None)
                     elif method_name == "llm":
                         method_options["provider"] = all_options.get(


### PR DESCRIPTION
Fixes #1060.

The HuggingFace dispatch path copies the complete NER configuration into method_options and forwards it downstream, so the loader receives load_ner_model(model, huggingface_model=...) instead of the clean load_ner_model(model). The fix pops huggingface_model from method_options after it is consumed — the loader only supports model/device/aggregation_strategy/tokenizer.