### PR TITLE
fix(semantic_extract): restore NER configuration test coverage after production API changes

### DIFF
--- a/semantica/semantic_extract/ner_extractor.py
+++ b/semantica/semantic_extract/ner_extractor.py
@@ -374,11 +374,14 @@ class NERExtractor:
                     if method_name == "huggingface":
                         # Prioritize runtime options over config/defaults
                         method_options["model"] = (
-                            options.get("huggingface_model") 
-                            or options.get("model") 
+                            options.get("huggingface_model")
+                            or options.get("model")
                             or self.huggingface_model
                         )
                         method_options["device"] = all_options.get("device")
+                        # Remove huggingface_model to prevent it leaking
+                        # as an unexpected kwarg into load_ner_model()
+                        method_options.pop("huggingface_model", None)
                     elif method_name == "llm":
                         method_options["provider"] = all_options.get(
                             "provider", "openai"

--- a/tests/test_ner_configurations.py
+++ b/tests/test_ner_configurations.py
@@ -29,34 +29,35 @@ class TestNERConfigurations(unittest.TestCase):
     def test_ner_llm_config(self, mock_create_provider):
         """Test NER with LLM configuration"""
         print("\nTesting NER with LLM configuration...")
-        
-        # Mock LLM provider
+
+        # Mock LLM provider — production now uses generate_typed (not generate_structured)
+        from semantica.semantic_extract.schemas import EntitiesResponse, EntityOut
         mock_provider = MagicMock()
         mock_provider.is_available.return_value = True
-        mock_provider.generate_structured.return_value = [
-            {"text": "Apple Inc.", "label": "ORG", "start": 0, "end": 10, "confidence": 0.95},
-            {"text": "Steve Jobs", "label": "PERSON", "start": 26, "end": 36, "confidence": 0.98}
-        ]
+        mock_provider.generate_typed.return_value = EntitiesResponse(entities=[
+            EntityOut(text="Apple Inc.", label="ORG", start_char=0, end_char=10, confidence=0.95),
+            EntityOut(text="Steve Jobs", label="PERSON", start_char=26, end_char=36, confidence=0.98),
+        ])
         mock_create_provider.return_value = mock_provider
-        
+
         # Initialize extractor with LLM method
         extractor = NERExtractor(
-            method="llm", 
-            provider="openai", 
+            method="llm",
+            provider="openai",
             model="gpt-4",
             temperature=0.1
         )
-        
+
         entities = extractor.extract_entities(self.text)
-        
+
         # Verify provider creation args
         mock_create_provider.assert_called_with("openai", model="gpt-4", temperature=0.1)
-        
-        # Verify extraction
+
+        # Verify extraction — extraction_method is now "llm_typed"
         self.assertEqual(len(entities), 2)
         self.assertEqual(entities[0].text, "Apple Inc.")
         self.assertEqual(entities[0].label, "ORG")
-        self.assertEqual(entities[0].metadata["extraction_method"], "llm")
+        self.assertEqual(entities[0].metadata["extraction_method"], "llm_typed")
         self.assertEqual(entities[0].metadata["model"], "gpt-4")
 
     @patch('semantica.semantic_extract.methods.spacy')
@@ -183,10 +184,7 @@ class TestNERConfigurations(unittest.TestCase):
         
         self.assertTrue(len(entities) >= 2)
         texts = [e.text for e in entities]
-        self.assertIn("Apple Inc", texts) # Regex pattern does not capture the trailing dot
-        # Actually methods.py regex: r"\b([A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)*\s+(?:Inc|Corp|LLC|Ltd|Company))\b"
-        # "Apple Inc." -> "Apple Inc" (dot is outside \b if not matched?)
-        # Let's check the result strictly
+        self.assertIn("Apple Inc.", texts) # ORG pattern updated to capture trailing period
         
     @patch('semantica.semantic_extract.methods.create_provider')
     @patch('semantica.semantic_extract.methods.spacy')
@@ -255,7 +253,7 @@ class TestNERConfigurations(unittest.TestCase):
         )
         entities = extractor.extract_entities(self.text)
         
-        mock_loader.load_ner_model.assert_called_with("dslim/bert-base-NER")
+        mock_loader.load_ner_model.assert_called_once_with("dslim/bert-base-NER")
         self.assertEqual(len(entities), 1)
         self.assertEqual(entities[0].text, "Apple Inc.")
         self.assertEqual(entities[0].label, "ORG")


### PR DESCRIPTION
## Summary

Fixes three failing tests in `tests/test_ner_configurations.py` that broke after production API changes. Also fixes a `huggingface_model` kwargs leak in `NERExtractor` that caused one of the test failures.

Closes #1059

## Changes

### Test fixes (`tests/test_ner_configurations.py`)

1. **`test_ner_pattern_config`**: Updated assertion from `"Apple Inc"` to `"Apple Inc."` — the ORG regex pattern was updated in commit `246bcc96` to capture trailing periods.

2. **`test_ner_llm_config`**: Updated mock to use `generate_typed()` with `EntitiesResponse` Pydantic schema (production migrated from `generate_structured()`). Updated `extraction_method` assertion from `"llm"` to `"llm_typed"`.

3. **`test_ner_huggingface_config`**: Fixed a bug where `huggingface_model` kwargs leaked from `NERExtractor.method_options` into `load_ner_model(**kwargs)`. Fix: `method_options.pop("huggingface_model", None)`.

### Bug fix (`ner_extractor.py`)

- **`huggingface_model` kwargs leak**: `method_options` dict was passed directly to `load_ner_model()`, causing an unexpected keyword argument error when `huggingface_model` was present. Now properly popped before forwarding.

## Testing

- All 3 previously failing tests now pass
- Full test suite green (CI passes)
- Verified against current `main` HEAD