### PR TITLE
feat(providers): add OrcaRouter provider for unified frontier-model routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1151,7 +1151,7 @@ if report.valid:
 | **Graph Databases (LPG)** | Neo4j · FalkorDB · Apache AGE · AWS Neptune |
 | **Triple Stores (RDF)** | Oxigraph (embedded) · Blazegraph · Apache Jena · Eclipse RDF4J · unified `TripletStore` interface · SPARQL query & bulk load |
 | **Enterprise Data Platforms** | Databricks (`DatabricksIngestor`: Unity Catalog + Delta Lake, PAT/OAuth M2M, table/query ingestion, catalog/schema/table/lineage introspection) · Snowflake (`SnowflakeIngestor`: warehouse/database/schema, password/key-pair/OAuth auth) |
-| **LLM Providers** | **All already supported today:** OpenAI (GPT-4o, o1, o3) · Anthropic (Claude) · Google Gemini · Mistral · Meta Llama · Groq · Cohere · Azure OpenAI · AWS Bedrock · Ollama · DeepSeek · Perplexity · Together AI · Fireworks AI · Replicate · HuggingFace · via `semantica.llms` and LiteLLM |
+| **LLM Providers** | **All already supported today:** OpenAI (GPT-4o, o1, o3) · Anthropic (Claude) · Google Gemini · Mistral · Meta Llama · Groq · Cohere · Azure OpenAI · AWS Bedrock · Ollama · DeepSeek · OrcaRouter · Perplexity · Together AI · Fireworks AI · Replicate · HuggingFace · via `semantica.llms` and LiteLLM |
 
 ---
 
@@ -1191,7 +1191,7 @@ Start with `semantica`, verify with `doctor`, build a graph, and explore the com
 
 ## Integrations
 
-Native plugin bundles for Claude Code, Cursor, Codex, Windsurf, Cline, Continue, VS Code, and OpenClaw; a full-featured MCP server for any MCP-compatible client; a comprehensive REST API; and first-class Agno and CrewAI support for agentic frameworks. Every major LLM provider is already supported via `semantica.llms` and LiteLLM: OpenAI, Anthropic, Gemini, Mistral, Llama, Groq, Cohere, Azure, Bedrock, Ollama, DeepSeek, HuggingFace, and more.
+Native plugin bundles for Claude Code, Cursor, Codex, Windsurf, Cline, Continue, VS Code, and OpenClaw; a full-featured MCP server for any MCP-compatible client; a comprehensive REST API; and first-class Agno and CrewAI support for agentic frameworks. Every major LLM provider is already supported via `semantica.llms` and LiteLLM: OpenAI, Anthropic, Gemini, Mistral, Llama, Groq, Cohere, Azure, Bedrock, Ollama, DeepSeek, OrcaRouter, HuggingFace, and more.
 
 MCP setup takes 30 seconds — see [MCP Server](#mcp-server) below.
 

--- a/docs/guides/llm-integrations.md
+++ b/docs/guides/llm-integrations.md
@@ -143,6 +143,33 @@ risk_data = oai.generate_structured(
 
 The default model `gpt-3.5-turbo` is fine for classification and light extraction. Switch to `gpt-4o` for complex multi-step regulatory reasoning or document understanding.
 
+## OrcaRouter — Unified Gateway to Frontier Models
+
+**[OrcaRouter](https://www.orcarouter.ai)** is a routing gateway that exposes one OpenAI-compatible endpoint and forwards every request to the best available frontier model — Anthropic Claude, OpenAI GPT, Google Gemini, DeepSeek and more — under a single API key. Models use the familiar `provider/model` prefix (`openai/gpt-4o`, `anthropic/claude-sonnet-4.6`, `deepseek/deepseek-v4-flash`), so swapping vendors is a one-line change. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+Use the `OrcaRouter` provider when you want a single contract across multiple frontier vendors, need to fail over between models without touching application code, or want your extraction pipeline to be vendor-agnostic.
+
+```python
+from semantica.llms import OrcaRouter
+
+orca = OrcaRouter(model="openai/gpt-4o", api_key="YOUR_ORCAROUTER_KEY")
+# api_key falls back to ORCAROUTER_API_KEY environment variable
+
+response = orca.generate(
+    "Classify this alert: 4200 LDAP objects enumerated in 8s from ws-finance-03."
+)
+print(response)
+
+# Structured output — same .generate_structured() interface as every provider
+risk_data = orca.generate_structured(
+    "Extract all counterparty names and exposure amounts from: "
+    "Counterparty A: 45M EUR notional, Counterparty B: 12M EUR notional."
+)
+# {"counterparties": [{"name": "Counterparty A", "exposure_eur": 45000000}, ...]}
+```
+
+The default model `openai/gpt-4o` is a good all-round default for classification and extraction. Use the `provider/model` prefix to target any model on the gateway, e.g. `anthropic/claude-sonnet-4.6` for high-accuracy reasoning.
+
 ## LiteLLM — One Interface, 100+ Providers
 
 **LiteLLM** is a universal adapter that provides a single interface to over 100 different LLM providers, including Anthropic Claude, Azure OpenAI, AWS Bedrock, Google Vertex AI, and local Ollama instances. It acts as a translation layer, converting your unified API calls into provider-specific requests, enabling easy switching between providers without code changes.

--- a/docs/reference/llms.md
+++ b/docs/reference/llms.md
@@ -16,7 +16,7 @@ icon: "microchip"
 ## Exported Classes
 
 ```python
-from semantica.llms import Groq, OpenAI, LiteLLM, HuggingFaceLLM
+from semantica.llms import Groq, OpenAI, LiteLLM, HuggingFaceLLM, OrcaRouter
 ```
 
 | Class | Provider | API Key Required |
@@ -25,6 +25,7 @@ from semantica.llms import Groq, OpenAI, LiteLLM, HuggingFaceLLM
 | `OpenAI` | OpenAI / any OpenAI-compatible gateway | `OPENAI_API_KEY` |
 | `LiteLLM` | 100+ providers via LiteLLM routing | Depends on model |
 | `HuggingFaceLLM` | Local HuggingFace Transformers | None (local) |
+| `OrcaRouter` | Routing gateway to frontier models (Anthropic, OpenAI, Gemini, DeepSeek, …) | `ORCAROUTER_API_KEY` |
 
 <Tip>
   **Anthropic, Gemini, Ollama, DeepSeek, Azure, Bedrock, Cohere, and 90+ others** are all available via `LiteLLM` using their model-string prefix. See the [LiteLLM section](#litellm-100-providers) below.
@@ -167,6 +168,7 @@ from semantica.llms import Groq, OpenAI, LiteLLM, HuggingFaceLLM
 export GROQ_API_KEY="your_groq_api_key_here"
 export OPENAI_API_KEY="your_openai_api_key_here" 
 export ANTHROPIC_API_KEY="your_anthropic_api_key_here"
+export ORCAROUTER_API_KEY="your_orcarouter_api_key_here"
 
 # Reload your shell
 source ~/.bashrc
@@ -243,6 +245,18 @@ llm = OpenAI(
     temperature=0.0,
 )
 # **Best for:** general purpose, function calling, JSON mode
+```
+
+```python OrcaRouter
+import os
+from semantica.llms import OrcaRouter
+
+llm = OrcaRouter(
+    model="openai/gpt-4o",              # any provider/model prefix on the gateway
+    api_key=os.getenv("ORCAROUTER_API_KEY"),
+    temperature=0.0,
+)
+# **Best for:** one contract across frontier vendors (Anthropic, OpenAI, Gemini, DeepSeek)
 ```
 
 ```python LiteLLM (100+ providers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,11 +106,12 @@ llm-gemini = ["google-genai>=0.1.0"]
 llm-anthropic = ["anthropic>=0.18.0"]
 llm-ollama = ["ollama>=0.1.0"]
 llm-deepseek = ["openai>=1.0.0"]
+llm-orcarouter = ["openai>=1.0.0"]
 llm-litellm = ["litellm>=1.83.9"]
 llm-instructor = ["instructor>=1.15.3"]
 
 llm-all = [
-  "semantica[llm-openai,llm-groq,llm-gemini,llm-anthropic,llm-ollama,llm-deepseek,llm-litellm,llm-instructor]"
+  "semantica[llm-openai,llm-groq,llm-gemini,llm-anthropic,llm-ollama,llm-deepseek,llm-orcarouter,llm-litellm,llm-instructor]"
 ]
 
 # ---- Document Parsing ----

--- a/semantica/llms/__init__.py
+++ b/semantica/llms/__init__.py
@@ -10,28 +10,33 @@ Supported Providers:
     - OpenAI: OpenAI API (GPT-3.5, GPT-4, etc.)
     - HuggingFaceLLM: HuggingFace Transformers for local LLM inference
     - LiteLLM: Unified interface to 100+ LLM providers (OpenAI, Anthropic, Groq, Azure, Bedrock, Vertex AI, etc.)
+    - OrcaRouter: Routing gateway to frontier models (OpenAI-compatible)
 
 Example Usage:
-    >>> from semantica.llms import Groq, OpenAI, HuggingFaceLLM, LiteLLM
-    >>> 
+    >>> from semantica.llms import Groq, OpenAI, HuggingFaceLLM, LiteLLM, OrcaRouter
+    >>>
     >>> # Groq provider
     >>> groq = Groq(model="llama-3.1-8b-instant", api_key="your-key")
     >>> response = groq.generate("Hello, world!")
-    >>> 
+    >>>
     >>> # OpenAI provider
     >>> openai = OpenAI(model="gpt-4", api_key="your-key")
     >>> response = openai.generate("Hello, world!")
-    >>> 
+    >>>
     >>> # HuggingFace LLM provider
     >>> hf = HuggingFaceLLM(model_name="gpt2")
     >>> response = hf.generate("Hello, world!")
-    >>> 
+    >>>
     >>> # LiteLLM provider (supports 100+ LLMs)
     >>> llm = LiteLLM(model="openai/gpt-4o", api_key="your-key")
     >>> response = llm.generate("Hello, world!")
     >>> # Or use other providers via LiteLLM
     >>> llm = LiteLLM(model="anthropic/claude-sonnet-4-20250514")
     >>> response = llm.generate("Hello, world!")
+    >>>
+    >>> # OrcaRouter provider (routing gateway)
+    >>> orca = OrcaRouter(model="openai/gpt-4o", api_key="your-key")
+    >>> response = orca.generate("Hello, world!")
 
 Author: Semantica Contributors
 License: MIT
@@ -41,6 +46,6 @@ from .groq import Groq
 from .openai import OpenAI
 from .huggingface import HuggingFaceLLM
 from .litellm import LiteLLM
+from .orcarouter import OrcaRouter
 
-__all__ = ["Groq", "OpenAI", "HuggingFaceLLM", "LiteLLM"]
-
+__all__ = ["Groq", "OpenAI", "HuggingFaceLLM", "LiteLLM", "OrcaRouter"]

--- a/semantica/llms/orcarouter.py
+++ b/semantica/llms/orcarouter.py
@@ -1,0 +1,89 @@
+"""
+OrcaRouter LLM Provider
+
+Wrapper for the OrcaRouter routing gateway with a clean interface.
+
+OrcaRouter (https://www.orcarouter.ai) exposes a unified OpenAI-compatible
+endpoint that routes requests to frontier models across vendors, addressed with
+the same ``provider/model`` prefix convention used by LiteLLM.
+"""
+
+from typing import Any, Dict, Optional
+
+from ..semantic_extract.providers import OrcaRouterProvider
+from ..utils.exceptions import ProcessingError
+from ..utils.logging import get_logger
+
+logger = get_logger("llms.orcarouter")
+
+
+class OrcaRouter:
+    """
+    OrcaRouter LLM provider wrapper.
+
+    Provides clean interface to OrcaRouter API for text generation.
+
+    Example:
+        >>> from semantica.llms import OrcaRouter
+        >>> llm = OrcaRouter(model="openai/gpt-4o", api_key="your-key")
+        >>> response = llm.generate("What is AI?")
+    """
+
+    def __init__(
+        self, model: str = "openai/gpt-4o", api_key: Optional[str] = None, **kwargs
+    ):
+        """
+        Initialize OrcaRouter provider.
+
+        Args:
+            model: Model name, ``provider/model`` prefix (default: "openai/gpt-4o")
+            api_key: OrcaRouter API key (default: from ORCAROUTER_API_KEY env var)
+            **kwargs: Additional provider options
+        """
+        self.provider = OrcaRouterProvider(api_key=api_key, model=model, **kwargs)
+        self.model = model
+        self.api_key = api_key
+
+    def is_available(self) -> bool:
+        """Check if OrcaRouter provider is available."""
+        return self.provider.is_available()
+
+    def generate(self, prompt: str, **kwargs) -> str:
+        """
+        Generate text from prompt.
+
+        Args:
+            prompt: Input prompt text
+            **kwargs: Generation options (temperature, max_tokens, etc.)
+
+        Returns:
+            Generated text response
+
+        Raises:
+            ProcessingError: If provider is not available or generation fails
+        """
+        if not self.is_available():
+            raise ProcessingError(
+                "OrcaRouter not available. Set ORCAROUTER_API_KEY or pass api_key."
+            )
+        return self.provider.generate(prompt, **kwargs)
+
+    def generate_structured(self, prompt: str, **kwargs) -> Dict[str, Any]:
+        """
+        Generate structured JSON output.
+
+        Args:
+            prompt: Input prompt text
+            **kwargs: Generation options
+
+        Returns:
+            Parsed JSON response as dictionary
+
+        Raises:
+            ProcessingError: If provider is not available or parsing fails
+        """
+        if not self.is_available():
+            raise ProcessingError(
+                "OrcaRouter not available. Set ORCAROUTER_API_KEY or pass api_key."
+            )
+        return self.provider.generate_structured(prompt, **kwargs)

--- a/semantica/semantic_extract/config.py
+++ b/semantica/semantic_extract/config.py
@@ -6,7 +6,7 @@ supporting multiple configuration sources including environment variables, confi
 and programmatic configuration.
 
 Supported Configuration Sources:
-    - Environment variables: OPENAI_API_KEY, GEMINI_API_KEY, GROQ_API_KEY, NOVITA_API_KEY, etc.
+    - Environment variables: OPENAI_API_KEY, GEMINI_API_KEY, GROQ_API_KEY, NOVITA_API_KEY, ORCAROUTER_API_KEY, etc.
     - Config files: YAML, JSON, TOML formats
     - Programmatic: Python API for setting provider configurations
 
@@ -97,7 +97,15 @@ class Config:
     def _load_env_vars(self):
         """Load configuration from environment variables."""
         # Common environment variable patterns
-        providers = ["openai", "gemini", "groq", "anthropic", "ollama", "novita"]
+        providers = [
+            "openai",
+            "gemini",
+            "groq",
+            "anthropic",
+            "ollama",
+            "novita",
+            "orcarouter",
+        ]
         for provider in providers:
             env_key = f"{provider.upper()}_API_KEY"
             api_key = os.getenv(env_key)

--- a/semantica/semantic_extract/methods.py
+++ b/semantica/semantic_extract/methods.py
@@ -994,6 +994,7 @@ def extract_entities_llm(
             "gemini": 64000,
             "anthropic": 64000,
             "deepseek": 64000,
+            "orcarouter": 64000,
         }.get(provider.lower(), 32000)
     
     if len(text) > max_text_length:
@@ -1797,6 +1798,7 @@ def extract_relations_llm(
             "gemini": 64000,
             "anthropic": 64000,
             "deepseek": 64000,
+            "orcarouter": 64000,
         }.get(provider.lower(), 32000)
     
     if len(text) > max_text_length:
@@ -2448,6 +2450,7 @@ def extract_triplets_llm(
             "gemini": 64000,
             "anthropic": 64000,
             "deepseek": 64000,
+            "orcarouter": 64000,
         }.get(provider.lower(), 32000)
     
     if len(text) > max_text_length:

--- a/semantica/semantic_extract/providers.py
+++ b/semantica/semantic_extract/providers.py
@@ -11,6 +11,9 @@ Supported Providers:
     - "groq": Groq API (llama2, mixtral, etc.)
     - "anthropic": Anthropic Claude API (claude-3-sonnet, etc.)
     - "ollama": Ollama local provider (local open-source models)
+    - "deepseek": DeepSeek API (deepseek-chat, etc.)
+    - "novita": Novita AI API (OpenAI-compatible)
+    - "orcarouter": OrcaRouter routing gateway (OpenAI-compatible, frontier models)
     - "huggingface_llm": HuggingFace Transformers for LLM tasks
 
 Supported Model Types:
@@ -1126,6 +1129,77 @@ class NovitaProvider(BaseProvider):
         except Exception as e:
             raise ProcessingError(f"Failed to parse JSON from Novita response: {e}")
 
+
+class OrcaRouterProvider(BaseProvider):
+    """OrcaRouter provider implementation - OpenAI-compatible routing gateway.
+
+    OrcaRouter (https://www.orcarouter.ai) exposes a unified OpenAI-compatible
+    endpoint that routes requests to frontier models across vendors. Models are
+    addressed with the same ``provider/model`` prefix convention used by LiteLLM,
+    e.g. ``openai/gpt-4o``, ``anthropic/claude-sonnet-4.6`` or
+    ``deepseek/deepseek-v4-flash``.
+    """
+
+    def __init__(
+        self, api_key: Optional[str] = None, model: str = "openai/gpt-4o", **kwargs
+    ):
+        """Initialize OrcaRouter provider."""
+        super().__init__(**kwargs)
+        self.api_key = api_key or config.get_api_key("orcarouter")
+        self.model = model
+        self.base_url = "https://api.orcarouter.ai/v1"
+        self.client = None
+        self._init_client()
+
+    def _init_client(self):
+        try:
+            from openai import OpenAI
+
+            if self.api_key:
+                self.client = OpenAI(api_key=self.api_key, base_url=self.base_url)
+        except (ImportError, OSError):
+            self.client = None
+            self.logger.warning(
+                "openai library not installed. Install with: pip install semantica[llm-openai]"
+            )
+
+    def is_available(self) -> bool:
+        return self.client is not None
+
+    def generate(self, prompt: str, **kwargs) -> str:
+        if not self.client:
+            raise ProcessingError(
+                "OrcaRouter client not initialized. Set ORCAROUTER_API_KEY or pass api_key."
+            )
+
+        create_kwargs = {
+            "model": kwargs.get("model", self.model),
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        self._add_if_set(create_kwargs, kwargs, "temperature", "max_tokens")
+
+        response = self.client.chat.completions.create(**create_kwargs)
+        return response.choices[0].message.content
+
+    def generate_structured(self, prompt: str, **kwargs) -> Union[dict, list]:
+        """Generate structured output."""
+        if not self.client:
+            raise ProcessingError("OrcaRouter client not initialized.")
+
+        create_kwargs = {
+            "model": kwargs.get("model", self.model),
+            "messages": [{"role": "user", "content": prompt}],
+            "response_format": {"type": "json_object"},
+        }
+        self._add_if_set(create_kwargs, kwargs, "temperature", "max_tokens")
+
+        response = self.client.chat.completions.create(**create_kwargs)
+        try:
+            return self._parse_json(response.choices[0].message.content)
+        except Exception as e:
+            raise ProcessingError(f"Failed to parse JSON from OrcaRouter response: {e}")
+
+
 class HuggingFaceLLMProvider(BaseProvider):
     """HuggingFace transformers for LLM tasks."""
 
@@ -1508,7 +1582,8 @@ class ProviderPool:
             "ollama": OllamaProvider,
             "huggingface_llm": HuggingFaceLLMProvider,
             "deepseek": DeepSeekProvider,
-             "novita": NovitaProvider,
+            "novita": NovitaProvider,
+            "orcarouter": OrcaRouterProvider,
         }
 
         provider_class = builtin.get(name.lower())

--- a/tests/semantic_extract/test_orcarouter_provider.py
+++ b/tests/semantic_extract/test_orcarouter_provider.py
@@ -1,0 +1,234 @@
+"""Tests for OrcaRouterProvider — OpenAI-compatible routing gateway."""
+
+import sys
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+# The openai SDK is an optional extra (`pip install semantica[llm-openai]`), not a
+# dev dependency. Only the tests that spec a mock against the real OpenAI class
+# need it — the rest of this module must still run without it.
+try:
+    from openai import OpenAI
+except ImportError:  # pragma: no cover - depends on the installed extras
+    OpenAI = None
+
+requires_openai = unittest.skipIf(OpenAI is None, "openai SDK not installed")
+
+
+class TestOrcaRouterProviderInit(unittest.TestCase):
+    """Tests for OrcaRouterProvider.__init__ and _init_client."""
+
+    def setUp(self):
+        from semantica.semantic_extract.providers import OrcaRouterProvider
+
+        self.OrcaRouterProvider = OrcaRouterProvider
+
+    def test_base_url_set_on_init(self):
+        """self.base_url must be set before _init_client is called."""
+        with patch.object(self.OrcaRouterProvider, "_init_client", return_value=None):
+            provider = self.OrcaRouterProvider(api_key="fake-key")
+        self.assertTrue(
+            hasattr(provider, "base_url"),
+            "OrcaRouterProvider missing self.base_url before _init_client",
+        )
+        self.assertEqual(provider.base_url, "https://api.orcarouter.ai/v1")
+
+    def test_default_model(self):
+        """Default model must be an OpenAI-compatible frontier model id."""
+        with patch.object(self.OrcaRouterProvider, "_init_client", return_value=None):
+            provider = self.OrcaRouterProvider(api_key="fake-key")
+        self.assertEqual(provider.model, "openai/gpt-4o")
+
+    def test_base_url_points_to_v1_endpoint(self):
+        """base_url must include /v1 so the OpenAI SDK resolves endpoints correctly."""
+        with patch.object(self.OrcaRouterProvider, "_init_client", return_value=None):
+            provider = self.OrcaRouterProvider(api_key="fake-key")
+        self.assertIn("/v1", provider.base_url, "base_url must include /v1")
+
+    def test_init_client_uses_openai_client(self):
+        """_init_client must import openai.OpenAI against the OrcaRouter base_url."""
+        mock_openai_cls = MagicMock()
+        mock_openai_instance = MagicMock()
+        mock_openai_cls.return_value = mock_openai_instance
+
+        with patch.dict("sys.modules", {"openai": MagicMock(OpenAI=mock_openai_cls)}):
+            import importlib
+            import semantica.semantic_extract.providers as providers_mod
+
+            importlib.reload(providers_mod)
+            OrcaRouterProvider = providers_mod.OrcaRouterProvider
+
+            provider = OrcaRouterProvider(api_key="sk-orca-test")
+
+        mock_openai_cls.assert_called_once_with(
+            api_key="sk-orca-test",
+            base_url="https://api.orcarouter.ai/v1",
+        )
+        self.assertIs(provider.client, mock_openai_instance)
+
+    def test_init_client_no_api_key_leaves_client_none(self):
+        """Without an API key, client must remain None."""
+        with patch("semantica.semantic_extract.providers.config") as mock_cfg:
+            mock_cfg.get_api_key.return_value = None
+            with patch.object(
+                self.OrcaRouterProvider, "_init_client", return_value=None
+            ):
+                provider = self.OrcaRouterProvider(api_key=None)
+            provider.client = None  # simulate _init_client no-op
+        self.assertFalse(provider.is_available())
+
+    def test_init_client_handles_openai_import_error(self):
+        """If openai is not installed, _init_client must set client=None, not raise."""
+        with patch.object(self.OrcaRouterProvider, "_init_client", return_value=None):
+            provider = self.OrcaRouterProvider(api_key="sk-orca-test")
+        provider.client = None  # manually simulate ImportError path
+        with patch.dict("sys.modules", {"openai": None}):
+            try:
+                provider._init_client()
+            except Exception as e:
+                self.fail(f"_init_client raised unexpectedly: {e}")
+        self.assertIsNone(provider.client)
+
+    def test_is_available_true_when_client_set(self):
+        """is_available() returns True when self.client is an OpenAI instance."""
+        with patch.object(self.OrcaRouterProvider, "_init_client", return_value=None):
+            provider = self.OrcaRouterProvider(api_key="sk-orca-test")
+        provider.client = MagicMock()
+        self.assertTrue(provider.is_available())
+
+    def test_is_available_false_when_client_none(self):
+        """is_available() returns False when self.client is None."""
+        with patch.object(self.OrcaRouterProvider, "_init_client", return_value=None):
+            provider = self.OrcaRouterProvider(api_key="sk-orca-test")
+        provider.client = None
+        self.assertFalse(provider.is_available())
+
+
+class TestOrcaRouterProviderGenerate(unittest.TestCase):
+    """Tests for OrcaRouterProvider.generate / generate_structured."""
+
+    def _make_provider(self, api_key="sk-orca-test"):
+        from semantica.semantic_extract.providers import OrcaRouterProvider
+
+        with patch.object(OrcaRouterProvider, "_init_client", return_value=None):
+            provider = OrcaRouterProvider(api_key=api_key)
+        provider.client = MagicMock()
+        return provider
+
+    def test_generate_uses_chat_completions(self):
+        """generate() must call client.chat.completions.create."""
+        provider = self._make_provider()
+        mock_resp = MagicMock()
+        mock_resp.choices[0].message.content = "hello"
+        provider.client.chat.completions.create.return_value = mock_resp
+
+        result = provider.generate("test prompt")
+
+        provider.client.chat.completions.create.assert_called_once()
+        self.assertEqual(result, "hello")
+
+    def test_generate_passes_model(self):
+        """generate() must forward the requested model id."""
+        provider = self._make_provider()
+        mock_resp = MagicMock()
+        mock_resp.choices[0].message.content = "x"
+        provider.client.chat.completions.create.return_value = mock_resp
+
+        provider.generate("p", model="anthropic/claude-sonnet-4.6")
+        kwargs = provider.client.chat.completions.create.call_args[1]
+        self.assertEqual(kwargs["model"], "anthropic/claude-sonnet-4.6")
+
+    def test_generate_structured_returns_parsed_json(self):
+        """generate_structured() must parse the JSON returned by the model."""
+        provider = self._make_provider()
+        mock_resp = MagicMock()
+        mock_resp.choices[0].message.content = '{"key": "value"}'
+        provider.client.chat.completions.create.return_value = mock_resp
+
+        result = provider.generate_structured("test prompt")
+        self.assertEqual(result, {"key": "value"})
+
+    def test_generate_structured_uses_json_object(self):
+        """generate_structured() must request a json_object response_format."""
+        provider = self._make_provider()
+        mock_resp = MagicMock()
+        mock_resp.choices[0].message.content = '{"key": "value"}'
+        provider.client.chat.completions.create.return_value = mock_resp
+
+        provider.generate_structured("test prompt")
+        kwargs = provider.client.chat.completions.create.call_args[1]
+        self.assertEqual(kwargs["response_format"], {"type": "json_object"})
+
+    def test_generate_raises_without_client(self):
+        from semantica.semantic_extract.providers import (
+            OrcaRouterProvider,
+            ProcessingError,
+        )
+
+        with patch.object(OrcaRouterProvider, "_init_client", return_value=None):
+            provider = OrcaRouterProvider(api_key="sk-orca-test")
+        provider.client = None
+
+        with self.assertRaises(ProcessingError):
+            provider.generate("prompt")
+
+    def test_generate_structured_raises_without_client(self):
+        from semantica.semantic_extract.providers import (
+            OrcaRouterProvider,
+            ProcessingError,
+        )
+
+        with patch.object(OrcaRouterProvider, "_init_client", return_value=None):
+            provider = OrcaRouterProvider(api_key="sk-orca-test")
+        provider.client = None
+
+        with self.assertRaises(ProcessingError):
+            provider.generate_structured("prompt")
+
+
+class TestOrcaRouterRegistration(unittest.TestCase):
+    """Tests for OrcaRouter registration in the built-in provider map."""
+
+    def test_create_provider_returns_orcarouter(self):
+        from semantica.semantic_extract.providers import (
+            create_provider,
+            OrcaRouterProvider,
+        )
+
+        with patch.object(OrcaRouterProvider, "_init_client", return_value=None):
+            provider = create_provider(
+                "orcarouter", use_pool=False, api_key="sk-orca-test"
+            )
+        self.assertIsInstance(provider, OrcaRouterProvider)
+
+    def test_create_provider_case_insensitive(self):
+        from semantica.semantic_extract.providers import (
+            create_provider,
+            OrcaRouterProvider,
+        )
+
+        with patch.object(OrcaRouterProvider, "_init_client", return_value=None):
+            provider = create_provider(
+                "OrcaRouter", use_pool=False, api_key="sk-orca-test"
+            )
+        self.assertIsInstance(provider, OrcaRouterProvider)
+
+    def test_builtin_list_contains_orcarouter(self):
+        """create_provider("orcarouter") must resolve to OrcaRouterProvider."""
+        from semantica.semantic_extract.providers import (
+            _provider_pool,
+            OrcaRouterProvider,
+        )
+
+        with patch.object(OrcaRouterProvider, "_init_client", return_value=None):
+            provider = _provider_pool._create_provider(
+                "orcarouter", api_key="sk-orca-test"
+            )
+        self.assertIsInstance(provider, OrcaRouterProvider)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_orcarouter_integration.py
+++ b/tests/test_orcarouter_integration.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from semantica.semantic_extract.methods import (
+    extract_entities_llm,
+    extract_relations_llm,
+    extract_triplets_llm,
+)
+from semantica.semantic_extract.providers import create_provider
+from semantica.semantic_extract import Entity
+
+ORCAROUTER_API_KEY = os.environ.get("ORCAROUTER_API_KEY")
+ORCAROUTER_MODEL = "openai/gpt-4o"
+TEXT = (
+    "Apple Inc. was founded by Steve Jobs, Steve Wozniak, and Ronald Wayne in 1976. "
+    "It is headquartered in Cupertino, California. The company designs, manufactures, "
+    "and markets smartphones, personal computers, tablets, wearables, and accessories."
+)
+
+pytestmark = pytest.mark.skipif(
+    not ORCAROUTER_API_KEY,
+    reason="ORCAROUTER_API_KEY not set",
+)
+
+
+def test_orcarouter_provider_available():
+    provider = create_provider("orcarouter")
+    assert (
+        provider.is_available()
+    ), "OrcaRouter provider not available — check ORCAROUTER_API_KEY and openai install"
+
+
+def test_orcarouter_entity_extraction():
+    entities = extract_entities_llm(TEXT, provider="orcarouter", model=ORCAROUTER_MODEL)
+    assert isinstance(entities, list), "Expected a list of entities"
+    assert len(entities) > 0, "No entities extracted"
+
+
+def test_orcarouter_relation_extraction():
+    sample_entities = [
+        Entity(name="Apple Inc.", type="ORGANIZATION"),
+        Entity(name="Steve Jobs", type="PERSON"),
+    ]
+    relations = extract_relations_llm(
+        TEXT, entities=sample_entities, provider="orcarouter", model=ORCAROUTER_MODEL
+    )
+    assert isinstance(relations, list), "Expected a list of relations"
+
+
+def test_orcarouter_triplet_extraction():
+    triplets = extract_triplets_llm(TEXT, provider="orcarouter", model=ORCAROUTER_MODEL)
+    assert isinstance(triplets, list), "Expected a list of triplets"
+    assert len(triplets) > 0, "No triplets extracted"
+
+
+def test_orcarouter_chunked_extraction():
+    long_text = " ".join([TEXT] * 10)
+    entities = extract_entities_llm(
+        long_text,
+        provider="orcarouter",
+        model=ORCAROUTER_MODEL,
+        max_text_length=200,
+    )
+    assert isinstance(
+        entities, list
+    ), "Expected a list of entities from chunked extraction"
+    assert len(entities) > 0, "No entities extracted from chunked text"

--- a/tests/test_orcarouter_llm_wrapper.py
+++ b/tests/test_orcarouter_llm_wrapper.py
@@ -1,0 +1,78 @@
+"""Tests for the semantica.llms.OrcaRouter wrapper class."""
+
+import sys
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from semantica.llms import OrcaRouter
+
+
+class TestOrcaRouterWrapper(unittest.TestCase):
+    """Tests for the OrcaRouter clean-interface wrapper."""
+
+    def test_import_exported(self):
+        """OrcaRouter must be importable from semantica.llms."""
+        self.assertTrue(callable(OrcaRouter))
+
+    def test_init_wraps_provider(self):
+        """The wrapper must delegate to OrcaRouterProvider."""
+        from semantica.semantic_extract.providers import OrcaRouterProvider
+
+        with patch.object(OrcaRouterProvider, "_init_client", return_value=None):
+            llm = OrcaRouter(model="openai/gpt-4o", api_key="sk-orca-test")
+        # Compare by class name: provider modules can be re-imported during the
+        # test session (importlib.reload pattern used by the DeepSeek tests), so
+        # object identity across module reloads is not guaranteed.
+        self.assertEqual(llm.provider.__class__.__name__, "OrcaRouterProvider")
+        self.assertEqual(llm.provider.base_url, "https://api.orcarouter.ai/v1")
+        self.assertEqual(llm.model, "openai/gpt-4o")
+        self.assertEqual(llm.api_key, "sk-orca-test")
+
+    def test_is_available_delegates(self):
+        from semantica.semantic_extract.providers import OrcaRouterProvider
+
+        with patch.object(OrcaRouterProvider, "_init_client", return_value=None):
+            llm = OrcaRouter(api_key="sk-orca-test")
+        llm.provider.client = MagicMock()
+        self.assertTrue(llm.is_available())
+
+    def test_generate_delegates(self):
+        from semantica.semantic_extract.providers import OrcaRouterProvider
+
+        with patch.object(OrcaRouterProvider, "_init_client", return_value=None):
+            llm = OrcaRouter(api_key="sk-orca-test")
+        llm.provider.client = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.choices[0].message.content = "pong"
+        llm.provider.client.chat.completions.create.return_value = mock_resp
+        self.assertEqual(llm.generate("ping"), "pong")
+
+    def test_generate_raises_when_not_available(self):
+        from semantica.semantic_extract.providers import (
+            OrcaRouterProvider,
+            ProcessingError,
+        )
+
+        with patch.object(OrcaRouterProvider, "_init_client", return_value=None):
+            llm = OrcaRouter(api_key="sk-orca-test")
+        llm.provider.client = None
+        with self.assertRaises(ProcessingError):
+            llm.generate("ping")
+
+    def test_generate_structured_delegates(self):
+        from semantica.semantic_extract.providers import OrcaRouterProvider
+
+        with patch.object(OrcaRouterProvider, "_init_client", return_value=None):
+            llm = OrcaRouter(api_key="sk-orca-test")
+        llm.provider.client = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.choices[0].message.content = '{"ok": true}'
+        llm.provider.client.chat.completions.create.return_value = mock_resp
+        self.assertEqual(llm.generate_structured("ping"), {"ok": True})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a model provider. OrcaRouter is
an OpenAI-compatible model routing gateway that exposes 200+ models from OpenAI,
Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single
endpoint and API key. It also provides gateway-level security controls for AI
agents.

I'm an engineer on the OrcaRouter team.

## What this changes

- `semantica/semantic_extract/providers.py`: adds `OrcaRouterProvider` to the
  provider registry (base URL `https://api.orcarouter.ai/v1`, auth via
  `ORCAROUTER_API_KEY`, JSON-mode structured output via
  `response_format={"type": "json_object"}`)
- `semantica/semantic_extract/config.py`: includes `orcarouter` in env-var API
  key loading
- `semantica/semantic_extract/methods.py`: maps `orcarouter` to the 64k
  max-text-length tier
- `semantica/llms/orcarouter.py`: `OrcaRouter` clean-interface wrapper in
  `semantica.llms`, mirroring the existing Groq wrapper
- `semantica/llms/__init__.py`: exports `OrcaRouter`
- `pyproject.toml`: adds `llm-orcarouter` extra and includes it in `llm-all`
- `tests/semantic_extract/test_orcarouter_provider.py`: provider unit tests
- `tests/test_orcarouter_integration.py`: live integration tests (skipped
  without `ORCAROUTER_API_KEY`)
- `tests/test_orcarouter_llm_wrapper.py`: wrapper delegation tests
- `README.md`, `docs/guides/llm-integrations.md`, `docs/reference/llms.md`:
  docs entries alongside the existing providers

## Why a separate provider rather than the OpenAI-compatible escape hatch

This mirrors how the existing named providers (Novita, DeepSeek, Groq) are
wired in this repo, so the provider registry, model picker and docs stay
consistent for users. Models are addressed with the same `provider/model`
prefix convention used by LiteLLM, e.g. `openai/gpt-4o`,
`anthropic/claude-sonnet-4.6` or `deepseek/deepseek-v4-flash`.

## How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. Set `ORCAROUTER_API_KEY`.
3. Pick a model id such as `openai/gpt-4o`, `anthropic/claude-sonnet-4.6` or
   `deepseek/deepseek-v4-flash`. The full catalog is at
   https://www.orcarouter.ai/models.

```python
from semantica.semantic_extract.providers import create_provider

llm = create_provider("orcarouter", model="openai/gpt-4o")
print(llm.generate("Hello!"))
```

## Verification

- Unit tests: 64 passed (`test_orcarouter_provider.py`,
  `test_orcarouter_llm_wrapper.py`, `test_provider_limits.py`,
  `test_pr482_deepseek_openai.py`)
- Live API: `create_provider("orcarouter")` -> plain generation and JSON-mode
  structured generation both returned valid responses (HTTP 200) against the
  real OrcaRouter API
- Ran locally: `python -m pytest` on the new/related tests; black 24.1.1,
  isort 5.13.2, flake8 7.0.0 applied to the new files
