### PR TITLE
feat(agno): 集成层迁移至 Agno 2.9（v2 API）

### DIFF
--- a/docs/integrations/agno.md
+++ b/docs/integrations/agno.md
@@ -6,6 +6,7 @@ icon: "robot"
 
 > Five drop-in components that bring Semantica's KG, vector memory, and decision intelligence into any Agno agent or team.
 
+Requires **agno ≥ 2.9** (the v2 API — agno v1 is not supported).
 
 ## Installation
 
@@ -24,7 +25,7 @@ pip install "semantica[agno,graph-neo4j,vectorstore-pgvector]"
 
 ## Components at a Glance
 
-- **AgnoContextStore** — `AgentMemory(db=…)`: Replaces Agno's flat storage with hybrid vector + context graph memory. Adds decision tracking and precedent search to any agent.
+- **AgnoContextStore** — `Agent(db=…)`: Replaces Agno's flat storage with hybrid vector + context graph memory. Adds decision tracking and precedent search to any agent.
 - **AgnoKnowledgeGraph** — `Agent(knowledge=…)`: Documents flow through the full Semantica extraction pipeline into a queryable `ContextGraph` with multi-hop GraphRAG.
 - **AgnoDecisionKit** — `Agent(tools=[…])`: 6 decision intelligence tools: record decisions, find precedents, trace causal chains, analyze impact, check policies, summarize history.
 - **AgnoKGToolkit** — `Agent(tools=[…])`: 7 KG construction tools: extract entities, extract relations, add to graph, query graph, find related, infer facts, export subgraph.
@@ -35,11 +36,10 @@ pip install "semantica[agno,graph-neo4j,vectorstore-pgvector]"
 
 <Tabs>
   <Tab title="AgnoContextStore">
-    Replaces Agno's flat conversation storage with a hybrid **vector + context graph** memory store. Implements `agno.memory.db.base.MemoryDb`.
+    Replaces Agno's flat conversation storage with a hybrid **vector + context graph** memory store. Implements `agno.db.base.BaseDb` (the v2 storage interface). Only the **UserMemory** group is backed by Semantica storage; the other `BaseDb` groups (sessions, metrics, evals, traces, …) raise `NotImplementedError`, which Agno safely degrades to a logged warning.
 
     ```python
     from agno.agent import Agent
-    from agno.memory import AgentMemory
     from agno.models.openai import OpenAIChat
     from semantica.context import ContextGraph
     from semantica.vector_store import VectorStore
@@ -50,25 +50,25 @@ pip install "semantica[agno,graph-neo4j,vectorstore-pgvector]"
         knowledge_graph=ContextGraph(advanced_analytics=True),
         decision_tracking=True,
         graph_expansion=True,
-        session_id="user_session_42",
     )
 
     agent = Agent(
         model=OpenAIChat(id="gpt-4o"),
-        memory=AgentMemory(db=store),
+        db=store,
+        update_memory_on_run=True,
         description="A financially aware assistant with persistent decision intelligence.",
     )
     ```
 
     | Method | Description |
     | :-------- | :------------- |
-    | `upsert_memory()` | Store text in `AgentContext` (vector index + graph node) |
-    | `read_memories()` | Hybrid retrieval: vector similarity + graph hop expansion |
+    | `upsert_user_memory()` | Store text in `AgentContext` (vector index + graph node) |
+    | `get_user_memories()` | Filtered / sorted / paginated memory reads |
     | `record_decision()` | Record a structured decision with reasoning and outcome |
     | `find_precedents()` | Return semantically similar historical decisions |
   </Tab>
   <Tab title="AgnoKnowledgeGraph">
-    Gives Agno agents a queryable `ContextGraph` instead of a flat document store. Ingested documents pass through the full Semantica extraction pipeline.
+    Gives Agno agents a queryable `ContextGraph` instead of a flat document store. Subclasses `agno.knowledge.knowledge.Knowledge` (v2) — ingested documents pass through the full Semantica extraction pipeline.
 
     ```python
     from agno.agent import Agent
@@ -83,8 +83,8 @@ pip install "semantica[agno,graph-neo4j,vectorstore-pgvector]"
         relation_extractor=RelationExtractor(),
     )
 
-    kg.load("regulatory_docs/", recursive=True)
-    kg.load(texts=["Basel IV capital requirements apply from January 2026."])
+    kg.insert(path="regulatory_docs/", include=["*.txt"])
+    kg.insert(text_content="Basel IV capital requirements apply from January 2026.")
 
     agent = Agent(model=OpenAIChat(id="gpt-4o"), knowledge=kg, search_knowledge=True)
     ```
@@ -94,7 +94,8 @@ pip install "semantica[agno,graph-neo4j,vectorstore-pgvector]"
     **Search:** `vector retrieval → entity lookup → graph hop expansion → context injection`
 
     ```python
-    ctx = kg.get_graph_context("Basel IV")
+    docs = kg.search("Basel IV capital requirements", max_results=5)
+    ctx  = kg.get_graph_context("Basel IV")
     # Returns a text summary of the entity's immediate neighbourhood
     ```
   </Tab>
@@ -155,7 +156,7 @@ pip install "semantica[agno,graph-neo4j,vectorstore-pgvector]"
 
     ```python
     from agno.agent import Agent
-    from agno.team import Team
+    from agno.team.team import Team
     from agno.models.openai import OpenAIChat
     from semantica.context import ContextGraph
     from semantica.vector_store import VectorStore
@@ -170,20 +171,22 @@ pip install "semantica[agno,graph-neo4j,vectorstore-pgvector]"
     research_agent = Agent(
         name="Researcher",
         model=OpenAIChat(id="gpt-4o"),
-        memory=shared.bind_agent("researcher"),
+        db=shared.bind_agent("researcher"),
+        update_memory_on_run=True,
         tools=[AgnoKGToolkit(context=shared)],
     )
     decision_agent = Agent(
         name="Analyst",
         model=OpenAIChat(id="gpt-4o"),
-        memory=shared.bind_agent("analyst"),
+        db=shared.bind_agent("analyst"),
+        update_memory_on_run=True,
         tools=[AgnoDecisionKit(context=shared)],
     )
 
     team = Team(
         name="Research & Decision Team",
-        agents=[research_agent, decision_agent],
-        mode="coordinate",
+        members=[research_agent, decision_agent],
+        session_state={"shared_session_id": shared.session_id},
     )
     ```
 
@@ -207,12 +210,12 @@ pip install "semantica[agno,graph-neo4j,vectorstore-pgvector]"
 
 ```python
 from integrations.agno import (
-    AgnoContextStore,    # MemoryDb implementation
-    AgnoKnowledgeGraph,  # AgentKnowledge implementation
+    AgnoContextStore,    # agno.db.base.BaseDb implementation (UserMemory group)
+    AgnoKnowledgeGraph,  # agno.knowledge.knowledge.Knowledge implementation
     AgnoDecisionKit,     # Decision intelligence Toolkit
     AgnoKGToolkit,       # Knowledge graph Toolkit
     AgnoSharedContext,   # Team-level shared context
-    AGNO_AVAILABLE,      # bool: True if agno is installed
+    AGNO_AVAILABLE,      # bool: True if agno >= 2.9 is installed
 )
 ```
 

--- a/integrations/agno/__init__.py
+++ b/integrations/agno/__init__.py
@@ -3,12 +3,12 @@ Semantica × Agno Integration
 =============================
 
 First-class integration between the Semantica semantic intelligence stack and
-the `Agno <https://github.com/agno-agi/agno>`_ agentic framework.
+the `Agno <https://github.com/agno-agi/agno>`_ agentic framework (v2 API).
 
 Public surface
 --------------
-AgnoContextStore   — Graph-backed ``MemoryDb`` (drop-in for ``AgentMemory(db=…)``)
-AgnoKnowledgeGraph — Relational ``AgentKnowledge`` with multi-hop GraphRAG
+AgnoContextStore   — Graph-backed ``BaseDb`` (drop-in for ``Agent(db=…, update_memory_on_run=True)``)
+AgnoKnowledgeGraph — Relational ``Knowledge`` with multi-hop GraphRAG
 AgnoDecisionKit    — Agno ``Toolkit`` exposing decision-intelligence tools
 AgnoKGToolkit      — Agno ``Toolkit`` exposing KG construction/query tools
 AgnoSharedContext  — Team-level shared ``ContextGraph`` with per-agent scoping
@@ -27,12 +27,14 @@ Quick start
 
 Compatibility
 -------------
-Requires ``agno >= 1.0``.  All five classes degrade gracefully when ``agno``
-is not installed — they are still importable and carry the full Semantica API,
-but cannot be passed directly to Agno ``Agent`` / ``Team`` constructors.
+Requires ``agno >= 2.9`` (the v2 API — agno v1 is **not** supported).  All
+five classes degrade gracefully when ``agno`` is not installed — they are
+still importable and carry the full Semantica API, but cannot be passed
+directly to Agno ``Agent`` / ``Team`` constructors.
 """
 
-from .context_store import AGNO_AVAILABLE, AgnoContextStore
+from ._availability import AGNO_AVAILABLE, AGNO_IMPORT_ERROR
+from .context_store import AgnoContextStore
 from .decision_kit import AgnoDecisionKit
 from .kg_toolkit import AgnoKGToolkit
 from .knowledge_graph import AgnoKnowledgeGraph
@@ -45,6 +47,7 @@ __all__ = [
     "AgnoKGToolkit",
     "AgnoSharedContext",
     "AGNO_AVAILABLE",
+    "AGNO_IMPORT_ERROR",
 ]
 
-__version__ = "0.3.0"
+__version__ = "1.0.0"

--- a/integrations/agno/_availability.py
+++ b/integrations/agno/_availability.py
@@ -1,0 +1,29 @@
+"""
+Shared Agno availability probe.
+
+Every integration module needs to know whether the real ``agno`` package
+(version 2.x) is installed.  Probing once here (instead of once per module)
+guarantees the exported ``AGNO_AVAILABLE`` flag means the *whole* integration
+is ready — a caller gating on it will never see a store using the v2 ``BaseDb``
+API while a toolkit silently degrades (or vice versa).
+
+Only ``agno >= 2.9`` is supported.  When agno v1 is installed the v2 import
+paths below fail and the integration degrades gracefully (importable, but not
+attachable to Agno ``Agent`` / ``Team`` constructors).
+"""
+
+from typing import Optional
+
+AGNO_AVAILABLE = False
+AGNO_IMPORT_ERROR: Optional[str] = None
+
+try:
+    from agno.db.base import BaseDb  # noqa: F401
+    from agno.db.schemas.memory import UserMemory  # noqa: F401
+    from agno.knowledge.document.base import Document  # noqa: F401
+    from agno.knowledge.knowledge import Knowledge  # noqa: F401
+    from agno.tools.toolkit import Toolkit  # noqa: F401
+
+    AGNO_AVAILABLE = True
+except ImportError as exc:
+    AGNO_IMPORT_ERROR = str(exc)

--- a/integrations/agno/context_store.py
+++ b/integrations/agno/context_store.py
@@ -1,19 +1,27 @@
 """
-AgnoContextStore — Graph-backed agent memory storage for Agno.
+AgnoContextStore — Graph-backed agent memory storage for Agno 2.x.
 
-Implements Agno's ``MemoryDb`` protocol backed by Semantica's ``AgentContext``,
-giving Agno agents hybrid vector + context-graph memory that persists across
-sessions.
+Implements Agno's v2 ``agno.db.base.BaseDb`` interface backed by Semantica's
+``AgentContext``, giving Agno agents hybrid vector + context-graph user memory
+that persists across sessions.
 
 Key behaviours
 --------------
-- ``upsert_memory()``  → stores text in ``AgentContext`` (vector + graph) and
-                          extracts entities into the knowledge graph
-- ``read_memories()``  → hybrid retrieval: vector similarity + graph expansion
-- ``delete_memory()``  → removes from cache and calls ``AgentContext.forget()``
-- ``record_decision()`` → records a structured decision with reasoning & outcome
-- ``find_precedents()`` → returns semantically similar historical decisions
+- ``upsert_user_memory()``  → stores text in ``AgentContext`` (vector + graph)
+                              and extracts entities into the knowledge graph
+- ``get_user_memories()``   → filtered / sorted / paginated memory reads
+- ``delete_user_memory()``  → removes from cache and calls ``AgentContext.forget()``
+- ``record_decision()``     → records a structured decision with reasoning & outcome
+- ``find_precedents()``     → returns semantically similar historical decisions
 - ``get_context_for_prompt()`` → formats precedents for system-prompt injection
+
+Only the **UserMemory** group of ``BaseDb`` is backed by Semantica storage.
+The remaining groups (sessions, metrics, evals, knowledge, traces, culture,
+learnings, schema versions) raise ``NotImplementedError`` — the same
+degradation pattern used by the CrewAI integration.  This is safe at runtime:
+Agno wraps every ``db.*`` call in ``try/except`` (see ``agno.agent._storage``
+and ``agno.memory.manager``), so an unsupported group degrades to a logged
+warning instead of crashing the agent run.
 
 Install
 -------
@@ -28,74 +36,97 @@ Example
     ...     vector_store=VectorStore(backend="faiss"),
     ...     knowledge_graph=ContextGraph(advanced_analytics=True),
     ...     decision_tracking=True,
-    ...     session_id="user_session_42",
     ... )
     >>> from agno.agent import Agent
-    >>> from agno.memory import AgentMemory
-    >>> agent = Agent(memory=AgentMemory(db=store))
+    >>> agent = Agent(db=store, update_memory_on_run=True)
 """
 
 from __future__ import annotations
 
 import time
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from semantica.utils.logging import get_logger
+
+from ._availability import AGNO_AVAILABLE
 
 logger = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
-# Optional: Agno MemoryDb base class
+# Optional: Agno v2 BaseDb base class + UserMemory schema
 # ---------------------------------------------------------------------------
-AGNO_AVAILABLE = False
-AGNO_IMPORT_ERROR: Optional[str] = None
+_BaseDbBase: Any = object  # fallback when agno is absent
 
-_MemoryDbBase: Any = object  # fallback when agno is absent
+if AGNO_AVAILABLE:
+    from agno.db.base import BaseDb as _AgnoBaseDb  # type: ignore
+    from agno.db.schemas.memory import UserMemory as _AgnoUserMemory  # type: ignore
 
-try:
-    from agno.memory.db.base import MemoryDb as _AgnoMemoryDb  # type: ignore
-    from agno.memory.db.row import MemoryRow as _AgnoMemoryRow  # type: ignore
-
-    _MemoryDbBase = _AgnoMemoryDb
-    AGNO_AVAILABLE = True
-except ImportError as exc:
-    AGNO_IMPORT_ERROR = str(exc)
+    _BaseDbBase = _AgnoBaseDb
 
 
 # ---------------------------------------------------------------------------
-# Lightweight memory row when agno is not installed
+# Lightweight UserMemory stand-in when agno is not installed
 # ---------------------------------------------------------------------------
-class _MemoryRow:
-    """Minimal stand-in for ``agno.memory.db.row.MemoryRow``."""
-
-    __slots__ = ("id", "memory", "user_id", "topics", "input", "last_updated")
+class _UserMemory:
+    """Minimal stand-in for ``agno.db.schemas.memory.UserMemory``."""
 
     def __init__(
         self,
         memory: str,
-        id: Optional[str] = None,
-        user_id: Optional[str] = None,
+        memory_id: Optional[str] = None,
         topics: Optional[List[str]] = None,
+        user_id: Optional[str] = None,
         input: Optional[str] = None,
+        created_at: Optional[int] = None,
+        updated_at: Optional[int] = None,
+        feedback: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        team_id: Optional[str] = None,
     ) -> None:
-        self.id = id or str(uuid.uuid4())
         self.memory = memory
+        self.memory_id = memory_id
+        self.topics = topics
         self.user_id = user_id
-        self.topics = topics or []
         self.input = input
-        self.last_updated = time.time()
+        self.created_at = created_at
+        self.updated_at = updated_at
+        self.feedback = feedback
+        self.agent_id = agent_id
+        self.team_id = team_id
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            k: v
+            for k, v in {
+                "memory": self.memory,
+                "memory_id": self.memory_id,
+                "topics": self.topics,
+                "user_id": self.user_id,
+                "input": self.input,
+                "created_at": self.created_at,
+                "updated_at": self.updated_at,
+                "feedback": self.feedback,
+                "agent_id": self.agent_id,
+                "team_id": self.team_id,
+            }.items()
+            if v is not None
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "_UserMemory":
+        return cls(**data)
 
 
-MemoryRow = _AgnoMemoryRow if AGNO_AVAILABLE else _MemoryRow  # type: ignore
+UserMemory = _AgnoUserMemory if AGNO_AVAILABLE else _UserMemory  # type: ignore
 
 
 # ---------------------------------------------------------------------------
 # AgnoContextStore
 # ---------------------------------------------------------------------------
-class AgnoContextStore(_MemoryDbBase):  # type: ignore[misc]
+class AgnoContextStore(_BaseDbBase):  # type: ignore[misc]
     """
-    Graph-backed agent memory store that implements Agno's ``MemoryDb`` protocol.
+    Graph-backed agent memory store implementing Agno's v2 ``BaseDb``.
 
     Parameters
     ----------
@@ -106,10 +137,11 @@ class AgnoContextStore(_MemoryDbBase):  # type: ignore[misc]
         A ``semantica.context.ContextGraph`` instance (or ``None`` for a fresh
         in-memory graph).
     decision_tracking:
-        Automatically record every ``upsert_memory`` call as a lightweight
+        Automatically record every ``upsert_user_memory`` call as a lightweight
         decision entry.
     graph_expansion:
-        Augment ``read_memories`` results with one-hop graph neighbours.
+        Reserved flag — hybrid retrieval in ``retrieve()`` already combines
+        vector similarity with graph context.
     session_id:
         Logical session identifier used for node scoping in the context graph.
     agent_context_kwargs:
@@ -132,7 +164,7 @@ class AgnoContextStore(_MemoryDbBase):  # type: ignore[misc]
         self.decision_tracking = decision_tracking
         self.graph_expansion = graph_expansion
         self.session_id = session_id or str(uuid.uuid4())
-        self._memories: Dict[str, Any] = {}  # id → MemoryRow (in-process cache)
+        self._memories: Dict[str, Any] = {}  # memory_id → UserMemory
 
         # ------------------------------------------------------------------
         # Build AgentContext from provided components
@@ -159,47 +191,157 @@ class AgnoContextStore(_MemoryDbBase):  # type: ignore[misc]
         )
 
     # ------------------------------------------------------------------
-    # MemoryDb protocol
+    # BaseDb — UserMemory group (fully implemented)
     # ------------------------------------------------------------------
 
-    def create(self) -> None:
-        """Initialise storage (no-op for in-memory graph)."""
-        logger.debug("AgnoContextStore.create() called — in-memory graph ready")
-
-    def table_exists(self) -> bool:
+    def table_exists(self, table_name: str) -> bool:
+        """The in-memory graph store is always ready."""
         return True
 
-    def memory_exists(self, memory: Any) -> bool:
-        mem_id = getattr(memory, "id", None)
-        return mem_id is not None and mem_id in self._memories
+    def clear_memories(self) -> None:
+        """Delete all user memories."""
+        self._memories.clear()
+        try:
+            self._context.forget()
+        except Exception as exc:
+            logger.debug("clear_memories forget() failed: %s", exc)
 
-    def read_memories(
+    def delete_user_memory(self, memory_id: str, user_id: Optional[str] = None) -> None:
+        """Delete a single user memory, optionally verifying ownership."""
+        existing = self._memories.get(memory_id)
+        if existing is None:
+            return
+        if user_id is not None and getattr(existing, "user_id", None) != user_id:
+            return
+        self._memories.pop(memory_id, None)
+        try:
+            self._context.forget(memory_id=memory_id)
+        except Exception as exc:
+            logger.debug("forget(%s) failed: %s", memory_id, exc)
+        logger.debug("delete_user_memory id=%s", memory_id)
+
+    def delete_user_memories(
+        self, memory_ids: List[str], user_id: Optional[str] = None
+    ) -> None:
+        """Delete multiple user memories."""
+        for memory_id in memory_ids:
+            self.delete_user_memory(memory_id, user_id=user_id)
+
+    def get_all_memory_topics(self, user_id: Optional[str] = None) -> List[str]:
+        """Return the union of topics across all (optionally filtered) memories."""
+        topics = set()
+        for memory in self._memories.values():
+            if user_id is not None and getattr(memory, "user_id", None) != user_id:
+                continue
+            memory_topics = getattr(memory, "topics", None) or []
+            topics.update(memory_topics)
+        return sorted(topics)
+
+    def get_user_memory(
+        self,
+        memory_id: str,
+        deserialize: Optional[bool] = True,
+        user_id: Optional[str] = None,
+    ) -> Optional[Union[Any, Dict[str, Any]]]:
+        """Return a single memory (or its dict form), honouring ``user_id``."""
+        memory = self._memories.get(memory_id)
+        if memory is None:
+            return None
+        if user_id is not None and getattr(memory, "user_id", None) != user_id:
+            return None
+        if not deserialize:
+            return memory.to_dict() if hasattr(memory, "to_dict") else dict(memory.__dict__)
+        return memory
+
+    def get_user_memories(
         self,
         user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        team_id: Optional[str] = None,
+        topics: Optional[List[str]] = None,
+        search_content: Optional[str] = None,
         limit: Optional[int] = None,
-        sort: Optional[str] = None,
-    ) -> List[Any]:
+        page: Optional[int] = None,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
+        deserialize: Optional[bool] = True,
+    ) -> Union[List[Any], Tuple[List[Dict[str, Any]], int]]:
         """
-        Return stored memories, optionally filtered by ``user_id``.
+        Return stored memories with filtering, sorting and pagination.
 
-        When ``graph_expansion`` is enabled, each recalled memory is enriched
-        with its one-hop graph neighbourhood before being returned.
+        Matches the semantics of Agno's own ``InMemoryDb``: when
+        ``deserialize`` is false a ``(list_of_dicts, total_count)`` tuple is
+        returned, otherwise a plain list of ``UserMemory`` objects.
         """
-        rows = list(self._memories.values())
+        filtered = []
+        for memory in self._memories.values():
+            if user_id is not None and getattr(memory, "user_id", None) != user_id:
+                continue
+            if agent_id is not None and getattr(memory, "agent_id", None) != agent_id:
+                continue
+            if team_id is not None and getattr(memory, "team_id", None) != team_id:
+                continue
+            if topics is not None:
+                memory_topics = getattr(memory, "topics", None) or []
+                if not any(t in memory_topics for t in topics):
+                    continue
+            if search_content is not None:
+                if search_content.lower() not in str(getattr(memory, "memory", "")).lower():
+                    continue
+            filtered.append(memory)
 
-        if user_id:
-            rows = [r for r in rows if getattr(r, "user_id", None) == user_id]
+        total_count = len(filtered)
 
         # Sort: newest first by default
-        reverse = sort != "asc"
-        rows.sort(key=lambda r: getattr(r, "last_updated", 0), reverse=reverse)
+        sort_key = sort_by or "updated_at"
+        reverse = (sort_order or "desc").lower() != "asc"
+        filtered.sort(key=lambda m: getattr(m, sort_key, None) or 0, reverse=reverse)
+
+        # Paginate
+        if limit is not None:
+            start = (page - 1) * limit if page is not None else 0
+            filtered = filtered[start : start + limit]
+
+        if not deserialize:
+            return (
+                [m.to_dict() if hasattr(m, "to_dict") else dict(m.__dict__) for m in filtered],
+                total_count,
+            )
+        return filtered
+
+    def get_user_memory_stats(
+        self,
+        limit: Optional[int] = None,
+        page: Optional[int] = None,
+        user_id: Optional[str] = None,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """Return per-user memory statistics and the total user count."""
+        stats: Dict[str, Dict[str, Any]] = {}
+        for memory in self._memories.values():
+            uid = getattr(memory, "user_id", None)
+            if user_id is not None and uid != user_id:
+                continue
+            entry = stats.setdefault(
+                uid or "",
+                {"user_id": uid, "total_memories": 0, "topics": set()},
+            )
+            entry["total_memories"] += 1
+            entry["topics"].update(getattr(memory, "topics", None) or [])
+
+        rows = [
+            {**entry, "topics": sorted(entry["topics"])}
+            for entry in stats.values()
+        ]
+        total_count = len(rows)
 
         if limit is not None:
-            rows = rows[:limit]
+            start = (page - 1) * limit if page is not None else 0
+            rows = rows[start : start + limit]
+        return rows, total_count
 
-        return rows
-
-    def upsert_memory(self, memory: Any) -> Optional[Any]:
+    def upsert_user_memory(
+        self, memory: Any, deserialize: Optional[bool] = True
+    ) -> Optional[Union[Any, Dict[str, Any]]]:
         """
         Persist ``memory`` into both the vector store and the context graph.
 
@@ -207,9 +349,14 @@ class AgnoContextStore(_MemoryDbBase):  # type: ignore[misc]
         with nodes for the stored content.  If ``decision_tracking`` is enabled
         a lightweight decision entry is also recorded.
         """
-        mem_id = getattr(memory, "id", None) or str(uuid.uuid4())
+        mem_id = getattr(memory, "memory_id", None) or str(uuid.uuid4())
         mem_text = getattr(memory, "memory", str(memory))
         user_id = getattr(memory, "user_id", None)
+
+        now = int(time.time())
+        if getattr(memory, "created_at", None) is None:
+            memory.created_at = now
+        memory.updated_at = now
 
         # Persist in AgentContext (vector + graph)
         try:
@@ -223,6 +370,7 @@ class AgnoContextStore(_MemoryDbBase):  # type: ignore[misc]
         # Extract entities and index them into the knowledge graph
         try:
             from semantica.semantic_extract import NERExtractor
+
             ner = NERExtractor()
             entities = ner.extract_entities(mem_text) or []
             kg = getattr(self._context, "knowledge_graph", None)
@@ -243,7 +391,7 @@ class AgnoContextStore(_MemoryDbBase):  # type: ignore[misc]
                 self._context.record_decision(
                     category="memory",
                     scenario=mem_text[:200],
-                    reasoning="Stored via AgnoContextStore.upsert_memory()",
+                    reasoning="Stored via AgnoContextStore.upsert_user_memory()",
                     outcome="stored",
                     confidence=1.0,
                 )
@@ -251,35 +399,171 @@ class AgnoContextStore(_MemoryDbBase):  # type: ignore[misc]
                 logger.debug("Decision tracking skipped: %s", exc)
 
         # Update in-process cache
-        if hasattr(memory, "id"):
-            memory.id = mem_id
+        if hasattr(memory, "memory_id"):
+            memory.memory_id = mem_id
         self._memories[mem_id] = memory
-        logger.debug("upsert_memory id=%s", mem_id)
+        logger.debug("upsert_user_memory id=%s", mem_id)
+
+        if not deserialize:
+            return memory.to_dict() if hasattr(memory, "to_dict") else dict(memory.__dict__)
         return memory
 
-    def delete_memory(self, id: str) -> None:
-        self._memories.pop(id, None)
-        try:
-            self._context.forget(memory_id=id)
-        except Exception as exc:
-            logger.debug("forget(%s) failed: %s", id, exc)
-        logger.debug("delete_memory id=%s", id)
+    def upsert_memories(
+        self,
+        memories: List[Any],
+        deserialize: Optional[bool] = True,
+        preserve_updated_at: bool = False,
+    ) -> List[Union[Any, Dict[str, Any]]]:
+        """Bulk upsert — delegates to ``upsert_user_memory`` per memory."""
+        results: List[Union[Any, Dict[str, Any]]] = []
+        for memory in memories:
+            if memory is None:
+                continue
+            if preserve_updated_at:
+                # Keep the caller-provided timestamps untouched.
+                created_at = getattr(memory, "created_at", None)
+                updated_at = getattr(memory, "updated_at", None)
+                result = self.upsert_user_memory(memory, deserialize=deserialize)
+                memory.created_at = created_at
+                memory.updated_at = updated_at
+            else:
+                result = self.upsert_user_memory(memory, deserialize=deserialize)
+            if result is not None:
+                results.append(result)
+        return results
 
-    def drop_table(self) -> None:
-        self._memories.clear()
-        try:
-            self._context.forget()
-        except Exception as exc:
-            logger.debug("drop_table forget() failed: %s", exc)
-        logger.debug("AgnoContextStore: all memories dropped")
+    # ------------------------------------------------------------------
+    # BaseDb — remaining groups (not backed by Semantica storage)
+    # ------------------------------------------------------------------
+    # Agno wraps every db call in try/except (agno.agent._storage,
+    # agno.memory.manager), so NotImplementedError here degrades to a logged
+    # warning instead of crashing the agent run.  Only the UserMemory group
+    # above is wired to Semantica's hybrid store.
 
-    def clear(self) -> bool:
-        self._memories.clear()
-        try:
-            self._context.forget()
-        except Exception as exc:
-            logger.debug("clear forget() failed: %s", exc)
-        return True
+    def _unsupported(self, method: str) -> None:
+        raise NotImplementedError(
+            f"AgnoContextStore does not implement BaseDb.{method} — "
+            "only the UserMemory group is backed by Semantica storage."
+        )
+
+    # --- Sessions ---
+    def get_session(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("get_session")
+
+    def get_sessions(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("get_sessions")
+
+    def upsert_session(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("upsert_session")
+
+    def upsert_sessions(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("upsert_sessions")
+
+    def delete_session(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("delete_session")
+
+    def delete_sessions(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("delete_sessions")
+
+    def rename_session(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("rename_session")
+
+    # --- Metrics ---
+    def get_metrics(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("get_metrics")
+
+    def calculate_metrics(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("calculate_metrics")
+
+    # --- Evals ---
+    def create_eval_run(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("create_eval_run")
+
+    def get_eval_run(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("get_eval_run")
+
+    def get_eval_runs(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("get_eval_runs")
+
+    def delete_eval_runs(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("delete_eval_runs")
+
+    def rename_eval_run(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("rename_eval_run")
+
+    # --- Knowledge contents ---
+    def get_knowledge_content(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("get_knowledge_content")
+
+    def get_knowledge_contents(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("get_knowledge_contents")
+
+    def upsert_knowledge_content(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("upsert_knowledge_content")
+
+    def delete_knowledge_content(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("delete_knowledge_content")
+
+    # --- Cultural knowledge ---
+    def get_cultural_knowledge(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("get_cultural_knowledge")
+
+    def get_all_cultural_knowledge(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("get_all_cultural_knowledge")
+
+    def upsert_cultural_knowledge(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("upsert_cultural_knowledge")
+
+    def delete_cultural_knowledge(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("delete_cultural_knowledge")
+
+    def clear_cultural_knowledge(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("clear_cultural_knowledge")
+
+    # --- Learnings ---
+    def get_learning(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("get_learning")
+
+    def get_learnings(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("get_learnings")
+
+    def upsert_learning(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("upsert_learning")
+
+    def delete_learning(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("delete_learning")
+
+    # --- Traces & spans ---
+    def upsert_trace(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("upsert_trace")
+
+    def get_trace(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("get_trace")
+
+    def get_traces(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("get_traces")
+
+    def get_trace_stats(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("get_trace_stats")
+
+    def create_span(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("create_span")
+
+    def create_spans(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("create_spans")
+
+    def get_span(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("get_span")
+
+    def get_spans(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("get_spans")
+
+    # --- Schema versions ---
+    def get_latest_schema_version(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("get_latest_schema_version")
+
+    def upsert_schema_version(self, *args: Any, **kwargs: Any) -> None:
+        self._unsupported("upsert_schema_version")
 
     # ------------------------------------------------------------------
     # Extended Semantica API (usable from application code directly)

--- a/integrations/agno/decision_kit.py
+++ b/integrations/agno/decision_kit.py
@@ -38,23 +38,19 @@ from typing import Any, Dict, List, Optional
 
 from semantica.utils.logging import get_logger
 
+from ._availability import AGNO_AVAILABLE, AGNO_IMPORT_ERROR  # noqa: F401
+
 logger = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # Optional: Agno Toolkit base class
 # ---------------------------------------------------------------------------
-AGNO_AVAILABLE = False
-AGNO_IMPORT_ERROR: Optional[str] = None
-
 _ToolkitBase: Any = object
 
-try:
+if AGNO_AVAILABLE:
     from agno.tools.toolkit import Toolkit as _AgnoToolkit  # type: ignore
 
     _ToolkitBase = _AgnoToolkit
-    AGNO_AVAILABLE = True
-except ImportError as exc:
-    AGNO_IMPORT_ERROR = str(exc)
 
 
 # ---------------------------------------------------------------------------

--- a/integrations/agno/kg_toolkit.py
+++ b/integrations/agno/kg_toolkit.py
@@ -33,23 +33,19 @@ from typing import Any, Dict, List, Optional
 
 from semantica.utils.logging import get_logger
 
+from ._availability import AGNO_AVAILABLE, AGNO_IMPORT_ERROR  # noqa: F401
+
 logger = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # Optional: Agno Toolkit base class
 # ---------------------------------------------------------------------------
-AGNO_AVAILABLE = False
-AGNO_IMPORT_ERROR: Optional[str] = None
-
 _ToolkitBase: Any = object
 
-try:
+if AGNO_AVAILABLE:
     from agno.tools.toolkit import Toolkit as _AgnoToolkit  # type: ignore
 
     _ToolkitBase = _AgnoToolkit
-    AGNO_AVAILABLE = True
-except ImportError as exc:
-    AGNO_IMPORT_ERROR = str(exc)
 
 
 # ---------------------------------------------------------------------------

--- a/integrations/agno/knowledge_graph.py
+++ b/integrations/agno/knowledge_graph.py
@@ -1,8 +1,9 @@
 """
 AgnoKnowledgeGraph — Relational agent knowledge backed by Semantica's KG pipeline.
 
-Implements Agno's ``AgentKnowledge`` protocol so that Agno agents can query a
-structured ``ContextGraph`` instead of a flat vector document store.
+Subclasses Agno's v2 ``agno.knowledge.knowledge.Knowledge`` so that Agno
+agents can query a structured ``ContextGraph`` instead of a flat vector
+document store.
 
 Ingested documents pass through the full Semantica extraction pipeline:
 
@@ -25,43 +26,38 @@ Example
     ...     ner_extractor=NERExtractor(),
     ...     relation_extractor=RelationExtractor(),
     ... )
-    >>> kg.load("regulatory_docs/", recursive=True)
+    >>> kg.insert(path="regulatory_docs/", include=["*.txt"])
     >>> from agno.agent import Agent
     >>> agent = Agent(knowledge=kg, search_knowledge=True)
 """
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from semantica.utils.logging import get_logger
+
+from ._availability import AGNO_AVAILABLE
 
 logger = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
-# Optional: Agno AgentKnowledge base class
+# Optional: Agno v2 Knowledge base class + Document schema
 # ---------------------------------------------------------------------------
-AGNO_AVAILABLE = False
-AGNO_IMPORT_ERROR: Optional[str] = None
-
 _KnowledgeBase: Any = object
 
-try:
-    from agno.knowledge.base import AgentKnowledge as _AgnoAgentKnowledge  # type: ignore
+if AGNO_AVAILABLE:
+    from agno.knowledge.knowledge import Knowledge as _AgnoKnowledge  # type: ignore
 
-    _KnowledgeBase = _AgnoAgentKnowledge
-    AGNO_AVAILABLE = True
-except ImportError as exc:
-    AGNO_IMPORT_ERROR = str(exc)
+    _KnowledgeBase = _AgnoKnowledge
 
 
 # ---------------------------------------------------------------------------
 # Lightweight document stand-in (used when agno is absent)
 # ---------------------------------------------------------------------------
 class _Document:
-    """Minimal stand-in for ``agno.document.Document``."""
+    """Minimal stand-in for ``agno.knowledge.document.base.Document``."""
 
     __slots__ = ("id", "content", "meta_data", "name")
 
@@ -78,9 +74,9 @@ class _Document:
         self.meta_data = meta_data or {}
 
 
-try:
-    from agno.document.base import Document as AgnoDocument  # type: ignore
-except ImportError:
+if AGNO_AVAILABLE:
+    from agno.knowledge.document.base import Document as AgnoDocument  # type: ignore
+else:
     AgnoDocument = _Document  # type: ignore
 
 
@@ -112,7 +108,8 @@ class AgnoKnowledgeGraph(_KnowledgeBase):  # type: ignore[misc]
     graph_store_uri:
         Connection URI for the chosen graph store backend.
     num_documents:
-        Default number of documents returned by ``search()``.
+        Default number of documents returned by ``search()`` — mapped to
+        ``max_results`` on the Agno v2 ``Knowledge`` base class.
     chunk_size:
         Maximum characters per text chunk during ingestion.
     """
@@ -127,11 +124,20 @@ class AgnoKnowledgeGraph(_KnowledgeBase):  # type: ignore[misc]
         graph_store_uri: Optional[str] = None,
         num_documents: int = 5,
         chunk_size: int = 1000,
+        name: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         if AGNO_AVAILABLE:
-            super().__init__(**kwargs)  # type: ignore[call-arg]
+            super().__init__(  # type: ignore[call-arg]
+                name=name or "semantica_knowledge_graph",
+                max_results=num_documents,
+                **kwargs,
+            )
+        else:
+            self.name = name or "semantica_knowledge_graph"
+            self.max_results = num_documents
 
+        # Backwards-compatible alias for the Semantica-side API.
         self.num_documents = num_documents
         self.chunk_size = chunk_size
         self._graph_store_backend = graph_store_backend
@@ -167,14 +173,15 @@ class AgnoKnowledgeGraph(_KnowledgeBase):  # type: ignore[misc]
         )
 
     # ------------------------------------------------------------------
-    # AgentKnowledge protocol
+    # Knowledge v2 protocol — search
     # ------------------------------------------------------------------
 
     def search(
         self,
         query: str,
-        num_documents: Optional[int] = None,
-        filters: Optional[Dict[str, Any]] = None,
+        max_results: Optional[int] = None,
+        filters: Optional[Any] = None,
+        search_type: Optional[str] = None,
     ) -> List[Any]:
         """
         Multi-hop GraphRAG search.
@@ -186,7 +193,7 @@ class AgnoKnowledgeGraph(_KnowledgeBase):  # type: ignore[misc]
         Falls back to keyword scoring over the in-process ``_docs`` cache
         when vector retrieval is unavailable.
         """
-        k = num_documents or self.num_documents
+        k = max_results or self.num_documents
         results: List[Any] = []
 
         # Primary: vector similarity retrieval
@@ -237,6 +244,66 @@ class AgnoKnowledgeGraph(_KnowledgeBase):  # type: ignore[misc]
         logger.debug("search('%s') → %d documents (keyword)", query, len(results))
         return results
 
+    async def asearch(
+        self,
+        query: str,
+        max_results: Optional[int] = None,
+        filters: Optional[Any] = None,
+        search_type: Optional[str] = None,
+    ) -> List[Any]:
+        """Async variant — delegates to the synchronous GraphRAG search."""
+        return self.search(
+            query=query,
+            max_results=max_results,
+            filters=filters,
+            search_type=search_type,
+        )
+
+    # ------------------------------------------------------------------
+    # Knowledge v2 protocol — insert
+    # ------------------------------------------------------------------
+
+    def insert(
+        self,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        path: Optional[str] = None,
+        url: Optional[str] = None,
+        text_content: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        topics: Optional[List[str]] = None,
+        remote_content: Optional[Any] = None,
+        reader: Optional[Any] = None,
+        include: Optional[List[str]] = None,
+        exclude: Optional[List[str]] = None,
+        upsert: bool = True,
+        skip_if_exists: bool = False,
+        auth: Optional[Any] = None,
+    ) -> None:
+        """
+        Ingest content into the knowledge graph via the Semantica pipeline.
+
+        Supports ``path`` (file, directory, or glob), ``url`` (http/https
+        only), and ``text_content``.  ``remote_content``, ``reader`` and
+        ``auth`` are accepted for signature compatibility with Agno v2 but
+        are not used — ingestion always runs through Semantica's
+        parse → NER → relation extract → graph build pipeline.
+        """
+        if remote_content is not None or reader is not None or auth is not None:
+            logger.warning(
+                "AgnoKnowledgeGraph.insert: remote_content/reader/auth are not "
+                "supported by the Semantica pipeline and will be ignored."
+            )
+
+        if text_content:
+            self._ingest_text(text_content, source=name or "<inline>")
+
+        if path is not None:
+            self._ingest_path(Path(path), include=include, exclude=exclude)
+
+        if url is not None:
+            self.load_urls([url])
+
     def load(
         self,
         path: Union[str, Path, None] = None,
@@ -246,7 +313,8 @@ class AgnoKnowledgeGraph(_KnowledgeBase):  # type: ignore[misc]
         recreate: bool = False,
     ) -> None:
         """
-        Ingest documents into the knowledge graph.
+        Ingest documents into the knowledge graph (Semantica-side convenience
+        wrapper around ``insert()``).
 
         Parameters
         ----------
@@ -269,7 +337,12 @@ class AgnoKnowledgeGraph(_KnowledgeBase):  # type: ignore[misc]
                 self._ingest_text(text, source="<inline>")
 
         if path is not None:
-            self._ingest_path(Path(path), recursive=recursive)
+            p = Path(path)
+            if p.is_dir():
+                pattern = "**/*" if recursive else "*"
+                self._ingest_path(p, include=[pattern])
+            else:
+                self._ingest_path(p)
 
         if urls:
             self.load_urls(urls)
@@ -299,7 +372,6 @@ class AgnoKnowledgeGraph(_KnowledgeBase):  # type: ignore[misc]
             except Exception as exc:
                 logger.warning("Failed to fetch %s: %s", url, exc)
 
-    # AgentKnowledge also expects `load_documents`
     def load_documents(
         self,
         documents: List[Any],
@@ -432,15 +504,24 @@ class AgnoKnowledgeGraph(_KnowledgeBase):  # type: ignore[misc]
             len(chunks),
         )
 
-    def _ingest_path(self, path: Path, recursive: bool = False) -> None:
-        """Walk a file or directory and ingest all text files."""
+    def _ingest_path(
+        self,
+        path: Path,
+        include: Optional[List[str]] = None,
+        exclude: Optional[List[str]] = None,
+    ) -> None:
+        """Walk a file or directory and ingest all matching files."""
         if path.is_file():
             self._ingest_file(path)
         elif path.is_dir():
-            pattern = "**/*" if recursive else "*"
-            for child in path.glob(pattern):
-                if child.is_file():
-                    self._ingest_file(child)
+            patterns = include or ["*"]
+            excluded: set = set()
+            for pattern in exclude or []:
+                excluded.update(path.glob(pattern))
+            for pattern in patterns:
+                for child in sorted(path.glob(pattern)):
+                    if child.is_file() and child not in excluded:
+                        self._ingest_file(child)
         else:
             logger.warning("Path not found: %s", path)
 

--- a/integrations/agno/shared_context.py
+++ b/integrations/agno/shared_context.py
@@ -22,24 +22,31 @@ Example
     ...     decision_tracking=True,
     ... )
     >>> from agno.agent import Agent
-    >>> from agno.team import Team
+    >>> from agno.team.team import Team
     >>> researcher = Agent(
     ...     name="Researcher",
-    ...     memory=shared.bind_agent("researcher"),
+    ...     db=shared.bind_agent("researcher"),
+    ...     update_memory_on_run=True,
     ...     tools=[AgnoKGToolkit(context=shared)],
     ... )
     >>> analyst = Agent(
     ...     name="Analyst",
-    ...     memory=shared.bind_agent("analyst"),
+    ...     db=shared.bind_agent("analyst"),
+    ...     update_memory_on_run=True,
     ...     tools=[AgnoDecisionKit(context=shared)],
     ... )
-    >>> team = Team(agents=[researcher, analyst], mode="coordinate")
-"""
+    >>> team = Team(
+    ...     members=[researcher, analyst],
+    ...     session_state={"shared_session_id": shared.session_id},
+    ... )
+    """
 
 from __future__ import annotations
 
 import threading
-from typing import Any, Dict, List, Optional
+import time
+import uuid
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from semantica.utils.logging import get_logger
 
@@ -71,14 +78,19 @@ class _AgentScopedStore(AgnoContextStore):
         self._context = shared._context  # type: ignore[attr-defined]
 
     # ------------------------------------------------------------------
-    # Override upsert / record to tag with role
+    # Override upsert / read to tag with role and share across agents
     # ------------------------------------------------------------------
 
-    def upsert_memory(self, memory: Any) -> Optional[Any]:  # type: ignore[override]
-        import uuid
-
-        mem_id = getattr(memory, "id", None) or str(uuid.uuid4())
+    def upsert_user_memory(
+        self, memory: Any, deserialize: Optional[bool] = True
+    ) -> Optional[Union[Any, Dict[str, Any]]]:  # type: ignore[override]
+        mem_id = getattr(memory, "memory_id", None) or str(uuid.uuid4())
         mem_text = getattr(memory, "memory", str(memory))
+
+        now = int(time.time())
+        if getattr(memory, "created_at", None) is None:
+            memory.created_at = now
+        memory.updated_at = now
 
         try:
             self._context.store(mem_text, conversation_id=self.session_id)
@@ -97,35 +109,80 @@ class _AgentScopedStore(AgnoContextStore):
             except Exception as exc:
                 logger.warning("[%s] record_decision failed: %s", self._role, exc, exc_info=True)
 
-        if hasattr(memory, "id"):
-            memory.id = mem_id
+        if hasattr(memory, "memory_id"):
+            memory.memory_id = mem_id
         self._memories[mem_id] = memory
 
         # Also push into the shared registry so all agents can read it
         self._shared._shared_memories[mem_id] = memory
 
+        if not deserialize:
+            return memory.to_dict() if hasattr(memory, "to_dict") else dict(memory.__dict__)
         return memory
 
-    def read_memories(  # type: ignore[override]
+    def get_user_memories(  # type: ignore[override]
         self,
         user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        team_id: Optional[str] = None,
+        topics: Optional[List[str]] = None,
+        search_content: Optional[str] = None,
         limit: Optional[int] = None,
-        sort: Optional[str] = None,
-    ) -> List[Any]:
+        page: Optional[int] = None,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
+        deserialize: Optional[bool] = True,
+    ) -> Union[List[Any], Tuple[List[Dict[str, Any]], int]]:
         # Return own memories + shared memories from all agents
         combined = dict(self._shared._shared_memories)
         combined.update(self._memories)
 
         rows = list(combined.values())
-        if user_id:
+        if user_id is not None:
             rows = [r for r in rows if getattr(r, "user_id", None) == user_id]
+        if topics is not None:
+            rows = [
+                r
+                for r in rows
+                if any(t in (getattr(r, "topics", None) or []) for t in topics)
+            ]
+        if search_content is not None:
+            rows = [
+                r
+                for r in rows
+                if search_content.lower() in str(getattr(r, "memory", "")).lower()
+            ]
 
-        reverse = sort != "asc"
-        rows.sort(key=lambda r: getattr(r, "last_updated", 0), reverse=reverse)
+        total_count = len(rows)
+
+        sort_key = sort_by or "updated_at"
+        reverse = (sort_order or "desc").lower() != "asc"
+        rows.sort(key=lambda r: getattr(r, sort_key, None) or 0, reverse=reverse)
 
         if limit is not None:
-            rows = rows[:limit]
+            start = (page - 1) * limit if page is not None else 0
+            rows = rows[start : start + limit]
+
+        if not deserialize:
+            return (
+                [r.to_dict() if hasattr(r, "to_dict") else dict(r.__dict__) for r in rows],
+                total_count,
+            )
         return rows
+
+    def delete_user_memory(self, memory_id: str, user_id: Optional[str] = None) -> None:  # type: ignore[override]
+        self._memories.pop(memory_id, None)
+        self._shared._shared_memories.pop(memory_id, None)
+        try:
+            self._context.forget(memory_id=memory_id)
+        except Exception as exc:
+            logger.debug("[%s] forget(%s) failed: %s", self._role, memory_id, exc)
+
+    def clear_memories(self) -> None:  # type: ignore[override]
+        """Clear this role's memories and its entries in the shared pool."""
+        for mem_id in list(self._memories):
+            self._shared._shared_memories.pop(mem_id, None)
+        self._memories.clear()
 
 
 class AgnoSharedContext:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,7 @@ gpu = [
 ]
 
 # ---- Agentic Framework Integrations ----
-agno = ["agno>=1.0.0"]
+agno = ["agno>=2.9,<3"]
 # crewai core provides BaseTool and BaseKnowledgeSource; crewai-tools is not
 # needed (it pulls vulnerable transitive deps like chromadb) and would only
 # duplicate the prebuilt tooling users can install separately.

--- a/tests/integrations/agno/conftest.py
+++ b/tests/integrations/agno/conftest.py
@@ -1,14 +1,11 @@
 """
 Shared pytest configuration for Agno integration tests.
 
-Installs a comprehensive agno stub into sys.modules before any test in this
-directory runs, so that every test file can import the integration modules
-without a real agno installation.
-
-Each per-file stub only runs `if "agno" in sys.modules: return`, which would
-skip when another file already loaded a partial stub.  This conftest installs
-ALL required sub-modules at session start so the guard works correctly for
-every file.
+When the real ``agno`` package (v2) is importable, tests run against it
+directly — no stubs are installed.  Otherwise a comprehensive agno v2 stub is
+installed into sys.modules before any test in this directory runs, so that
+every test file can import the integration modules without a real agno
+installation.
 """
 from __future__ import annotations
 
@@ -16,39 +13,92 @@ import sys
 import types
 
 
+def _real_agno_available() -> bool:
+    try:
+        import agno  # noqa: F401
+        from agno.db.base import BaseDb  # noqa: F401
+        from agno.knowledge.knowledge import Knowledge  # noqa: F401
+        from agno.tools.toolkit import Toolkit  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 def _install_agno_stubs() -> None:
-    """Install a full set of agno stubs into sys.modules."""
+    """Install a full set of agno v2 stubs into sys.modules."""
+
+    agno = types.ModuleType("agno")
 
     # -----------------------------------------------------------------------
-    # agno root
+    # agno.db.base  — BaseDb
     # -----------------------------------------------------------------------
-    agno = sys.modules.get("agno") or types.ModuleType("agno")
+    db_pkg = types.ModuleType("agno.db")
+    db_base = types.ModuleType("agno.db.base")
 
-    # -----------------------------------------------------------------------
-    # agno.memory.db.base  — MemoryDb
-    # -----------------------------------------------------------------------
-    memory_pkg = types.ModuleType("agno.memory")
-    memory_db_pkg = types.ModuleType("agno.memory.db")
-    memory_db_base = types.ModuleType("agno.memory.db.base")
-    memory_db_row = types.ModuleType("agno.memory.db.row")
-
-    class MemoryDb:  # noqa: D101
+    class BaseDb:  # noqa: D101
         def __init__(self, *a, **kw): ...  # noqa: E704
 
-    class MemoryRow:  # noqa: D101
-        def __init__(self, memory: str, id=None, user_id=None, **kw):
-            self.memory = memory
-            self.id = id
-            self.user_id = user_id
-            self.last_updated = 0.0
-            self.topics = kw.get("topics", [])
+    db_base.BaseDb = BaseDb  # type: ignore
+    db_pkg.base = db_base
 
-    memory_db_base.MemoryDb = MemoryDb  # type: ignore
-    memory_db_row.MemoryRow = MemoryRow  # type: ignore
-    memory_db_pkg.base = memory_db_base
-    memory_db_pkg.row = memory_db_row
-    memory_pkg.db = memory_db_pkg
-    agno.memory = memory_pkg  # type: ignore
+    # -----------------------------------------------------------------------
+    # agno.db.schemas.memory  — UserMemory
+    # -----------------------------------------------------------------------
+    db_schemas = types.ModuleType("agno.db.schemas")
+    db_schemas_memory = types.ModuleType("agno.db.schemas.memory")
+
+    class UserMemory:  # noqa: D101
+        def __init__(
+            self,
+            memory,
+            memory_id=None,
+            topics=None,
+            user_id=None,
+            input=None,
+            created_at=None,
+            updated_at=None,
+            feedback=None,
+            agent_id=None,
+            team_id=None,
+        ):
+            self.memory = memory
+            self.memory_id = memory_id
+            self.topics = topics
+            self.user_id = user_id
+            self.input = input
+            self.created_at = created_at
+            self.updated_at = updated_at
+            self.feedback = feedback
+            self.agent_id = agent_id
+            self.team_id = team_id
+
+        def to_dict(self):
+            return {
+                k: v
+                for k, v in {
+                    "memory": self.memory,
+                    "memory_id": self.memory_id,
+                    "topics": self.topics,
+                    "user_id": self.user_id,
+                    "input": self.input,
+                    "created_at": self.created_at,
+                    "updated_at": self.updated_at,
+                    "feedback": self.feedback,
+                    "agent_id": self.agent_id,
+                    "team_id": self.team_id,
+                }.items()
+                if v is not None
+            }
+
+        @classmethod
+        def from_dict(cls, data):
+            return cls(**data)
+
+    db_schemas_memory.UserMemory = UserMemory  # type: ignore
+    db_schemas.memory = db_schemas_memory
+    db_pkg.schemas = db_schemas
+    agno.db = db_pkg  # type: ignore
 
     # -----------------------------------------------------------------------
     # agno.tools.toolkit  — Toolkit
@@ -59,36 +109,37 @@ def _install_agno_stubs() -> None:
     class Toolkit:  # noqa: D101
         def __init__(self, name: str = "toolkit", **kw):
             self.name = name
-            self._tools: list = []
+            self.functions: dict = {}
 
-        def register(self, fn):  # noqa: D102
-            self._tools.append(fn)
+        def register(self, fn, name=None):  # noqa: D102
+            self.functions[name or fn.__name__] = fn
 
     tools_toolkit_mod.Toolkit = Toolkit  # type: ignore
     tools_pkg.toolkit = tools_toolkit_mod
     agno.tools = tools_pkg  # type: ignore
 
     # -----------------------------------------------------------------------
-    # agno.knowledge.base  — AgentKnowledge
+    # agno.knowledge.knowledge  — Knowledge
     # -----------------------------------------------------------------------
     knowledge_pkg = types.ModuleType("agno.knowledge")
-    knowledge_base_mod = types.ModuleType("agno.knowledge.base")
+    knowledge_mod = types.ModuleType("agno.knowledge.knowledge")
 
-    class AgentKnowledge:  # noqa: D101
-        def __init__(self, *a, **kw): ...  # noqa: E704
+    class Knowledge:  # noqa: D101
+        def __init__(self, name=None, max_results=10, **kw):
+            self.name = name
+            self.max_results = max_results
 
-        def search(self, query, num_documents=None, filters=None):  # noqa: D102
+        def search(self, query, max_results=None, filters=None, search_type=None):  # noqa: D102
             return []
 
-    knowledge_base_mod.AgentKnowledge = AgentKnowledge  # type: ignore
-    knowledge_pkg.base = knowledge_base_mod
-    agno.knowledge = knowledge_pkg  # type: ignore
+    knowledge_mod.Knowledge = Knowledge  # type: ignore
+    knowledge_pkg.knowledge = knowledge_mod
 
     # -----------------------------------------------------------------------
-    # agno.document.base  — Document
+    # agno.knowledge.document.base  — Document
     # -----------------------------------------------------------------------
-    document_pkg = types.ModuleType("agno.document")
-    document_base_mod = types.ModuleType("agno.document.base")
+    document_pkg = types.ModuleType("agno.knowledge.document")
+    document_base_mod = types.ModuleType("agno.knowledge.document.base")
 
     class Document:  # noqa: D101
         def __init__(self, content="", id=None, name=None, meta_data=None):
@@ -99,27 +150,29 @@ def _install_agno_stubs() -> None:
 
     document_base_mod.Document = Document  # type: ignore
     document_pkg.base = document_base_mod
-    agno.document = document_pkg  # type: ignore
+    knowledge_pkg.document = document_pkg
+    agno.knowledge = knowledge_pkg  # type: ignore
 
     # -----------------------------------------------------------------------
     # Register everything
     # -----------------------------------------------------------------------
     _mods = {
         "agno": agno,
-        "agno.memory": memory_pkg,
-        "agno.memory.db": memory_db_pkg,
-        "agno.memory.db.base": memory_db_base,
-        "agno.memory.db.row": memory_db_row,
+        "agno.db": db_pkg,
+        "agno.db.base": db_base,
+        "agno.db.schemas": db_schemas,
+        "agno.db.schemas.memory": db_schemas_memory,
         "agno.tools": tools_pkg,
         "agno.tools.toolkit": tools_toolkit_mod,
         "agno.knowledge": knowledge_pkg,
-        "agno.knowledge.base": knowledge_base_mod,
-        "agno.document": document_pkg,
-        "agno.document.base": document_base_mod,
+        "agno.knowledge.knowledge": knowledge_mod,
+        "agno.knowledge.document": document_pkg,
+        "agno.knowledge.document.base": document_base_mod,
     }
     for name, mod in _mods.items():
         sys.modules[name] = mod
 
 
-# Install once at import time (conftest is imported before any test file)
-_install_agno_stubs()
+# Install stubs only when the real agno v2 package is not importable.
+if not _real_agno_available():
+    _install_agno_stubs()

--- a/tests/integrations/agno/test_context_store.py
+++ b/tests/integrations/agno/test_context_store.py
@@ -1,71 +1,21 @@
 """
-Tests for AgnoContextStore — graph-backed Agno MemoryDb.
+Tests for AgnoContextStore — graph-backed Agno v2 ``BaseDb``.
 
-All tests run without a real Agno installation by mocking the base class
-and using in-memory Semantica components only.
+All tests run with or without a real Agno installation (conftest installs a
+v2 stub when agno is absent) and use in-memory Semantica components only.
 """
 
 from __future__ import annotations
 
-import sys
-import types
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 
-# ---------------------------------------------------------------------------
-# Stub the agno package so the import succeeds without it installed
-# ---------------------------------------------------------------------------
-def _stub_agno() -> None:
-    """Insert minimal agno stubs into sys.modules."""
-    if "agno" in sys.modules:
-        return  # real agno installed — no stub needed
-
-    agno = types.ModuleType("agno")
-
-    # agno.memory.db.base
-    memory_pkg = types.ModuleType("agno.memory")
-    memory_db_pkg = types.ModuleType("agno.memory.db")
-    memory_db_base = types.ModuleType("agno.memory.db.base")
-
-    class MemoryDb:  # noqa: D101
-        def __init__(self, *a, **kw): ...  # noqa: E704
-
-    memory_db_base.MemoryDb = MemoryDb  # type: ignore
-
-    # agno.memory.db.row
-    memory_db_row = types.ModuleType("agno.memory.db.row")
-
-    class MemoryRow:  # noqa: D101
-        def __init__(self, memory: str, id=None, user_id=None, **kw):
-            self.memory = memory
-            self.id = id
-            self.user_id = user_id
-            self.last_updated = 0.0
-            self.topics = kw.get("topics", [])
-
-    memory_db_row.MemoryRow = MemoryRow  # type: ignore
-
-    memory_db_pkg.base = memory_db_base
-    memory_db_pkg.row = memory_db_row
-    memory_pkg.db = memory_db_pkg
-
-    agno.memory = memory_pkg  # type: ignore
-
-    for name, mod in [
-        ("agno", agno),
-        ("agno.memory", memory_pkg),
-        ("agno.memory.db", memory_db_pkg),
-        ("agno.memory.db.base", memory_db_base),
-        ("agno.memory.db.row", memory_db_row),
-    ]:
-        sys.modules.setdefault(name, mod)
+from integrations.agno.context_store import AgnoContextStore, UserMemory  # noqa: E402
 
 
-_stub_agno()
-
-
-from integrations.agno.context_store import AgnoContextStore  # noqa: E402
+def _make_memory(text: str, uid: str = "u1", **kwargs) -> UserMemory:
+    return UserMemory(memory=text, user_id=uid, **kwargs)
 
 
 class TestAgnoContextStoreInit(unittest.TestCase):
@@ -96,83 +46,171 @@ class TestAgnoContextStoreInit(unittest.TestCase):
         self.assertIsNotNone(store.context)
 
 
-class TestAgnoContextStoreMemoryDb(unittest.TestCase):
-    """MemoryDb protocol methods."""
+class TestAgnoContextStoreUserMemoryGroup(unittest.TestCase):
+    """BaseDb UserMemory-group protocol methods."""
 
     def setUp(self):
         self.store = AgnoContextStore(decision_tracking=False)
 
-    def _make_row(self, text: str, uid: str = "u1"):
-        row = MagicMock()
-        row.memory = text
-        row.id = None
-        row.user_id = uid
-        row.last_updated = 0.0
-        row.topics = []
-        return row
-
     def test_table_exists(self):
-        self.assertTrue(self.store.table_exists())
-
-    def test_create_noop(self):
-        # Should not raise
-        self.store.create()
+        self.assertTrue(self.store.table_exists("user_memories"))
 
     def test_upsert_and_read(self):
-        row = self._make_row("Hello world")
-        self.store.upsert_memory(row)
-        memories = self.store.read_memories()
+        self.store.upsert_user_memory(_make_memory("Hello world"))
+        memories = self.store.get_user_memories()
         self.assertEqual(len(memories), 1)
 
-    def test_upsert_sets_id(self):
-        row = self._make_row("Test memory")
-        self.store.upsert_memory(row)
-        self.assertIsNotNone(row.id)
+    def test_upsert_sets_memory_id(self):
+        mem = _make_memory("Test memory")
+        self.store.upsert_user_memory(mem)
+        self.assertIsNotNone(mem.memory_id)
 
-    def test_memory_exists_after_upsert(self):
-        row = self._make_row("Exists check")
-        self.store.upsert_memory(row)
-        self.assertTrue(self.store.memory_exists(row))
+    def test_upsert_sets_timestamps(self):
+        mem = _make_memory("Timestamped")
+        self.store.upsert_user_memory(mem)
+        self.assertIsNotNone(mem.created_at)
+        self.assertIsNotNone(mem.updated_at)
 
-    def test_memory_not_exists_before_upsert(self):
-        row = self._make_row("Not yet")
-        row.id = "unknown-id"
-        self.assertFalse(self.store.memory_exists(row))
+    def test_get_user_memory_by_id(self):
+        mem = _make_memory("Fetch me")
+        self.store.upsert_user_memory(mem)
+        fetched = self.store.get_user_memory(mem.memory_id)
+        self.assertIsNotNone(fetched)
+        self.assertEqual(fetched.memory, "Fetch me")
 
-    def test_delete_memory(self):
-        row = self._make_row("To delete")
-        self.store.upsert_memory(row)
-        mem_id = row.id
-        self.store.delete_memory(mem_id)
-        self.assertFalse(self.store.memory_exists(row))
+    def test_get_user_memory_missing_returns_none(self):
+        self.assertIsNone(self.store.get_user_memory("no-such-id"))
 
-    def test_read_memories_user_filter(self):
-        row_a = self._make_row("User A memory", uid="alice")
-        row_b = self._make_row("User B memory", uid="bob")
-        self.store.upsert_memory(row_a)
-        self.store.upsert_memory(row_b)
+    def test_get_user_memory_deserialize_false_returns_dict(self):
+        mem = _make_memory("As dict")
+        self.store.upsert_user_memory(mem)
+        raw = self.store.get_user_memory(mem.memory_id, deserialize=False)
+        self.assertIsInstance(raw, dict)
+        self.assertEqual(raw["memory"], "As dict")
 
-        alice_rows = self.store.read_memories(user_id="alice")
+    def test_get_user_memory_user_id_mismatch(self):
+        mem = _make_memory("Owned by alice", uid="alice")
+        self.store.upsert_user_memory(mem)
+        self.assertIsNone(self.store.get_user_memory(mem.memory_id, user_id="bob"))
+
+    def test_delete_user_memory(self):
+        mem = _make_memory("To delete")
+        self.store.upsert_user_memory(mem)
+        self.store.delete_user_memory(mem.memory_id)
+        self.assertIsNone(self.store.get_user_memory(mem.memory_id))
+
+    def test_delete_user_memory_wrong_user_keeps_memory(self):
+        mem = _make_memory("Owned", uid="alice")
+        self.store.upsert_user_memory(mem)
+        self.store.delete_user_memory(mem.memory_id, user_id="bob")
+        self.assertIsNotNone(self.store.get_user_memory(mem.memory_id))
+
+    def test_delete_user_memories_bulk(self):
+        ids = []
+        for i in range(3):
+            mem = _make_memory(f"Bulk {i}")
+            self.store.upsert_user_memory(mem)
+            ids.append(mem.memory_id)
+        self.store.delete_user_memories(ids)
+        self.assertEqual(len(self.store.get_user_memories()), 0)
+
+    def test_get_user_memories_user_filter(self):
+        self.store.upsert_user_memory(_make_memory("User A memory", uid="alice"))
+        self.store.upsert_user_memory(_make_memory("User B memory", uid="bob"))
+
+        alice_rows = self.store.get_user_memories(user_id="alice")
         self.assertEqual(len(alice_rows), 1)
         self.assertEqual(alice_rows[0].user_id, "alice")
 
-    def test_read_memories_limit(self):
+    def test_get_user_memories_search_content(self):
+        self.store.upsert_user_memory(_make_memory("Basel IV applies from 2026"))
+        self.store.upsert_user_memory(_make_memory("Unrelated note"))
+        rows = self.store.get_user_memories(search_content="basel")
+        self.assertEqual(len(rows), 1)
+
+    def test_get_user_memories_topics_filter(self):
+        self.store.upsert_user_memory(_make_memory("Finance fact", topics=["finance"]))
+        self.store.upsert_user_memory(_make_memory("Sports fact", topics=["sports"]))
+        rows = self.store.get_user_memories(topics=["finance"])
+        self.assertEqual(len(rows), 1)
+
+    def test_get_user_memories_limit(self):
         for i in range(5):
-            self.store.upsert_memory(self._make_row(f"Memory {i}"))
-        rows = self.store.read_memories(limit=3)
+            self.store.upsert_user_memory(_make_memory(f"Memory {i}"))
+        rows = self.store.get_user_memories(limit=3)
         self.assertEqual(len(rows), 3)
 
-    def test_clear(self):
-        for i in range(3):
-            self.store.upsert_memory(self._make_row(f"M{i}"))
-        result = self.store.clear()
-        self.assertTrue(result)
-        self.assertEqual(len(self.store.read_memories()), 0)
+    def test_get_user_memories_deserialize_false_returns_tuple(self):
+        for i in range(4):
+            self.store.upsert_user_memory(_make_memory(f"M{i}"))
+        rows, total = self.store.get_user_memories(limit=2, deserialize=False)
+        self.assertEqual(total, 4)
+        self.assertEqual(len(rows), 2)
+        self.assertIsInstance(rows[0], dict)
 
-    def test_drop_table(self):
-        self.store.upsert_memory(self._make_row("Drop me"))
-        self.store.drop_table()
-        self.assertEqual(len(self.store.read_memories()), 0)
+    def test_get_all_memory_topics(self):
+        self.store.upsert_user_memory(_make_memory("A", topics=["x", "y"]))
+        self.store.upsert_user_memory(_make_memory("B", topics=["y", "z"]))
+        self.assertEqual(self.store.get_all_memory_topics(), ["x", "y", "z"])
+
+    def test_get_user_memory_stats(self):
+        self.store.upsert_user_memory(_make_memory("A", uid="alice", topics=["t1"]))
+        self.store.upsert_user_memory(_make_memory("B", uid="alice"))
+        self.store.upsert_user_memory(_make_memory("C", uid="bob"))
+        rows, total = self.store.get_user_memory_stats()
+        self.assertEqual(total, 2)
+        alice = next(r for r in rows if r["user_id"] == "alice")
+        self.assertEqual(alice["total_memories"], 2)
+        self.assertEqual(alice["topics"], ["t1"])
+
+    def test_upsert_memories_bulk(self):
+        mems = [_make_memory(f"Bulk {i}") for i in range(3)]
+        results = self.store.upsert_memories(mems)
+        self.assertEqual(len(results), 3)
+        self.assertEqual(len(self.store.get_user_memories()), 3)
+
+    def test_upsert_memories_deserialize_false(self):
+        results = self.store.upsert_memories([_make_memory("x")], deserialize=False)
+        self.assertIsInstance(results[0], dict)
+
+    def test_clear_memories(self):
+        for i in range(3):
+            self.store.upsert_user_memory(_make_memory(f"M{i}"))
+        self.store.clear_memories()
+        self.assertEqual(len(self.store.get_user_memories()), 0)
+
+
+class TestAgnoContextStoreUnsupportedGroups(unittest.TestCase):
+    """Non-memory BaseDb groups raise NotImplementedError (documented degradation)."""
+
+    def setUp(self):
+        self.store = AgnoContextStore(decision_tracking=False)
+
+    def test_session_group_unsupported(self):
+        with self.assertRaises(NotImplementedError):
+            self.store.get_session(session_id="s1")
+        with self.assertRaises(NotImplementedError):
+            self.store.upsert_session(session=MagicMock())
+        with self.assertRaises(NotImplementedError):
+            self.store.delete_session(session_id="s1")
+
+    def test_metrics_group_unsupported(self):
+        with self.assertRaises(NotImplementedError):
+            self.store.get_metrics()
+        with self.assertRaises(NotImplementedError):
+            self.store.calculate_metrics()
+
+    def test_knowledge_group_unsupported(self):
+        with self.assertRaises(NotImplementedError):
+            self.store.get_knowledge_content(id="k1")
+
+    def test_eval_group_unsupported(self):
+        with self.assertRaises(NotImplementedError):
+            self.store.get_eval_runs()
+
+    def test_traces_group_unsupported(self):
+        with self.assertRaises(NotImplementedError):
+            self.store.get_traces()
 
 
 class TestAgnoContextStoreExtendedAPI(unittest.TestCase):
@@ -218,13 +256,7 @@ class TestAgnoContextStoreExtendedAPI(unittest.TestCase):
         self.assertEqual(call_kwargs["entities"], ["applicant", "loan"])
 
     def test_upsert_with_decision_tracking(self):
-        row = MagicMock()
-        row.memory = "Important fact"
-        row.id = None
-        row.user_id = "u1"
-        row.last_updated = 0.0
-        row.topics = []
-        self.store.upsert_memory(row)
+        self.store.upsert_user_memory(_make_memory("Important fact"))
         # decision should have been recorded
         self.store._context.record_decision.assert_called()
 

--- a/tests/integrations/agno/test_decision_kit.py
+++ b/tests/integrations/agno/test_decision_kit.py
@@ -5,45 +5,9 @@ Tests for AgnoDecisionKit — decision intelligence Agno Toolkit.
 from __future__ import annotations
 
 import json
-import sys
-import types
 import unittest
 from unittest.mock import MagicMock, patch
 
-
-# ---------------------------------------------------------------------------
-# Stub agno Toolkit
-# ---------------------------------------------------------------------------
-def _stub_agno() -> None:
-    if "agno" in sys.modules:
-        return
-
-    agno = types.ModuleType("agno")
-
-    tools_pkg = types.ModuleType("agno.tools")
-    tools_toolkit = types.ModuleType("agno.tools.toolkit")
-
-    class Toolkit:
-        def __init__(self, name="toolkit", **kw):
-            self.name = name
-            self._tools = []
-
-        def register(self, fn):
-            self._tools.append(fn)
-
-    tools_toolkit.Toolkit = Toolkit  # type: ignore
-    tools_pkg.toolkit = tools_toolkit
-    agno.tools = tools_pkg  # type: ignore
-
-    for name, mod in [
-        ("agno", agno),
-        ("agno.tools", tools_pkg),
-        ("agno.tools.toolkit", tools_toolkit),
-    ]:
-        sys.modules.setdefault(name, mod)
-
-
-_stub_agno()
 
 from integrations.agno.decision_kit import AgnoDecisionKit  # noqa: E402
 

--- a/tests/integrations/agno/test_kg_toolkit.py
+++ b/tests/integrations/agno/test_kg_toolkit.py
@@ -5,44 +5,9 @@ Tests for AgnoKGToolkit — knowledge graph Agno Toolkit.
 from __future__ import annotations
 
 import json
-import sys
-import types
 import unittest
 from unittest.mock import MagicMock, patch
 
-
-# ---------------------------------------------------------------------------
-# Stub agno Toolkit
-# ---------------------------------------------------------------------------
-def _stub_agno() -> None:
-    if "agno" in sys.modules:
-        return
-
-    agno = types.ModuleType("agno")
-    tools_pkg = types.ModuleType("agno.tools")
-    tools_toolkit = types.ModuleType("agno.tools.toolkit")
-
-    class Toolkit:
-        def __init__(self, name="toolkit", **kw):
-            self.name = name
-            self._tools = []
-
-        def register(self, fn):
-            self._tools.append(fn)
-
-    tools_toolkit.Toolkit = Toolkit  # type: ignore
-    tools_pkg.toolkit = tools_toolkit
-    agno.tools = tools_pkg  # type: ignore
-
-    for name, mod in [
-        ("agno", agno),
-        ("agno.tools", tools_pkg),
-        ("agno.tools.toolkit", tools_toolkit),
-    ]:
-        sys.modules.setdefault(name, mod)
-
-
-_stub_agno()
 
 from integrations.agno.kg_toolkit import AgnoKGToolkit  # noqa: E402
 

--- a/tests/integrations/agno/test_knowledge_graph.py
+++ b/tests/integrations/agno/test_knowledge_graph.py
@@ -1,62 +1,12 @@
 """
-Tests for AgnoKnowledgeGraph — relational AgentKnowledge with GraphRAG.
+Tests for AgnoKnowledgeGraph — relational Agno v2 ``Knowledge`` with GraphRAG.
 """
 
 from __future__ import annotations
 
-import sys
-import types
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-
-# ---------------------------------------------------------------------------
-# Stub agno
-# ---------------------------------------------------------------------------
-def _stub_agno() -> None:
-    if "agno" in sys.modules:
-        return
-
-    agno = types.ModuleType("agno")
-
-    # agno.knowledge.base
-    knowledge_pkg = types.ModuleType("agno.knowledge")
-    knowledge_base = types.ModuleType("agno.knowledge.base")
-
-    class AgentKnowledge:
-        def __init__(self, *a, **kw): ...  # noqa: E704
-        def search(self, query, num_documents=None, filters=None): return []  # noqa: E704
-
-    knowledge_base.AgentKnowledge = AgentKnowledge  # type: ignore
-    knowledge_pkg.base = knowledge_base
-    agno.knowledge = knowledge_pkg  # type: ignore
-
-    # agno.document.base
-    document_pkg = types.ModuleType("agno.document")
-    document_base = types.ModuleType("agno.document.base")
-
-    class Document:
-        def __init__(self, content="", id=None, name=None, meta_data=None):
-            self.content = content
-            self.id = id
-            self.name = name
-            self.meta_data = meta_data or {}
-
-    document_base.Document = Document  # type: ignore
-    document_pkg.base = document_base
-    agno.document = document_pkg  # type: ignore
-
-    for name, mod in [
-        ("agno", agno),
-        ("agno.knowledge", knowledge_pkg),
-        ("agno.knowledge.base", knowledge_base),
-        ("agno.document", document_pkg),
-        ("agno.document.base", document_base),
-    ]:
-        sys.modules.setdefault(name, mod)
-
-
-_stub_agno()
 
 from integrations.agno.knowledge_graph import AgnoKnowledgeGraph  # noqa: E402
 
@@ -93,6 +43,16 @@ class _FakeContextGraph:
         return [node]
 
 
+def _make_kg(**kwargs) -> AgnoKnowledgeGraph:
+    return AgnoKnowledgeGraph(
+        graph_builder=_FakeGraphBuilder(),
+        ner_extractor=_FakeNER(),
+        relation_extractor=_FakeRelExtractor(),
+        context_graph=_FakeContextGraph(),
+        **kwargs,
+    )
+
+
 class TestAgnoKnowledgeGraphInit(unittest.TestCase):
 
     def test_creates_with_defaults(self):
@@ -100,28 +60,23 @@ class TestAgnoKnowledgeGraphInit(unittest.TestCase):
         self.assertIsNotNone(kg)
 
     def test_creates_with_custom_components(self):
-        kg = AgnoKnowledgeGraph(
-            graph_builder=_FakeGraphBuilder(),
-            ner_extractor=_FakeNER(),
-            relation_extractor=_FakeRelExtractor(),
-            context_graph=_FakeContextGraph(),
-        )
+        kg = _make_kg()
         self.assertIsNotNone(kg)
 
     def test_num_documents_default(self):
         kg = AgnoKnowledgeGraph(num_documents=10)
         self.assertEqual(kg.num_documents, 10)
+        self.assertEqual(kg.max_results, 10)
+
+    def test_custom_name(self):
+        kg = _make_kg(name="regulatory_kb")
+        self.assertEqual(kg.name, "regulatory_kb")
 
 
 class TestAgnoKnowledgeGraphLoad(unittest.TestCase):
 
     def setUp(self):
-        self.kg = AgnoKnowledgeGraph(
-            graph_builder=_FakeGraphBuilder(),
-            ner_extractor=_FakeNER(),
-            relation_extractor=_FakeRelExtractor(),
-            context_graph=_FakeContextGraph(),
-        )
+        self.kg = _make_kg()
 
     def test_load_texts(self):
         self.kg.load(texts=["Alice works at Acme Corp.", "Bob is the CEO."])
@@ -151,15 +106,50 @@ class TestAgnoKnowledgeGraphLoad(unittest.TestCase):
         self.assertTrue(len(stored["entities"]) > 0)
 
 
+class TestAgnoKnowledgeGraphInsert(unittest.TestCase):
+    """v2 Knowledge.insert() entry point."""
+
+    def setUp(self):
+        self.kg = _make_kg()
+
+    def test_insert_text_content(self):
+        self.kg.insert(text_content="Basel IV applies from 2026.", name="basel")
+        self.assertEqual(len(self.kg._docs), 1)
+        self.assertEqual(self.kg._docs[0]["source"], "basel")
+
+    def test_insert_path_file(self):
+        import os
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("Inserted from a file.")
+            tmp_path = f.name
+        try:
+            self.kg.insert(path=tmp_path)
+            self.assertEqual(len(self.kg._docs), 1)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_insert_path_directory_with_include(self):
+        import os
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            for fname in ("a.txt", "b.txt", "c.md"):
+                with open(os.path.join(d, fname), "w") as f:
+                    f.write(f"content of {fname}")
+            self.kg.insert(path=d, include=["*.txt"])
+            self.assertEqual(len(self.kg._docs), 2)
+
+    def test_insert_url_disallowed_scheme_skipped(self):
+        self.kg.insert(url="file:///etc/passwd")
+        self.assertEqual(len(self.kg._docs), 0)
+
+
 class TestAgnoKnowledgeGraphSearch(unittest.TestCase):
 
     def setUp(self):
-        self.kg = AgnoKnowledgeGraph(
-            graph_builder=_FakeGraphBuilder(),
-            ner_extractor=_FakeNER(),
-            relation_extractor=_FakeRelExtractor(),
-            context_graph=_FakeContextGraph(),
-        )
+        self.kg = _make_kg()
         self.kg.load(texts=[
             "Machine learning is a subset of artificial intelligence.",
             "Python is a popular programming language.",
@@ -171,24 +161,26 @@ class TestAgnoKnowledgeGraphSearch(unittest.TestCase):
         self.assertIsInstance(results, list)
 
     def test_search_returns_agno_documents(self):
-        results = self.kg.search("python", num_documents=2)
+        results = self.kg.search("python", max_results=2)
         self.assertTrue(len(results) <= 2)
         for doc in results:
             self.assertTrue(hasattr(doc, "content"))
 
     def test_search_empty_kg_returns_empty(self):
-        kg = AgnoKnowledgeGraph(
-            graph_builder=_FakeGraphBuilder(),
-            ner_extractor=_FakeNER(),
-            relation_extractor=_FakeRelExtractor(),
-            context_graph=_FakeContextGraph(),
-        )
+        kg = _make_kg()
         results = kg.search("anything")
         self.assertEqual(results, [])
 
-    def test_search_num_documents_respected(self):
-        results = self.kg.search("a", num_documents=1)
+    def test_search_max_results_respected(self):
+        results = self.kg.search("a", max_results=1)
         self.assertTrue(len(results) <= 1)
+
+    def test_asearch_delegates_to_search(self):
+        import asyncio
+
+        results = asyncio.run(self.kg.asearch("python", max_results=2))
+        self.assertIsInstance(results, list)
+        self.assertTrue(len(results) <= 2)
 
     def test_get_graph_context(self):
         ctx = self.kg.get_graph_context("FakeEntity")
@@ -199,25 +191,16 @@ class TestAgnoKnowledgeGraphPathLoading(unittest.TestCase):
     """Test path-based loading with a temporary file."""
 
     def test_load_missing_path_warns(self):
-        kg = AgnoKnowledgeGraph(
-            graph_builder=_FakeGraphBuilder(),
-            ner_extractor=_FakeNER(),
-            relation_extractor=_FakeRelExtractor(),
-            context_graph=_FakeContextGraph(),
-        )
+        kg = _make_kg()
         # Should not raise even for non-existent path
         kg.load(path="/nonexistent/path/xyz")
         self.assertEqual(len(kg._docs), 0)
 
     def test_load_file(self):
-        import tempfile, os
+        import os
+        import tempfile
 
-        kg = AgnoKnowledgeGraph(
-            graph_builder=_FakeGraphBuilder(),
-            ner_extractor=_FakeNER(),
-            relation_extractor=_FakeRelExtractor(),
-            context_graph=_FakeContextGraph(),
-        )
+        kg = _make_kg()
         with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
             f.write("Test document content for loading.")
             tmp_path = f.name

--- a/tests/integrations/agno/test_shared_context.py
+++ b/tests/integrations/agno/test_shared_context.py
@@ -4,56 +4,11 @@ Tests for AgnoSharedContext — multi-agent shared ContextGraph coordinator.
 
 from __future__ import annotations
 
-import sys
-import types
 import unittest
 from unittest.mock import MagicMock
 
 
-# ---------------------------------------------------------------------------
-# Stub agno (MemoryDb needed by AgnoContextStore base)
-# ---------------------------------------------------------------------------
-def _stub_agno() -> None:
-    if "agno" in sys.modules:
-        return
-
-    agno = types.ModuleType("agno")
-
-    memory_pkg = types.ModuleType("agno.memory")
-    memory_db_pkg = types.ModuleType("agno.memory.db")
-    memory_db_base = types.ModuleType("agno.memory.db.base")
-    memory_db_row = types.ModuleType("agno.memory.db.row")
-
-    class MemoryDb:
-        def __init__(self, *a, **kw): ...  # noqa: E704
-
-    class MemoryRow:
-        def __init__(self, memory, id=None, user_id=None, **kw):
-            self.memory = memory
-            self.id = id
-            self.user_id = user_id
-            self.last_updated = 0.0
-            self.topics = kw.get("topics", [])
-
-    memory_db_base.MemoryDb = MemoryDb  # type: ignore
-    memory_db_row.MemoryRow = MemoryRow  # type: ignore
-    memory_db_pkg.base = memory_db_base
-    memory_db_pkg.row = memory_db_row
-    memory_pkg.db = memory_db_pkg
-    agno.memory = memory_pkg  # type: ignore
-
-    for name, mod in [
-        ("agno", agno),
-        ("agno.memory", memory_pkg),
-        ("agno.memory.db", memory_db_pkg),
-        ("agno.memory.db.base", memory_db_base),
-        ("agno.memory.db.row", memory_db_row),
-    ]:
-        sys.modules.setdefault(name, mod)
-
-
-_stub_agno()
-
+from integrations.agno.context_store import UserMemory  # noqa: E402
 from integrations.agno.shared_context import AgnoSharedContext  # noqa: E402
 
 
@@ -66,6 +21,10 @@ def _make_shared(**kwargs) -> AgnoSharedContext:
     mock_ctx.get_context_insights.return_value = {"total": 0}
     shared._context = mock_ctx
     return shared
+
+
+def _make_row(text: str) -> UserMemory:
+    return UserMemory(memory=text, user_id="u1")
 
 
 class TestAgnoSharedContextInit(unittest.TestCase):
@@ -135,60 +94,57 @@ class TestSharedMemoryPool(unittest.TestCase):
         self.researcher = self.shared.bind_agent("researcher")
         self.analyst = self.shared.bind_agent("analyst")
 
-    def _make_row(self, text: str):
-        row = MagicMock()
-        row.memory = text
-        row.id = None
-        row.user_id = "u1"
-        row.last_updated = 0.0
-        row.topics = []
-        return row
-
     def test_researcher_memory_visible_to_analyst(self):
-        row = self._make_row("New regulation: Basel IV applies from 2026")
-        self.researcher.upsert_memory(row)
+        self.researcher.upsert_user_memory(_make_row("New regulation: Basel IV applies from 2026"))
 
-        analyst_memories = self.analyst.read_memories()
+        analyst_memories = self.analyst.get_user_memories()
         texts = [getattr(m, "memory", "") for m in analyst_memories]
         self.assertIn("New regulation: Basel IV applies from 2026", texts)
 
     def test_analyst_memory_visible_to_researcher(self):
-        row = self._make_row("Market share: Competitor X grew by 12%")
-        self.analyst.upsert_memory(row)
+        self.analyst.upsert_user_memory(_make_row("Market share: Competitor X grew by 12%"))
 
-        researcher_memories = self.researcher.read_memories()
+        researcher_memories = self.researcher.get_user_memories()
         texts = [getattr(m, "memory", "") for m in researcher_memories]
         self.assertIn("Market share: Competitor X grew by 12%", texts)
 
     def test_both_memories_in_pool(self):
-        self.researcher.upsert_memory(self._make_row("Research insight A"))
-        self.analyst.upsert_memory(self._make_row("Analysis finding B"))
+        self.researcher.upsert_user_memory(_make_row("Research insight A"))
+        self.analyst.upsert_user_memory(_make_row("Analysis finding B"))
 
         # Either agent should see both
-        researcher_memories = self.researcher.read_memories()
+        researcher_memories = self.researcher.get_user_memories()
         self.assertTrue(len(researcher_memories) >= 2)
 
     def test_limit_respected_in_read(self):
         for i in range(5):
-            self.researcher.upsert_memory(self._make_row(f"Fact {i}"))
-        memories = self.analyst.read_memories(limit=2)
+            self.researcher.upsert_user_memory(_make_row(f"Fact {i}"))
+        memories = self.analyst.get_user_memories(limit=2)
         self.assertTrue(len(memories) <= 2)
+
+    def test_delete_removes_from_shared_pool(self):
+        mem = _make_row("Ephemeral fact")
+        self.researcher.upsert_user_memory(mem)
+        self.researcher.delete_user_memory(mem.memory_id)
+        analyst_memories = self.analyst.get_user_memories()
+        texts = [getattr(m, "memory", "") for m in analyst_memories]
+        self.assertNotIn("Ephemeral fact", texts)
 
     def test_upsert_memory_store_failure_logs_warning(self):
         self.shared._context.store.side_effect = RuntimeError("store error")
         with self.assertLogs("semantica.integrations.agno.shared_context", level="WARNING") as cm:
-            mem = self.researcher.upsert_memory(self._make_row("Test store fail"))
+            mem = self.researcher.upsert_user_memory(_make_row("Test store fail"))
         self.assertIsNotNone(mem)
-        self.assertIn(mem.id, self.researcher._memories)
+        self.assertIn(mem.memory_id, self.researcher._memories)
         self.assertTrue(any("store failed:" in msg and "store error" in msg for msg in cm.output))
         self.shared._context.store.side_effect = None
 
     def test_upsert_memory_record_decision_failure_logs_warning(self):
         self.shared._context.record_decision.side_effect = RuntimeError("decision error")
         with self.assertLogs("semantica.integrations.agno.shared_context", level="WARNING") as cm:
-            mem = self.researcher.upsert_memory(self._make_row("Test decision fail"))
+            mem = self.researcher.upsert_user_memory(_make_row("Test decision fail"))
         self.assertIsNotNone(mem)
-        self.assertIn(mem.id, self.researcher._memories)
+        self.assertIn(mem.memory_id, self.researcher._memories)
         self.assertTrue(any("record_decision failed:" in msg and "decision error" in msg for msg in cm.output))
         self.shared._context.record_decision.side_effect = None
 


### PR DESCRIPTION
## 背景

现有 `integrations/agno` 基于 Agno v1 API 编写（`MemoryDb`、`AgentKnowledge`），而 Agno v1→v2 是破坏性升级，这些类在 v2 中已被删除，导致安装 agno 2.9 后集成层直接 import 失败。

本 PR 将集成层整体迁移到 Agno 2.9（仅支持 `agno>=2.9,<3`，不再兼容 v1）。

## 主要改动

- **AgnoContextStore**：v1 `MemoryDb` → v2 `BaseDb`。UserMemory 分组的 9 个抽象方法全部完整实现（语义对齐 agno 自带 `InMemoryDb`，含过滤/排序/分页），底层仍走 Semantica 向量 + 图谱混合存储；sessions/metrics 等其余分组显式 `NotImplementedError` 降级（已核实 Agent 侧有 try/except 兜底）；决策跟踪等扩展 API 保留
- **AgnoKnowledgeGraph**：v1 `AgentKnowledge` → v2 `Knowledge`，覆写 `insert()` / `search()` / `asearch()`，多跳 GraphRAG 逻辑不变
- **AgnoKGToolkit / AgnoDecisionKit**：验证 v2 `Toolkit` 注册机制兼容，仅小改
- **AgnoSharedContext**：适配 v2 `Team(session_state=…)` 共享状态模式
- **新增 `_availability.py`**：与 crewai 集成同款的优雅降级探测，agno 未安装时可 import、不可挂接
- **`pyproject.toml`**：extras 改为 `agno>=2.9,<3`
- **文档**：`docs/integrations/agno.md` 示例全部更新为 v2 用法

## 测试

- 真实 agno 2.9.0 环境：`pytest tests/integrations/agno/` **157 passed**
- stub 降级路径（模拟未安装 agno）：**157 passed**
- smoke test：`Agent(db=…, knowledge=…, tools=[…])` 与 `Team(members=…, session_state=…)` 构造及记忆读写往返验证通过

破坏性变更：不再兼容 agno v1，集成版本号 0.3.0 → 1.0.0。