### PR TITLE
fix(kg): preserve entity_id aliases during entity merging

### DIFF
--- a/semantica/deduplication/entity_merger.py
+++ b/semantica/deduplication/entity_merger.py
@@ -45,16 +45,12 @@ License: MIT
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 
+from ..utils.entity_ids import get_entity_id
 from ..utils.exceptions import ProcessingError, ValidationError
 from ..utils.logging import get_logger
 from ..utils.progress_tracker import get_progress_tracker
 from .duplicate_detector import DuplicateDetector, DuplicateGroup
-from .merge_strategy import (
-    MergeResult,
-    MergeStrategy,
-    MergeStrategyManager,
-    _get_entity_id,
-)
+from .merge_strategy import MergeResult, MergeStrategy, MergeStrategyManager
 
 
 @dataclass
@@ -509,7 +505,7 @@ class EntityMerger:
         # Record source entities
         provenance["merged_from"] = [
             {
-                "id": _get_entity_id(e),
+                "id": get_entity_id(e),
                 "name": self._get_entity_value(e, "name"),
                 "source": self._get_entity_value(e, "metadata", {}).get("source") if hasattr(e, "metadata") or isinstance(e, dict) else None,
             }

--- a/semantica/deduplication/entity_merger.py
+++ b/semantica/deduplication/entity_merger.py
@@ -49,7 +49,12 @@ from ..utils.exceptions import ProcessingError, ValidationError
 from ..utils.logging import get_logger
 from ..utils.progress_tracker import get_progress_tracker
 from .duplicate_detector import DuplicateDetector, DuplicateGroup
-from .merge_strategy import MergeResult, MergeStrategy, MergeStrategyManager
+from .merge_strategy import (
+    MergeResult,
+    MergeStrategy,
+    MergeStrategyManager,
+    _get_entity_id,
+)
 
 
 @dataclass
@@ -504,7 +509,7 @@ class EntityMerger:
         # Record source entities
         provenance["merged_from"] = [
             {
-                "id": self._get_entity_value(e, "id"),
+                "id": _get_entity_id(e),
                 "name": self._get_entity_value(e, "name"),
                 "source": self._get_entity_value(e, "metadata", {}).get("source") if hasattr(e, "metadata") or isinstance(e, dict) else None,
             }

--- a/semantica/deduplication/merge_strategy.py
+++ b/semantica/deduplication/merge_strategy.py
@@ -50,6 +50,16 @@ from ..utils.logging import get_logger
 from ..utils.progress_tracker import get_progress_tracker
 
 
+def _get_entity_id(entity: Any) -> Any:
+    """Return an entity identifier from either supported ID field."""
+    if isinstance(entity, dict):
+        entity_id = entity.get("id")
+        return entity_id if entity_id is not None else entity.get("entity_id")
+
+    entity_id = getattr(entity, "id", None)
+    return entity_id if entity_id is not None else getattr(entity, "entity_id", None)
+
+
 class MergeStrategy(Enum):
     """Merge strategy types."""
 
@@ -317,14 +327,20 @@ class MergeStrategyManager:
                 message=f"Building merged entity... ({current_step}/{total_steps}, remaining: {remaining_steps} steps)"
             )
             # Build merged entity
+            merged_from = []
+            for entity in entities:
+                entity_id = _get_entity_id(entity)
+                if entity_id is not None:
+                    merged_from.append(entity_id)
+
             merged_entity = {
-                "id": base_entity.get("id"),
+                "id": _get_entity_id(base_entity),
                 "name": self._merge_top_level_field("name", entities, base_entity),
                 "type": self._merge_top_level_field("type", entities, base_entity),
                 "properties": merged_properties,
                 "relationships": merged_relationships,
                 "metadata": self._merge_metadata(entities, base_entity),
-                "merged_from": [e.get("id") for e in entities if e.get("id")],
+                "merged_from": merged_from,
                 "merge_strategy": strategy.value,
             }
 

--- a/semantica/deduplication/merge_strategy.py
+++ b/semantica/deduplication/merge_strategy.py
@@ -45,19 +45,10 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
+from ..utils.entity_ids import get_entity_id
 from ..utils.exceptions import ProcessingError, ValidationError
 from ..utils.logging import get_logger
 from ..utils.progress_tracker import get_progress_tracker
-
-
-def _get_entity_id(entity: Any) -> Any:
-    """Return an entity identifier from either supported ID field."""
-    if isinstance(entity, dict):
-        entity_id = entity.get("id")
-        return entity_id if entity_id is not None else entity.get("entity_id")
-
-    entity_id = getattr(entity, "id", None)
-    return entity_id if entity_id is not None else getattr(entity, "entity_id", None)
 
 
 class MergeStrategy(Enum):
@@ -329,12 +320,12 @@ class MergeStrategyManager:
             # Build merged entity
             merged_from = []
             for entity in entities:
-                entity_id = _get_entity_id(entity)
+                entity_id = get_entity_id(entity)
                 if entity_id is not None:
                     merged_from.append(entity_id)
 
             merged_entity = {
-                "id": _get_entity_id(base_entity),
+                "id": get_entity_id(base_entity),
                 "name": self._merge_top_level_field("name", entities, base_entity),
                 "type": self._merge_top_level_field("type", entities, base_entity),
                 "properties": merged_properties,

--- a/semantica/kg/entity_resolver.py
+++ b/semantica/kg/entity_resolver.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional
 
 from ..deduplication.duplicate_detector import DuplicateDetector, DuplicateGroup
 from ..deduplication.entity_merger import EntityMerger
+from ..utils.entity_ids import get_entity_id
 from ..utils.logging import get_logger
 from ..utils.progress_tracker import get_progress_tracker
 
@@ -240,9 +241,7 @@ class EntityResolver:
     @staticmethod
     def _get_entity_id(entity: Any) -> Any:
         """Return an entity ID while supporting dictionary and object inputs."""
-        if isinstance(entity, dict):
-            return entity.get("id") or entity.get("entity_id")
-        return getattr(entity, "id", None) or getattr(entity, "entity_id", None)
+        return get_entity_id(entity)
 
     @staticmethod
     def _get_entity_name(entity: Any) -> Optional[str]:
@@ -279,13 +278,13 @@ class EntityResolver:
         processed_ids = set()
         for op in merge_operations:
             for source_entity in op.source_entities:
-                entity_id = source_entity.get("id") or source_entity.get("entity_id")
-                if entity_id:
+                entity_id = get_entity_id(source_entity)
+                if entity_id is not None:
                     processed_ids.add(entity_id)
 
         for entity in entities:
-            entity_id = entity.get("id") or entity.get("entity_id")
-            if entity_id and entity_id not in processed_ids:
+            entity_id = get_entity_id(entity)
+            if entity_id is not None and entity_id not in processed_ids:
                 merged_entities.append(entity)
 
         self.logger.info(f"Merged to {len(merged_entities)} entities")

--- a/semantica/utils/entity_ids.py
+++ b/semantica/utils/entity_ids.py
@@ -1,0 +1,16 @@
+"""Helpers for reading entity identifiers consistently across the KG pipeline."""
+
+from typing import Any
+
+
+def get_entity_id(entity: Any) -> Any:
+    """Return a truthy identifier from either supported entity ID field.
+
+    The KG pipeline treats empty and otherwise falsy identifiers as missing.
+    Prefer the canonical ``id`` field when it is populated, then fall back to
+    the compatible ``entity_id`` alias.
+    """
+    if isinstance(entity, dict):
+        return entity.get("id") or entity.get("entity_id") or None
+
+    return getattr(entity, "id", None) or getattr(entity, "entity_id", None) or None

--- a/tests/kg/test_entity_pipeline.py
+++ b/tests/kg/test_entity_pipeline.py
@@ -1,9 +1,10 @@
 
 import pytest
-from semantica.utils.types import Entity
 from semantica.kg.graph_builder import GraphBuilder
 from semantica.kg.entity_resolver import EntityResolver
 from semantica.kg.graph_analyzer import GraphAnalyzer
+from semantica.utils.entity_ids import get_entity_id
+from semantica.utils.types import Entity
 
 def test_full_entity_pipeline():
     """
@@ -133,7 +134,9 @@ def test_entity_id_only_merge_remaps_relationship_endpoints():
         }
     )
 
-    merged_alice = next(entity for entity in graph["entities"] if entity["name"] == "Alice")
+    merged_alice = next(
+        entity for entity in graph["entities"] if entity["name"] == "Alice"
+    )
     relationship = graph["relationships"][0]
     entity_ids = {
         entity.get("id") or entity.get("entity_id") for entity in graph["entities"]
@@ -147,6 +150,17 @@ def test_entity_id_only_merge_remaps_relationship_endpoints():
     assert relationship["source"] == "alice:1"
     assert relationship["target"] == "org:1"
     assert {relationship["source"], relationship["target"]} <= entity_ids
+
+
+def test_entity_id_helper_ignores_falsy_identifiers():
+    """ID extraction must match the KG pipeline's falsy-ID contract."""
+    assert get_entity_id({"id": "", "entity_id": "alias:1"}) == "alias:1"
+    assert get_entity_id({"id": 0, "entity_id": "alias:2"}) == "alias:2"
+    assert (
+        get_entity_id({"id": "primary:1", "entity_id": "alias:3"})
+        == "primary:1"
+    )
+    assert get_entity_id({"id": "", "entity_id": 0}) is None
 
 if __name__ == "__main__":
     test_full_entity_pipeline()

--- a/tests/kg/test_entity_pipeline.py
+++ b/tests/kg/test_entity_pipeline.py
@@ -107,6 +107,47 @@ def test_direct_entity_objects_in_analyzer():
     
     print("Direct Entity objects test passed successfully!")
 
+
+def test_entity_id_only_merge_remaps_relationship_endpoints():
+    """Entity aliases must survive merging and relationship remapping."""
+    builder = GraphBuilder(
+        merge_entities=True,
+        entity_resolution_strategy="exact",
+        resolve_conflicts=False,
+    )
+
+    graph = builder.build(
+        {
+            "entities": [
+                {"entity_id": "alice:1", "name": "Alice", "type": "Person"},
+                {"entity_id": "alice:2", "name": " Alice ", "type": "Person"},
+                {"entity_id": "org:1", "name": "Acme", "type": "Organization"},
+            ],
+            "relationships": [
+                {
+                    "source_id": "alice:2",
+                    "target_id": "org:1",
+                    "type": "WORKS_FOR",
+                }
+            ],
+        }
+    )
+
+    merged_alice = next(entity for entity in graph["entities"] if entity["name"] == "Alice")
+    relationship = graph["relationships"][0]
+    entity_ids = {
+        entity.get("id") or entity.get("entity_id") for entity in graph["entities"]
+    }
+
+    assert merged_alice["id"] == "alice:1"
+    assert set(merged_alice["merged_from"]) == {"alice:1", "alice:2"}
+    assert {
+        item["id"] for item in merged_alice["metadata"]["provenance"]["merged_from"]
+    } == {"alice:1", "alice:2"}
+    assert relationship["source"] == "alice:1"
+    assert relationship["target"] == "org:1"
+    assert {relationship["source"], relationship["target"]} <= entity_ids
+
 if __name__ == "__main__":
     test_full_entity_pipeline()
     test_direct_entity_objects_in_analyzer()


### PR DESCRIPTION
## Description

Preserve `entity_id` aliases when duplicate entities are merged so relationship endpoints are remapped to the surviving entity.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues

Closes #1085

## Changes Made

- Use one shared `get_entity_id()` helper across entity resolution and merging.
- Treat empty and other falsy identifiers as missing, matching existing KG behavior.
- Preserve source IDs in `merged_from` and merge provenance.
- Add regression coverage for entity ID aliases, falsy IDs, and relationship remapping.

## Testing

- [x] Tested locally
- [x] Added tests for new functionality
- [ ] Package builds successfully (`python -m build`)

### Test Commands

```bash
pytest -q tests/deduplication tests/kg --ignore=tests/kg/test_node_embeddings.py --ignore=tests/kg/test_enhanced_algorithms_e2e.py --ignore=tests/kg/test_integration_comprehensive.py --ignore=tests/kg/test_provenance_integration.py
```

Result: `520 passed`.

The excluded Node2Vec tests require the existing optional `gensim` dependency. The local package build could not run because the `build` module is not installed.

## Documentation

- [ ] Updated relevant documentation
- [ ] Added code examples if applicable
- [ ] Updated API reference if adding new APIs
- [ ] Updated cookbook if adding new examples
- [x] No documentation changes needed

## Breaking Changes

**Breaking Changes**: No

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] Package builds successfully

## Additional Notes

Focused follow-up to the entity merge and relationship remapping fixes in #978 and #1026.