### PR TITLE
fix(export): escape Turtle string literals

### DIFF
--- a/semantica/export/rdf_exporter.py
+++ b/semantica/export/rdf_exporter.py
@@ -512,10 +512,13 @@ class RDFSerializer:
     @staticmethod
     def _escape_turtle_string(value: Any) -> str:
         """Escape characters that have syntax meaning in Turtle short strings."""
-        return str(value).translate(
-            str.maketrans(
-                {"\\": "\\\\", '"': '\\"', "\n": "\\n", "\r": "\\r", "\t": "\\t"}
-            )
+        return (
+            str(value)
+            .replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
         )
 
     def _reified_relationship_triples(

--- a/semantica/export/rdf_exporter.py
+++ b/semantica/export/rdf_exporter.py
@@ -398,7 +398,7 @@ class RDFSerializer:
             confidence = entity.get("confidence", 1.0)
 
             lines.append(f"<{entity_id}> a <{entity_type}> ;")
-            lines.append(f'    semantica:text "{text}" ;')
+            lines.append(f'    semantica:text "{self._escape_turtle_string(text)}" ;')
             lines.append(f"    semantica:confidence {confidence} .")
             lines.append("")
 
@@ -418,6 +418,15 @@ class RDFSerializer:
 
         return "\n".join(lines)
 
+    @staticmethod
+    def _escape_turtle_string(value: Any) -> str:
+        """Escape characters that have syntax meaning in Turtle short strings."""
+        return str(value).translate(
+            str.maketrans(
+                {"\\": "\\\\", '"': '\\"', "\n": "\\n", "\r": "\\r", "\t": "\\t"}
+            )
+        )
+
     def _owl_time_triples_for_rel(
         self, rel: Dict[str, Any], idx: int, time_axis: str
     ) -> List[str]:
@@ -434,7 +443,7 @@ class RDFSerializer:
         def _is_open(v: Any) -> bool:
             if v is None:
                 return False
-            if hasattr(v, "value"):          # TemporalBound enum
+            if hasattr(v, "value"):  # TemporalBound enum
                 return v.value == _OPEN_SENTINEL
             return str(v).strip().upper() == _OPEN_SENTINEL
 
@@ -466,9 +475,7 @@ class RDFSerializer:
             lines.append(f"    time:hasBeginning <{begin_id}> ;")
 
             if _is_open(until_val):
-                lines.append(
-                    '    semantica:openEndedInterval "true"^^xsd:boolean .'
-                )
+                lines.append('    semantica:openEndedInterval "true"^^xsd:boolean .')
             elif until_val is not None:
                 end_id = f"{rel_base_id}__{axis_name}_end"
                 lines.append(f"    time:hasEnd <{end_id}> .")
@@ -477,7 +484,9 @@ class RDFSerializer:
                     f'    time:inXSDDateTimeStamp "{until_val}"^^xsd:dateTimeStamp .'
                 )
             else:
-                lines[-1] = lines[-1].rstrip(" ;") + " ."  # close interval without hasEnd
+                lines[-1] = (
+                    lines[-1].rstrip(" ;") + " ."
+                )  # close interval without hasEnd
 
             lines.append(f"<{begin_id}> a time:Instant ;")
             lines.append(
@@ -791,8 +800,7 @@ class RDFValidator:
         # Check for required fields
         if "entities" not in rdf_data and "relationships" not in rdf_data:
             warnings.append(
-                "No entities or relationships found in RDF data. "
-                "RDF data may be empty."
+                "No entities or relationships found in RDF data. RDF data may be empty."
             )
 
         # Validate entities

--- a/semantica/export/rdf_exporter.py
+++ b/semantica/export/rdf_exporter.py
@@ -481,7 +481,7 @@ class RDFSerializer:
                 lines.append(f"    time:hasEnd <{end_id}> .")
                 lines.append(f"<{end_id}> a time:Instant ;")
                 lines.append(
-                    f'    time:inXSDDateTimeStamp "{until_val}"^^xsd:dateTimeStamp .'
+                    f'    time:inXSDDateTimeStamp "{self._escape_turtle_string(until_val)}"^^xsd:dateTimeStamp .'
                 )
             else:
                 lines[-1] = (
@@ -490,7 +490,7 @@ class RDFSerializer:
 
             lines.append(f"<{begin_id}> a time:Instant ;")
             lines.append(
-                f'    time:inXSDDateTimeStamp "{from_val}"^^xsd:dateTimeStamp .'
+                f'    time:inXSDDateTimeStamp "{self._escape_turtle_string(from_val)}"^^xsd:dateTimeStamp .'
             )
             lines.append("")
 

--- a/tests/test_export_module.py
+++ b/tests/test_export_module.py
@@ -325,5 +325,19 @@ class TestExportModule(unittest.TestCase):
         method("data", str(output_path))
         self.assertTrue(output_path.exists())
 
+    def test_owl_time_literals_escape_both_boundaries(self):
+        serializer = RDFSerializer()
+        rel = {
+            "id": "r1",
+            "valid_from": '2024-01-01T00:00:00"\\\n',
+            "valid_until": '2024-01-02T00:00:00\t"\\',
+        }
+
+        lines = serializer._owl_time_triples_for_rel(rel, 0, "valid")
+        output = "\n".join(lines)
+
+        self.assertIn('2024-01-01T00:00:00\\"\\\\\\n', output)
+        self.assertIn('2024-01-02T00:00:00\\t\\"\\\\', output)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_export_module.py
+++ b/tests/test_export_module.py
@@ -55,11 +55,19 @@ class TestExportModule(unittest.TestCase):
             data = json.load(f)
             self.assertEqual(len(data['entities']), 2)
             self.assertEqual(len(data['relationships']), 1)
-            
+
         # Test export_entities
         entities_path = Path(self.test_dir) / "entities.json"
         exporter.export_entities(self.entities, str(entities_path))
         self.assertTrue(entities_path.exists())
+
+    def test_turtle_serializer_escapes_literal_syntax(self):
+        turtle = RDFSerializer().serialize_to_turtle({
+            "entities": [{"id": "https://example.org/e1", "type": "Person",
+                          "text": 'He said "hi"\\then\nleft\r'}],
+            "relationships": [],
+        })
+        self.assertIn('semantica:text "He said \\"hi\\"\\\\then\\nleft\\r"', turtle)
 
     def test_export_knowledge_graph_smoke(self):
         from semantica.export.methods import export_knowledge_graph


### PR DESCRIPTION
Fixes #1098
Escape Turtle string literals for backslashes, quotes, and control characters (newline, carriage return, tab). Adds focused regression coverage.