### PR TITLE
fix(docker): use Python 3.13 for gensim compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN npm ci
 COPY explorer/ ./
 RUN mkdir -p /app/semantica && npm run build
 
-FROM python:3.14-slim AS runtime
+FROM python:3.13-slim AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
## Description

Fixes the Docker build failure caused by `gensim` not having a compatible pre-built wheel for the Python 3.14 runtime used by the Explorer image.

The runtime image is changed from `python:3.14-slim` to `python:3.13-slim`, allowing `gensim` to be installed without compiling from source.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues

Closes #1025

## Changes Made

- Changed the Docker runtime from `python:3.14-slim` to `python:3.13-slim`
- Avoided the `gensim` source build that requires `gcc`
- Kept the change limited to the Docker runtime configuration

## Testing

- [x] Tested locally
- [ ] Added tests for new functionality
- [ ] Package builds successfully (`python -m build`)

### Test Commands

```bash
docker compose up --build
docker compose exec explorer python --version
docker compose exec explorer python -c "import gensim; print(gensim.__version__)"
```

### Verification

The original Python 3.14 Docker build was reproduced locally and failed while building `gensim`:

```text
building 'gensim.models.word2vec_inner' extension
gcc ...
error: [Errno 2] No such file or directory: 'gcc'
```

After changing the runtime to Python 3.13:

- Docker image built successfully
- Python version verified as `3.13.15`
- Gensim version verified as `4.4.0`
- Semantica Explorer started successfully
- `/api/health` returned `200 OK`

## Documentation

- [ ] Updated relevant documentation
- [ ] Added code examples if applicable
- [ ] Updated API reference if adding new APIs
- [ ] Updated cookbook if adding new examples
- [x] No documentation changes needed

## Breaking Changes

**Breaking Changes**: No

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Package builds successfully

## Additional Notes

The issue was reproduced with the original Python 3.14 Docker runtime. The failure occurred while building `gensim.models.word2vec_inner` because `gcc` was unavailable in the `python:3.14-slim` image.

Using Python 3.13 avoids the source compilation path and allows the Explorer image to build and run successfully.