### PR TITLE
Write console progress to stderr by default

### DIFF
--- a/semantica/utils/progress_tracker.py
+++ b/semantica/utils/progress_tracker.py
@@ -119,16 +119,27 @@ class ProgressDisplay(ABC):
 
 
 class ConsoleProgressDisplay(ProgressDisplay):
-    """Console progress display with real-time updates."""
+    """Console progress display with real-time updates.
+
+    Progress is diagnostic output, so it defaults to stderr. stdio-based
+    protocols (the MCP server) require stdout to carry exclusively
+    newline-delimited JSON-RPC; any progress bar written there corrupts the
+    response stream. ``SEMANTICA_PROGRESS_STREAM=stdout`` restores the old
+    behavior for terminals that want progress mixed into stdout.
+    """
 
     def __init__(self, use_emoji: bool = True, update_interval: float = 0.1):
         self.use_emoji = use_emoji
-        
-        # Check if stdout supports emojis (especially on Windows)
+
+        self.stream_name = os.getenv("SEMANTICA_PROGRESS_STREAM", "stderr").strip().lower()
+        if self.stream_name not in ("stdout", "stderr"):
+            self.stream_name = "stderr"
+
+        # Check if the output stream supports emojis (especially on Windows)
         if self.use_emoji:
             try:
-                # Try encoding a test emoji with stdout's encoding
-                encoding = getattr(sys.stdout, "encoding", None)
+                # Try encoding a test emoji with the stream's encoding
+                encoding = getattr(self._stream(), "encoding", None)
                 if encoding:
                     "🧠".encode(encoding)
             except (UnicodeEncodeError, LookupError, AttributeError):
@@ -235,16 +246,21 @@ class ConsoleProgressDisplay(ProgressDisplay):
         # Otherwise combine them
         return f"{base_msg}: {message}"
 
+    def _stream(self):
+        """The output stream progress is written to (stderr by default)."""
+        return sys.stdout if self.stream_name == "stdout" else sys.stderr
+
     def _safe_write(self, text: str) -> None:
-        """Safely write text to stdout handling encoding errors."""
+        """Safely write text to the progress stream handling encoding errors."""
+        stream = self._stream()
         try:
-            sys.stdout.write(text)
+            stream.write(text)
         except UnicodeEncodeError:
             # Fallback: encode with replacement and write decoded
             # Use ascii as safe fallback if encoding is unknown or caused error
-            encoding = getattr(sys.stdout, "encoding", None) or "ascii"
+            encoding = getattr(stream, "encoding", None) or "ascii"
             safe_text = text.encode(encoding, errors="replace").decode(encoding)
-            sys.stdout.write(safe_text)
+            stream.write(safe_text)
 
     def update(self, item: ProgressItem) -> None:
         """Update console progress display."""
@@ -279,11 +295,11 @@ class ConsoleProgressDisplay(ProgressDisplay):
                     self._display_item_line(pipeline_item)
                     self._safe_write("\n")
                 
-                sys.stdout.flush()
+                self._stream().flush()
             else:
                 # Original single-item display
                 self._display_item_line(item)
-                sys.stdout.flush()
+                self._stream().flush()
     
     def _display_item_line(self, item: ProgressItem) -> None:
         """Display a single progress item line."""
@@ -445,13 +461,13 @@ class ConsoleProgressDisplay(ProgressDisplay):
                     f"Completed: {completed} | Failed: {failed} | Total Time: {total_time:.2f}s\n"
                 )
             self._safe_write("=" * 80 + "\n")
-            sys.stdout.flush()
+            self._stream().flush()
 
     def clear(self) -> None:
         """Clear console display."""
         with self.lock:
             self._safe_write("\r" + " " * 100 + "\r")
-            sys.stdout.flush()
+            self._stream().flush()
             self.current_lines.clear()
 
 

--- a/tests/utils/test_progress_display_stream.py
+++ b/tests/utils/test_progress_display_stream.py
@@ -1,0 +1,69 @@
+"""ConsoleProgressDisplay must keep stdout clean for stdio protocols (#1134).
+
+The root-level MCP server speaks newline-delimited JSON-RPC over stdout, so
+any progress-bar output written there corrupts the response a strict client
+can no longer parse. Progress is diagnostic output and now defaults to
+stderr, with ``SEMANTICA_PROGRESS_STREAM=stdout`` restoring the old behavior.
+"""
+
+import io
+import sys
+import unittest
+from unittest import mock
+
+from semantica.utils.progress_tracker import ConsoleProgressDisplay, ProgressItem
+
+
+def _drive_update(display: ConsoleProgressDisplay) -> None:
+    item = ProgressItem(
+        module="kg",
+        submodule="Building",
+        status="running",
+        progress_percentage=50.0,
+        message="Building knowledge graph",
+    )
+    display.update(item)
+
+
+class ConsoleProgressDisplayStreamTest(unittest.TestCase):
+    def _run_with_captured_streams(self, env: dict):
+        stdout, stderr = io.StringIO(), io.StringIO()
+        with mock.patch.dict("os.environ", env, clear=False):
+            display = ConsoleProgressDisplay(update_interval=0.0)
+            # Pin last_update so _should_update lets the update through.
+            display.last_update = -1.0
+            with mock.patch("sys.stdout", stdout), mock.patch("sys.stderr", stderr):
+                _drive_update(display)
+        return stdout.getvalue(), stderr.getvalue()
+
+    def test_progress_defaults_to_stderr_and_leaves_stdout_clean(self):
+        stdout_text, stderr_text = self._run_with_captured_streams(
+            {"SEMANTICA_PROGRESS_STREAM": ""}
+        )
+
+        self.assertEqual(
+            stdout_text,
+            "",
+            "stdout must carry no progress output: stdio protocols require it pristine",
+        )
+        self.assertIn("Building", stderr_text)
+
+    def test_explicit_stdout_stream_restores_old_behavior(self):
+        stdout_text, stderr_text = self._run_with_captured_streams(
+            {"SEMANTICA_PROGRESS_STREAM": "stdout"}
+        )
+
+        self.assertIn("Building", stdout_text)
+        self.assertEqual(stderr_text, "")
+
+    def test_invalid_stream_value_falls_back_to_stderr(self):
+        stdout_text, stderr_text = self._run_with_captured_streams(
+            {"SEMANTICA_PROGRESS_STREAM": "tcp://nowhere"}
+        )
+
+        self.assertEqual(stdout_text, "")
+        self.assertIn("Building", stderr_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses point 1 of #1134 (the protocol-level bug; the env-var persistence and README fixes are separate points).

## Root cause

`ConsoleProgressDisplay` wrote the progress bar to `sys.stdout` unconditionally. stdio MCP requires stdout to carry **exclusively** newline-delimited JSON-RPC — the repo's own `mcp/README.md` states this — so any tool whose code path emits progress prepends the bar to the JSON-RPC body on the same line, and a strict client cannot parse the response to `tools/call`. The issue's reproduction shows exactly that, with stderr already sent to `/dev/null` (ruling out stderr bleed).

## Fix

Progress is diagnostic output; stderr is the correct stream for it regardless of MCP. `ConsoleProgressDisplay` now defaults to `sys.stderr`:

- `SEMANTICA_PROGRESS_STREAM=stdout` restores the previous behavior for terminal users who want progress in stdout;
- an invalid value falls back to stderr;
- the emoji capability probe now checks the **chosen** stream's encoding (it previously probed stdout while writing to stdout);
- all write and flush sites route through the stream (`_stream()` / `_safe_write`), so the encoding-error fallback uses the right stream too.

`SEMANTICA_DISABLE_PROGRESS` still disables the display entirely, unchanged.

## Tests

`tests/utils/test_progress_display_stream.py` — captures both streams and drives a real `update()`:

- default: stdout stays byte-for-byte clean (the MCP-corruption assertion) and the progress renders on stderr;
- `SEMANTICA_PROGRESS_STREAM=stdout`: old behavior restored, stderr clean;
- invalid stream value: falls back to stderr.

Differential: the two default/stderr tests fail on `main` (progress lands on stdout), the explicit-stdout test passes on both. The full-suite collection errors on a clean checkout are the pre-existing missing-`fastapi` explorer imports tracked separately in #1167.