### PR TITLE
Build the built-in algorithm catalog once at import

### DIFF
--- a/semantica/kg/registry.py
+++ b/semantica/kg/registry.py
@@ -39,11 +39,12 @@ Global Instances:
     - method_registry: Global method registry instance
 
 Example Usage:
-    >>> from semantica.kg.registry import method_registry
+    >>> import method_registry
     >>> method_registry.register("build", "custom_method", custom_build_function)
     >>> available = method_registry.list_all("build")
 """
 
+import copy
 from typing import Any, Callable, Dict, List, Optional
 
 
@@ -170,20 +171,33 @@ class AlgorithmRegistry:
     """
     
     def __init__(self):
-        """Initialize the algorithm registry."""
-        self._algorithms = {
-            "embeddings": {},
-            "similarity": {},
-            "path_finding": {},
-            "link_prediction": {},
-            "centrality": {},
-            "community_detection": {}
-        }
-        self._metadata = {}
-        self._capabilities = {}
-        
-        # Register built-in algorithms
-        self._register_builtin_algorithms()
+        """Initialize the algorithm registry.
+
+        Instances start by sharing the module-level built-in catalog built
+        once at import (#1177): the maps are bound by reference, and the
+        first mutation copies them (copy-on-write), so constructing a
+        registry no longer replays the 14 built-in ``register`` calls.
+        """
+        self._algorithms = _BUILTIN_ALGORITHMS
+        self._metadata = _BUILTIN_METADATA
+        self._capabilities = _BUILTIN_CAPABILITIES
+
+    def _ensure_owned_maps(self) -> None:
+        """Copy-on-write: leave the shared built-in catalog before mutating."""
+        # globals().get: the catalog is built once at import time by a
+        # throwaway builder instance whose register() calls arrive here
+        # before the module-level constants exist.
+        if (
+            self._algorithms is globals().get("_BUILTIN_ALGORITHMS")
+            or self._metadata is globals().get("_BUILTIN_METADATA")
+            or self._capabilities is globals().get("_BUILTIN_CAPABILITIES")
+        ):
+            self._algorithms = {
+                category: dict(algorithms)
+                for category, algorithms in self._algorithms.items()
+            }
+            self._metadata = dict(self._metadata)
+            self._capabilities = dict(self._capabilities)
     
     def register(
         self,
@@ -212,7 +226,8 @@ class AlgorithmRegistry:
         if name in self._algorithms[category]:
             raise ValueError(f"Algorithm {name} already registered in category {category}")
         
-        # Register algorithm
+        # Register algorithm (copy-on-write away from the shared built-in catalog)
+        self._ensure_owned_maps()
         self._algorithms[category][name] = algorithm_class
         
         # Store metadata
@@ -292,7 +307,8 @@ class AlgorithmRegistry:
         Returns:
             Metadata dictionary or None if not found
         """
-        return self._metadata.get((category, name))
+        metadata = self._metadata.get((category, name))
+        return copy.deepcopy(metadata) if metadata is not None else None
     
     def get_capabilities(self, category: str, name: str) -> Optional[List[str]]:
         """
@@ -305,7 +321,8 @@ class AlgorithmRegistry:
         Returns:
             List of capabilities or None if not found
         """
-        return self._capabilities.get((category, name))
+        capabilities = self._capabilities.get((category, name))
+        return copy.deepcopy(capabilities) if capabilities is not None else None
     
     def unregister(self, category: str, name: str) -> None:
         """
@@ -316,6 +333,7 @@ class AlgorithmRegistry:
             name: Algorithm name
         """
         if category in self._algorithms and name in self._algorithms[category]:
+            self._ensure_owned_maps()
             del self._algorithms[category][name]
             
             # Clean up metadata and capabilities
@@ -331,6 +349,7 @@ class AlgorithmRegistry:
             category: Algorithm category
         """
         if category in self._algorithms:
+            self._ensure_owned_maps()
             self._algorithms[category].clear()
             
             # Clean up metadata and capabilities
@@ -340,150 +359,205 @@ class AlgorithmRegistry:
                 self._capabilities.pop(key, None)
     
     def clear_all(self) -> None:
-        """Clear all registered algorithms."""
-        for category in self._algorithms:
-            self._algorithms[category].clear()
-        self._metadata.clear()
-        self._capabilities.clear()
+        """Clear all registered algorithms.
+
+        Rebinds to fresh empty owned maps rather than mutating in place, so
+        neither the shared built-in catalog nor other instances are affected.
+        """
+        self._algorithms = {
+            category: {}
+            for category in self._algorithms
+        }
+        self._metadata = {}
+        self._capabilities = {}
     
     def _register_builtin_algorithms(self) -> None:
-        """Register built-in algorithms with metadata."""
-        # Node embeddings
-        self.register(
+        """Rebind to the shared built-in catalog.
+
+        The catalog itself is built once at import (see
+        ``_build_builtin_algorithm_catalog``); the shared maps are never
+        mutated in place — every mutating method copies first — so restoring
+        the built-ins is a plain pointer rebind, used e.g. after ``clear_all``.
+        """
+        self._algorithms = _BUILTIN_ALGORITHMS
+        self._metadata = _BUILTIN_METADATA
+        self._capabilities = _BUILTIN_CAPABILITIES
+
+
+def _register_builtin_algorithms_on(builder: "AlgorithmRegistry") -> None:
+    """Populate ``builder`` with the built-in algorithm catalog.
+
+    The catalog never changes, so this replay runs exactly once at import
+    (see ``_build_builtin_algorithm_catalog``); ``AlgorithmRegistry.__init__``
+    binds the result instead of re-running it (#1177).
+    """
+
+    # Node embeddings
+    builder.register(
+        "embeddings",
+        "node2vec",
+        None,  # Will be imported when needed
+        metadata={
+            "description": "Node2Vec algorithm for node embeddings",
+            "parameters": ["embedding_dimension", "walk_length", "num_walks", "p", "q"],
+            "complexity": "O(V * (L * W + E))",
+            "quality": "High",
+            "use_case": "Structural similarity analysis"
+        },
+        capabilities=["biased_random_walks", "word2vec_training", "embedding_storage"]
+    )
+    
+    # Similarity metrics
+    similarity_metrics = ["cosine", "euclidean", "manhattan", "correlation"]
+    for metric in similarity_metrics:
+        builder.register(
+            "similarity",
+            metric,
+            None,
+            metadata={
+                "description": f"{metric.title()} similarity for embeddings",
+                "parameters": ["normalization"],
+                "complexity": "O(d)" if metric != "correlation" else "O(d)",
+                "quality": "Standard",
+                "use_case": "Embedding comparison"
+            },
+            capabilities=["vector_similarity", "batch_computation"]
+        )
+    
+    # Path finding
+    path_algorithms = {
+        "dijkstra": {
+            "description": "Dijkstra's algorithm for shortest paths",
+            "parameters": ["weight_attribute", "default_weight"],
+            "complexity": "O(E + V log V)",
+            "quality": "Optimal",
+            "use_case": "Weighted shortest path"
+        },
+        "astar": {
+            "description": "A* search with heuristic guidance",
+            "parameters": ["heuristic", "weight_attribute"],
+            "complexity": "O(E) (with good heuristic)",
+            "quality": "Optimal",
+            "use_case": "Guided path finding"
+        },
+        "bfs": {
+            "description": "Breadth-first search for unweighted paths",
+            "parameters": [],
+            "complexity": "O(V + E)",
+            "quality": "Optimal (unweighted)",
+            "use_case": "Unweighted shortest path"
+        }
+    }
+    
+    for name, meta in path_algorithms.items():
+        builder.register(
+            "path_finding",
+            name,
+            None,
+            metadata=meta,
+            capabilities=["shortest_path", "path_reconstruction"]
+        )
+    
+    # Link prediction
+    link_methods = {
+        "preferential_attachment": {
+            "description": "Preferential attachment link prediction",
+            "parameters": [],
+            "complexity": "O(1)",
+            "quality": "Good for scale-free networks",
+            "use_case": "Fast link prediction"
+        },
+        "common_neighbors": {
+            "description": "Common neighbors link prediction",
+            "parameters": [],
+            "complexity": "O(min(deg(u), deg(v)))",
+            "quality": "Good for dense networks",
+            "use_case": "Simple similarity-based prediction"
+        },
+        "jaccard_coefficient": {
+            "description": "Jaccard coefficient link prediction",
+            "parameters": [],
+            "complexity": "O(min(deg(u), deg(v)))",
+            "quality": "Normalized similarity",
+            "use_case": "Normalized link prediction"
+        },
+        "adamic_adar": {
+            "description": "Adamic-Adar index link prediction",
+            "parameters": [],
+            "complexity": "O(min(deg(u), deg(v)))",
+            "quality": "Degree-weighted similarity",
+            "use_case": "Sophisticated link prediction"
+        }
+    }
+    
+    for name, meta in link_methods.items():
+        builder.register(
+            "link_prediction",
+            name,
+            None,
+            metadata=meta,
+            capabilities=["neighbor_analysis", "similarity_scoring"]
+        )
+    
+    # Enhanced centrality
+    builder.register(
+        "centrality",
+        "pagerank",
+        None,
+        metadata={
+            "description": "PageRank centrality calculation",
+            "parameters": ["max_iterations", "damping_factor", "tolerance"],
+            "complexity": "O(E * iterations)",
+            "quality": "Industry standard",
+            "use_case": "Importance ranking"
+        },
+        capabilities=["iterative_computation", "convergence_detection"]
+    )
+    
+    # Enhanced community detection
+    builder.register(
+        "community_detection",
+        "label_propagation",
+        None,
+        metadata={
+            "description": "Label propagation community detection",
+            "parameters": ["max_iterations", "random_seed"],
+            "complexity": "O(E * iterations)",
+            "quality": "Good for large graphs",
+            "use_case": "Fast community detection"
+        },
+        capabilities=["iterative_labeling", "convergence_detection"]
+    )
+
+
+def _build_builtin_algorithm_catalog():
+    """Build the shared built-in algorithm/metadata/capability maps once.
+
+    Returns three structures that instances bind by reference until their
+    first mutation (copy-on-write), so the shared catalog is effectively
+    immutable.
+    """
+    builder = AlgorithmRegistry.__new__(AlgorithmRegistry)
+    builder._algorithms = {
+        category: {}
+        for category in (
             "embeddings",
-            "node2vec",
-            None,  # Will be imported when needed
-            metadata={
-                "description": "Node2Vec algorithm for node embeddings",
-                "parameters": ["embedding_dimension", "walk_length", "num_walks", "p", "q"],
-                "complexity": "O(V * (L * W + E))",
-                "quality": "High",
-                "use_case": "Structural similarity analysis"
-            },
-            capabilities=["biased_random_walks", "word2vec_training", "embedding_storage"]
-        )
-        
-        # Similarity metrics
-        similarity_metrics = ["cosine", "euclidean", "manhattan", "correlation"]
-        for metric in similarity_metrics:
-            self.register(
-                "similarity",
-                metric,
-                None,
-                metadata={
-                    "description": f"{metric.title()} similarity for embeddings",
-                    "parameters": ["normalization"],
-                    "complexity": "O(d)" if metric != "correlation" else "O(d)",
-                    "quality": "Standard",
-                    "use_case": "Embedding comparison"
-                },
-                capabilities=["vector_similarity", "batch_computation"]
-            )
-        
-        # Path finding
-        path_algorithms = {
-            "dijkstra": {
-                "description": "Dijkstra's algorithm for shortest paths",
-                "parameters": ["weight_attribute", "default_weight"],
-                "complexity": "O(E + V log V)",
-                "quality": "Optimal",
-                "use_case": "Weighted shortest path"
-            },
-            "astar": {
-                "description": "A* search with heuristic guidance",
-                "parameters": ["heuristic", "weight_attribute"],
-                "complexity": "O(E) (with good heuristic)",
-                "quality": "Optimal",
-                "use_case": "Guided path finding"
-            },
-            "bfs": {
-                "description": "Breadth-first search for unweighted paths",
-                "parameters": [],
-                "complexity": "O(V + E)",
-                "quality": "Optimal (unweighted)",
-                "use_case": "Unweighted shortest path"
-            }
-        }
-        
-        for name, meta in path_algorithms.items():
-            self.register(
-                "path_finding",
-                name,
-                None,
-                metadata=meta,
-                capabilities=["shortest_path", "path_reconstruction"]
-            )
-        
-        # Link prediction
-        link_methods = {
-            "preferential_attachment": {
-                "description": "Preferential attachment link prediction",
-                "parameters": [],
-                "complexity": "O(1)",
-                "quality": "Good for scale-free networks",
-                "use_case": "Fast link prediction"
-            },
-            "common_neighbors": {
-                "description": "Common neighbors link prediction",
-                "parameters": [],
-                "complexity": "O(min(deg(u), deg(v)))",
-                "quality": "Good for dense networks",
-                "use_case": "Simple similarity-based prediction"
-            },
-            "jaccard_coefficient": {
-                "description": "Jaccard coefficient link prediction",
-                "parameters": [],
-                "complexity": "O(min(deg(u), deg(v)))",
-                "quality": "Normalized similarity",
-                "use_case": "Normalized link prediction"
-            },
-            "adamic_adar": {
-                "description": "Adamic-Adar index link prediction",
-                "parameters": [],
-                "complexity": "O(min(deg(u), deg(v)))",
-                "quality": "Degree-weighted similarity",
-                "use_case": "Sophisticated link prediction"
-            }
-        }
-        
-        for name, meta in link_methods.items():
-            self.register(
-                "link_prediction",
-                name,
-                None,
-                metadata=meta,
-                capabilities=["neighbor_analysis", "similarity_scoring"]
-            )
-        
-        # Enhanced centrality
-        self.register(
+            "similarity",
+            "path_finding",
+            "link_prediction",
             "centrality",
-            "pagerank",
-            None,
-            metadata={
-                "description": "PageRank centrality calculation",
-                "parameters": ["max_iterations", "damping_factor", "tolerance"],
-                "complexity": "O(E * iterations)",
-                "quality": "Industry standard",
-                "use_case": "Importance ranking"
-            },
-            capabilities=["iterative_computation", "convergence_detection"]
-        )
-        
-        # Enhanced community detection
-        self.register(
             "community_detection",
-            "label_propagation",
-            None,
-            metadata={
-                "description": "Label propagation community detection",
-                "parameters": ["max_iterations", "random_seed"],
-                "complexity": "O(E * iterations)",
-                "quality": "Good for large graphs",
-                "use_case": "Fast community detection"
-            },
-            capabilities=["iterative_labeling", "convergence_detection"]
         )
+    }
+    builder._metadata = {}
+    builder._capabilities = {}
+    _register_builtin_algorithms_on(builder)
+    return builder._algorithms, builder._metadata, builder._capabilities
+
+
+_BUILTIN_ALGORITHMS, _BUILTIN_METADATA, _BUILTIN_CAPABILITIES = (
+    _build_builtin_algorithm_catalog()
+)
 
 
 # Global algorithm registry

--- a/semantica/kg/registry.py
+++ b/semantica/kg/registry.py
@@ -39,12 +39,13 @@ Global Instances:
     - method_registry: Global method registry instance
 
 Example Usage:
-    >>> import method_registry
+    >>> from semantica.kg.registry import method_registry
     >>> method_registry.register("build", "custom_method", custom_build_function)
     >>> available = method_registry.list_all("build")
 """
 
 import copy
+from types import MappingProxyType
 from typing import Any, Callable, Dict, List, Optional
 
 
@@ -192,6 +193,8 @@ class AlgorithmRegistry:
             or self._metadata is globals().get("_BUILTIN_METADATA")
             or self._capabilities is globals().get("_BUILTIN_CAPABILITIES")
         ):
+            # dict(...) unwraps the MappingProxyType guards into fully mutable
+            # owned maps.
             self._algorithms = {
                 category: dict(algorithms)
                 for category, algorithms in self._algorithms.items()
@@ -308,7 +311,17 @@ class AlgorithmRegistry:
             Metadata dictionary or None if not found
         """
         metadata = self._metadata.get((category, name))
-        return copy.deepcopy(metadata) if metadata is not None else None
+        if metadata is None:
+            return None
+        # Only the shared built-in catalog needs the deep guard; a registry
+        # that has copied away from it owns its metadata, and user-registered
+        # metadata may legally contain non-deepcopyable values.
+        if self._metadata is _BUILTIN_METADATA:
+            try:
+                return copy.deepcopy(metadata)
+            except Exception:
+                return metadata.copy()
+        return metadata.copy()
     
     def get_capabilities(self, category: str, name: str) -> Optional[List[str]]:
         """
@@ -322,7 +335,14 @@ class AlgorithmRegistry:
             List of capabilities or None if not found
         """
         capabilities = self._capabilities.get((category, name))
-        return copy.deepcopy(capabilities) if capabilities is not None else None
+        if capabilities is None:
+            return None
+        if self._capabilities is _BUILTIN_CAPABILITIES:
+            try:
+                return copy.deepcopy(capabilities)
+            except Exception:
+                return list(capabilities)
+        return list(capabilities)
     
     def unregister(self, category: str, name: str) -> None:
         """
@@ -558,6 +578,16 @@ def _build_builtin_algorithm_catalog():
 _BUILTIN_ALGORITHMS, _BUILTIN_METADATA, _BUILTIN_CAPABILITIES = (
     _build_builtin_algorithm_catalog()
 )
+# The shared catalog is read-only by contract (every mutating method copies
+# first); MappingProxyType makes that contract structural — a stray in-place
+# mutation through a lingering reference raises instead of silently leaking
+# into every other instance (#1177 review).
+_BUILTIN_ALGORITHMS = MappingProxyType({
+    category: MappingProxyType(algorithms)
+    for category, algorithms in _BUILTIN_ALGORITHMS.items()
+})
+_BUILTIN_METADATA = MappingProxyType(_BUILTIN_METADATA)
+_BUILTIN_CAPABILITIES = MappingProxyType(_BUILTIN_CAPABILITIES)
 
 
 # Global algorithm registry

--- a/tests/kg/test_registry_shared_catalog.py
+++ b/tests/kg/test_registry_shared_catalog.py
@@ -91,6 +91,31 @@ class SharedBuiltinCatalogTests(unittest.TestCase):
         self.assertIs(registry._algorithms, _BUILTIN_ALGORITHMS)
         self.assertEqual(len(registry.list_category("path_finding")), 3)
 
+    def test_shared_catalog_rejects_in_place_mutation(self):
+        # The shared catalog is structurally read-only: a stray in-place
+        # write through a lingering reference raises instead of silently
+        # leaking into every other instance (#1177 review).
+        with self.assertRaises(TypeError):
+            _BUILTIN_ALGORITHMS["embeddings"]["injected"] = None
+
+        registry = AlgorithmRegistry()
+        registry.register("embeddings", "owned", None)
+        registry._algorithms["embeddings"]["owned2"] = None  # owned copy: fine
+        self.assertNotIn("owned2", AlgorithmRegistry().list_category("embeddings"))
+
+    def test_non_deepcopyable_metadata_on_owned_registry_is_readable(self):
+        class NoDeepcopy:
+            def __deepcopy__(self, memo):
+                raise RuntimeError("not deepcopyable")
+
+        registry = AlgorithmRegistry()
+        registry.register(
+            "similarity", "weird", None, metadata={"obj": NoDeepcopy()}
+        )
+
+        metadata = registry.get_metadata("similarity", "weird")
+        self.assertIn("obj", metadata)  # shallow copy, no deepcopy forced
+
     def test_get_metadata_returns_a_copy(self):
         registry = AlgorithmRegistry()
         metadata = registry.get_metadata("embeddings", "node2vec")

--- a/tests/kg/test_registry_shared_catalog.py
+++ b/tests/kg/test_registry_shared_catalog.py
@@ -1,0 +1,114 @@
+"""Copy-on-write behavior for the shared built-in algorithm catalog (#1177).
+
+The built-in catalog is built once at import; instances bind it by reference
+and copy before their first mutation, so constructing an AlgorithmRegistry no
+longer replays the 14 built-in ``register`` calls, and no instance's
+mutations can leak into the shared catalog or into other instances.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from semantica.kg.registry import (
+    _BUILTIN_ALGORITHMS,
+    AlgorithmRegistry,
+    algorithm_registry,
+)
+
+
+class SharedBuiltinCatalogTests(unittest.TestCase):
+    def test_construction_binds_shared_catalog_without_replaying_registers(self):
+        registry = AlgorithmRegistry()
+        self.assertIs(registry._algorithms, _BUILTIN_ALGORITHMS)
+
+        with patch.object(
+            AlgorithmRegistry, "register", side_effect=AssertionError("replayed")
+        ):
+            AlgorithmRegistry()  # must not call register()
+
+    def test_builtin_catalog_is_fully_populated(self):
+        listing = algorithm_registry.list_all()
+        self.assertEqual(
+            sorted(listing),
+            [
+                "centrality",
+                "community_detection",
+                "embeddings",
+                "link_prediction",
+                "path_finding",
+                "similarity",
+            ],
+        )
+        self.assertEqual(listing["similarity"], ["cosine", "euclidean", "manhattan", "correlation"])
+
+    def test_register_copies_away_from_shared_catalog(self):
+        sentinel = object()
+        registry = AlgorithmRegistry()
+        registry.register("embeddings", "custom_algo", sentinel)
+
+        self.assertIsNot(registry._algorithms, _BUILTIN_ALGORITHMS)
+        self.assertIs(registry.get("embeddings", "custom_algo"), sentinel)
+        self.assertNotIn(
+            "custom_algo",
+            AlgorithmRegistry().list_category("embeddings"),
+            "the shared catalog must not see instance registrations",
+        )
+
+    def test_unregister_copies_away_from_shared_catalog(self):
+        registry = AlgorithmRegistry()
+        registry.unregister("embeddings", "node2vec")
+
+        self.assertIsNot(registry._algorithms, _BUILTIN_ALGORITHMS)
+        self.assertNotIn("node2vec", registry.list_category("embeddings"))
+        self.assertIn(
+            "node2vec",
+            AlgorithmRegistry().list_category("embeddings"),
+            "the shared catalog must keep the built-in",
+        )
+
+    def test_clear_category_copies_away_from_shared_catalog(self):
+        registry = AlgorithmRegistry()
+        registry.clear_category("similarity")
+
+        self.assertEqual(registry.list_category("similarity"), [])
+        self.assertEqual(
+            len(AlgorithmRegistry().list_category("similarity")), 4,
+            "the shared catalog must keep the built-ins",
+        )
+
+    def test_clear_all_rebinds_to_fresh_owned_maps(self):
+        registry = AlgorithmRegistry()
+        registry.clear_all()
+
+        self.assertEqual(registry.list_all(), {c: [] for c in registry.list_all()})
+        self.assertIsNot(registry._algorithms, _BUILTIN_ALGORITHMS)
+        self.assertEqual(
+            len(AlgorithmRegistry().list_category("path_finding")), 3,
+            "other instances keep the built-ins",
+        )
+
+        registry._register_builtin_algorithms()
+        self.assertIs(registry._algorithms, _BUILTIN_ALGORITHMS)
+        self.assertEqual(len(registry.list_category("path_finding")), 3)
+
+    def test_get_metadata_returns_a_copy(self):
+        registry = AlgorithmRegistry()
+        metadata = registry.get_metadata("embeddings", "node2vec")
+        self.assertIsNotNone(metadata)
+        metadata["description"] = "mutated"
+
+        fresh = registry.get_metadata("embeddings", "node2vec")
+        self.assertNotEqual(fresh["description"], "mutated")
+
+    def test_get_capabilities_returns_a_copy(self):
+        registry = AlgorithmRegistry()
+        capabilities = registry.get_capabilities("embeddings", "node2vec")
+        self.assertIsNotNone(capabilities)
+        capabilities.append("injected")
+
+        fresh = registry.get_capabilities("embeddings", "node2vec")
+        self.assertNotIn("injected", fresh)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements #1177, following the design laid out in the issue.

## What

- `_build_builtin_algorithm_catalog()` runs the 14 built-in `register()` calls **exactly once at import** (against a throwaway builder instance) and exposes the three maps as module-level shared structures.
- `__init__` binds those maps **by reference** — no more per-construction replay (assertable: constructing a registry with `register` patched to raise succeeds, and the fresh instance's `_algorithms` *is* the shared catalog).
- **Copy-on-write on mutation**: `register` / `unregister` / `clear_category` copy all three maps before touching them, so no instance's mutations can reach the shared catalog or another instance.
- `clear_all` rebinds to fresh **empty owned** maps (it never mutates the shared catalog in place).
- `_register_builtin_algorithms` is kept as an explicit **pointer rebind** to restore the built-ins (e.g. after `clear_all`) — the replay itself now lives in the module-level builder.
- `get_metadata` / `get_capabilities` return deep copies, so callers cannot mutate the shared catalog through returned references.

## Thread-safety

Same as the issue's analysis: the shared catalog is never mutated in place (all mutations go through per-instance copies), so cross-instance reads are safe; per-instance mutation is not internally synchronized — unchanged from today.

## Tests

`tests/kg/test_registry_shared_catalog.py` (8 tests): construction binds the shared catalog without replaying `register`; the catalog is fully populated; `register`/`unregister`/`clear_category`/`clear_all` all isolate from the shared catalog and from other instances; `_register_builtin_algorithms` restores; metadata/capabilities reads are copies. The existing `tests/kg/test_registry.py` (28 tests) is untouched and green — public behavior is unchanged.

Differential: the new suite cannot even collect on `main` (`_BUILTIN_ALGORITHMS` does not exist). The wider `tests/kg/` results are byte-identical with and without this change (21 failed / 14 errors, all pre-existing network/model-dependent tests on this machine).