### PR TITLE
fix(tests): clear CodeQL false-positive on URL substring check (#4001)

### DIFF
--- a/tests/export/test_jsonld_default_graph.py
+++ b/tests/export/test_jsonld_default_graph.py
@@ -160,7 +160,7 @@ def test_a_url_valued_context_is_not_thrown_away(tmp_path):
     context = json.loads(path.read_text())["@context"]
 
     flattened = context if isinstance(context, list) else [context]
-    assert "https://schema.org/" in flattened, (
+    assert any(entry == "https://schema.org/" for entry in flattened), (
         "the caller's context was replaced by Semantica's defaults, "
         "which silently changes how every term expands"
     )


### PR DESCRIPTION
## Summary
- CodeQL alert #4001 (`py/incomplete-url-substring-sanitization`) flagged `tests/export/test_jsonld_default_graph.py:163`, an `"https://schema.org/" in flattened` check.
- This is a false positive: `flattened` is always a `list` (guaranteed by the ternary on the line above), so the check is exact list-membership, not a substring test on an untrusted URL. There is no sanitization, redirect, or SSRF path involved — it's a test assertion over a JSON-LD `@context` value.
- CodeQL's heuristic pattern-matches on the shape `"url-ish literal" in x` regardless of whether `x` is a string or a list, which is what triggered it here.
- Rewrote the check as `any(entry == "https://schema.org/" for entry in flattened)` — same behavior, but unambiguous to both readers and the scanner.

## Test plan
- [x] `pytest tests/export/test_jsonld_default_graph.py -q` — 13 passed