### PR TITLE
fix(context): accept analyzer vocabulary in causal edges

### DIFF
--- a/semantica/context/context_graph.py
+++ b/semantica/context/context_graph.py
@@ -2764,8 +2764,11 @@ class ContextGraph:
         """
         # Normalize so callers may use either vocabulary's spelling
         # ("causes" from CausalChainAnalyzer, or "CAUSED" from this module's
-        # canonical constant); the stored form is always canonical.
-        relationship_type = _CAUSAL_EDGE_ALIASES.get(relationship_type.upper())
+        # canonical constant); the stored form is always canonical. Invalid
+        # inputs keep raising ValueError rather than AttributeError.
+        if not isinstance(relationship_type, str):
+            raise ValueError(f"Relationship type must be one of: {_CAUSAL_EDGE_TYPES}")
+        relationship_type = _CAUSAL_EDGE_ALIASES.get(relationship_type.strip().upper())
         if relationship_type is None:
             raise ValueError(f"Relationship type must be one of: {_CAUSAL_EDGE_TYPES}")
         

--- a/semantica/context/context_graph.py
+++ b/semantica/context/context_graph.py
@@ -2889,10 +2889,13 @@ class ContextGraph:
         Returns:
             List of precedent decisions
         """
-        # Find decisions connected via PRECEDENT_FOR relationships
+        # Find decisions connected via PRECEDENT_FOR relationships, accepting
+        # the analyzer vocabulary's "precedes" spelling as well (issue #1184).
         precedent_ids = []
         for edge in self.edges:
-            if edge.target_id == decision_id and edge.edge_type == "PRECEDENT_FOR":
+            if edge.target_id == decision_id and edge.edge_type.upper() in {
+                "PRECEDENT_FOR", "PRECEDES",
+            }:
                 precedent_ids.append(edge.source_id)
         
         # Convert to Decision objects
@@ -3453,8 +3456,13 @@ class ContextGraph:
 
         # Explicit causal relationships recorded via add_causal_relationship() are
         # ground truth and always count as direct influence, in either direction.
-        for edge_type in _CAUSAL_EDGE_TYPES:
-            for edge in self.edge_type_index.get(edge_type, []):
+        # The index is keyed by the raw edge_type string ("causes" and "CAUSED"
+        # are separate keys), so filter by normalized type instead of iterating
+        # a fixed spelling list.
+        for edge_type, edges in self.edge_type_index.items():
+            if edge_type.upper() not in _CAUSAL_TRAVERSAL_TYPES:
+                continue
+            for edge in edges:
                 if edge.source_id == decision_id and edge.target_id in self._decisions:
                     direct_influence.add(edge.target_id)
                 elif edge.target_id == decision_id and edge.source_id in self._decisions:
@@ -3600,8 +3608,12 @@ class ContextGraph:
             # record_decision() (e.g. a graph restored via from_dict), so only
             # causes with a known decision record are kept.
             incoming_causal_edges = defaultdict(list)
-            for edge_type in _CAUSAL_EDGE_TYPES:
-                for edge in self.edge_type_index.get(edge_type, []):
+            # The index is keyed by the raw edge_type string ("causes" and
+            # "CAUSED" are separate keys), so filter by normalized type.
+            for edge_type, edges in self.edge_type_index.items():
+                if edge_type.upper() not in _CAUSAL_TRAVERSAL_TYPES:
+                    continue
+                for edge in edges:
                     if edge.source_id in self._decisions:
                         incoming_causal_edges[edge.target_id].append(edge)
 

--- a/semantica/context/context_graph.py
+++ b/semantica/context/context_graph.py
@@ -438,6 +438,23 @@ _ATTRS_MISSING = object()
 #: entities and timestamps.
 _CAUSAL_EDGE_TYPES = ("CAUSED", "INFLUENCED", "PRECEDENT_FOR")
 
+# Causal edges circulate under two vocabularies: this module's canonical
+# spellings above, and the present-tense spellings CausalChainAnalyzer also
+# accepts ("causes", "influences", "leads_to", "supports"). The present-tense
+# forms normalize onto the canonical types for storage; traversal accepts
+# both vocabularies so an edge recorded either way is never invisible.
+_CAUSAL_EDGE_ALIASES = {
+    "CAUSES": "CAUSED",
+    "CAUSED": "CAUSED",
+    "INFLUENCES": "INFLUENCED",
+    "INFLUENCED": "INFLUENCED",
+    "PRECEDES": "PRECEDENT_FOR",
+    "PRECEDENT_FOR": "PRECEDENT_FOR",
+}
+_CAUSAL_TRAVERSAL_TYPES = frozenset(_CAUSAL_EDGE_ALIASES) | {
+    "LEADS_TO", "LEAD_TO", "SUPPORTS", "SUPPORT",
+}
+
 
 class ContextGraph:
     """
@@ -2745,9 +2762,12 @@ class ContextGraph:
             target_decision_id: Target decision ID
             relationship_type: Type of relationship (CAUSED, INFLUENCED, PRECEDENT_FOR)
         """
-        valid_types = ["CAUSED", "INFLUENCED", "PRECEDENT_FOR"]
-        if relationship_type not in valid_types:
-            raise ValueError(f"Relationship type must be one of: {valid_types}")
+        # Normalize so callers may use either vocabulary's spelling
+        # ("causes" from CausalChainAnalyzer, or "CAUSED" from this module's
+        # canonical constant); the stored form is always canonical.
+        relationship_type = _CAUSAL_EDGE_ALIASES.get(relationship_type.upper())
+        if relationship_type is None:
+            raise ValueError(f"Relationship type must be one of: {_CAUSAL_EDGE_TYPES}")
         
         # Check if decisions exist - if not, skip adding relationship
         if source_decision_id not in self.nodes or target_decision_id not in self.nodes:
@@ -2839,11 +2859,11 @@ class ContextGraph:
             # Find connected decisions
             for edge in self.edges:
                 if direction == "upstream":
-                    if edge.target_id == current_id and edge.edge_type in ["CAUSED", "INFLUENCED", "PRECEDENT_FOR"]:
+                    if edge.target_id == current_id and edge.edge_type.upper() in _CAUSAL_TRAVERSAL_TYPES:
                         if edge.source_id not in visited and depth < max_depth:
                             queue.append((edge.source_id, depth + 1))
                 else:  # downstream
-                    if edge.source_id == current_id and edge.edge_type in ["CAUSED", "INFLUENCED", "PRECEDENT_FOR"]:
+                    if edge.source_id == current_id and edge.edge_type.upper() in _CAUSAL_TRAVERSAL_TYPES:
                         if edge.target_id not in visited and depth < max_depth:
                             queue.append((edge.target_id, depth + 1))
         

--- a/tests/context/test_decision_causal_edge_regression.py
+++ b/tests/context/test_decision_causal_edge_regression.py
@@ -323,3 +323,51 @@ def test_entity_based_inference_still_applies_without_explicit_edges():
         hop["from"] == earlier and hop["to"] == later and hop["type"] == "influences"
         for hop in hops
     )
+
+
+def test_get_causal_chain_accepts_lowercase_causal_edge_types():
+    """Issue #1184: edges recorded with the analyzer's lowercase vocabulary
+    must be traversed by get_causal_chain().
+
+    CausalChainAnalyzer documents causal types as lowercase ("causes",
+    "influences", ...) while get_causal_chain() matched only the uppercase
+    spellings, so an edge recorded as "causes" produced an empty audit
+    chain — silent and in the dangerous direction.
+    """
+    graph = ContextGraph(advanced_analytics=True)
+    cause = graph.record_decision(
+        category="a", scenario="upstream", reasoning="r",
+        outcome="x", confidence=0.9,
+    )
+    effect = graph.record_decision(
+        category="b", scenario="downstream", reasoning="r",
+        outcome="y", confidence=0.9,
+    )
+    graph.add_edge(cause, effect, "causes")
+
+    chain = graph.get_causal_chain(effect, direction="upstream")
+
+    assert [decision.decision_id for decision in chain] == [cause]
+
+
+def test_add_causal_relationship_accepts_any_case_and_stores_canonical():
+    """Issue #1184: add_causal_relationship() should accept either spelling
+    and store the canonical uppercase vocabulary."""
+    graph = ContextGraph(advanced_analytics=True)
+    cause = graph.record_decision(
+        category="a", scenario="upstream", reasoning="r",
+        outcome="x", confidence=0.9,
+    )
+    effect = graph.record_decision(
+        category="b", scenario="downstream", reasoning="r",
+        outcome="y", confidence=0.9,
+    )
+
+    graph.add_causal_relationship(cause, effect, relationship_type="causes")
+
+    edges = [
+        edge for edge in graph.edges
+        if edge.source_id == cause and edge.target_id == effect
+    ]
+    assert edges, "add_causal_relationship must store the edge"
+    assert edges[0].edge_type == "CAUSED"

--- a/tests/context/test_decision_causal_edge_regression.py
+++ b/tests/context/test_decision_causal_edge_regression.py
@@ -391,3 +391,64 @@ def test_add_causal_relationship_rejects_non_string_with_value_error():
     for bad_type in (None, 42, ["CAUSED"]):
         with pytest.raises(ValueError):
             graph.add_causal_relationship(cause, effect, relationship_type=bad_type)
+
+
+def test_analyze_decision_influence_sees_lowercase_causal_edge():
+    """Issue #1184 follow-up: influence analysis reads the same edge index as
+    the causal traversal, so lowercase edges must count as direct influence."""
+    graph = ContextGraph(advanced_analytics=True)
+    cause = graph.record_decision(
+        category="a", scenario="upstream", reasoning="r",
+        outcome="x", confidence=0.9,
+    )
+    effect = graph.record_decision(
+        category="b", scenario="downstream", reasoning="r",
+        outcome="y", confidence=0.9,
+    )
+    graph.add_edge(cause, effect, "causes")
+
+    impact = graph.analyze_decision_influence(cause)
+
+    direct_ids = {entry["decision_id"] for entry in impact["direct_influence"]}
+    assert effect in direct_ids
+
+
+def test_trace_decision_causality_sees_lowercase_causal_edge():
+    """Issue #1184 follow-up: the trace must not return an empty audit chain
+    for a decision with an explicit lowercase upstream causal edge."""
+    graph = ContextGraph(advanced_analytics=True)
+    cause = graph.record_decision(
+        category="a", scenario="upstream", reasoning="r",
+        outcome="x", confidence=0.9,
+    )
+    effect = graph.record_decision(
+        category="b", scenario="downstream", reasoning="r",
+        outcome="y", confidence=0.9,
+    )
+    graph.add_edge(cause, effect, "causes")
+
+    trace = graph.trace_decision_causality(effect)
+
+    assert any(
+        hop["from"] == cause and hop["to"] == effect
+        for chain in trace for hop in chain["hops"]
+    ), "lowercase causal edge must appear in the traced chain"
+
+
+def test_find_precedents_sees_lowercase_precedent_edge():
+    """Issue #1184 follow-up: precedent lookup must accept the analyzer's
+    spelling alongside the canonical PRECEDENT_FOR."""
+    graph = ContextGraph(advanced_analytics=True)
+    precedent = graph.record_decision(
+        category="a", scenario="earlier", reasoning="r",
+        outcome="x", confidence=0.9,
+    )
+    later = graph.record_decision(
+        category="b", scenario="later", reasoning="r",
+        outcome="y", confidence=0.9,
+    )
+    graph.add_edge(precedent, later, "precedes")
+
+    precedents = graph.find_precedents(later)
+
+    assert [d.decision_id for d in precedents] == [precedent]

--- a/tests/context/test_decision_causal_edge_regression.py
+++ b/tests/context/test_decision_causal_edge_regression.py
@@ -7,6 +7,8 @@ extraction found nothing, the chain came back empty even though an explicit
 ``CAUSED`` edge was stored in the graph.
 """
 
+import pytest
+
 from semantica.context import ContextGraph
 from semantica.context.context_graph import ContextEdge
 
@@ -371,3 +373,21 @@ def test_add_causal_relationship_accepts_any_case_and_stores_canonical():
     ]
     assert edges, "add_causal_relationship must store the edge"
     assert edges[0].edge_type == "CAUSED"
+
+
+def test_add_causal_relationship_rejects_non_string_with_value_error():
+    """Invalid relationship types must keep raising ValueError (issue #1184
+    follow-up): normalization must not turn them into AttributeError."""
+    graph = ContextGraph(advanced_analytics=True)
+    cause = graph.record_decision(
+        category="a", scenario="upstream", reasoning="r",
+        outcome="x", confidence=0.9,
+    )
+    effect = graph.record_decision(
+        category="b", scenario="downstream", reasoning="r",
+        outcome="y", confidence=0.9,
+    )
+
+    for bad_type in (None, 42, ["CAUSED"]):
+        with pytest.raises(ValueError):
+            graph.add_causal_relationship(cause, effect, relationship_type=bad_type)


### PR DESCRIPTION
## Description

`ContextGraph.get_causal_chain()` matched causal edges against only the canonical uppercase spellings (`CAUSED`, `INFLUENCED`, `PRECEDENT_FOR`), while `CausalChainAnalyzer` accepts the present-tense forms (`causes`, `influences`, `leads_to`, `supports`). The two vocabularies differ in **word form, not just case** — `"causes".upper()` is `"CAUSES"`, not `"CAUSED"` — so an edge recorded with the analyzer's vocabulary produced an **empty audit chain**: silent, and in the dangerous direction for compliance use.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1184

Found while building a lending-compliance demo on top of the library (the demo works around it today by using the uppercase spelling).

## Changes Made

- `semantica/context/context_graph.py`:
  - `_CAUSAL_EDGE_ALIASES` — maps the analyzer's present-tense spellings onto the canonical types (`causes`→`CAUSED`, `influences`→`INFLUENCED`, `precedes`→`PRECEDENT_FOR`)
  - `_CAUSAL_TRAVERSAL_TYPES` — the union vocabulary (`leads_to`, `supports`, …) accepted by `get_causal_chain()` traversal
  - `add_causal_relationship()` normalizes input through the alias map and stores the canonical form; unknown types still raise `ValueError`
- `tests/context/test_decision_causal_edge_regression.py`: 2 regression tests — lowercase `causes` edge via `add_edge()` is traversed by `get_causal_chain()`, and `add_causal_relationship(..., "causes")` stores `CAUSED`

## Testing

- [x] Tested locally
- [x] Added tests for new functionality

### Test Commands

```bash
python3 -m pytest tests/context/test_decision_causal_edge_regression.py -q   # 16 passed
python3 -m pytest tests/context/ -q --continue-on-collection-errors           # 587 passed
```

## Documentation

- [x] No documentation changes needed

## Breaking Changes

**Breaking Changes**: No — strictly more permissive: previously rejected or ignored spellings now work; canonical behavior unchanged.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## AI-assisted development disclosure

Claude Code assisted with implementing the fix and regression tests from the issue spec. I reviewed the final diff, ran the validation above, and take responsibility for the submitted change.