### PR TITLE
fix(conflicts): resolve TypeError on unhashable values in voting/credibility strategies

### DIFF
--- a/semantica/conflicts/conflict_resolver.py
+++ b/semantica/conflicts/conflict_resolver.py
@@ -56,6 +56,7 @@ Author: Semantica Contributors
 License: MIT
 """
 
+import json
 from collections import Counter
 from dataclasses import dataclass, field
 from enum import Enum
@@ -65,6 +66,25 @@ from ..utils.logging import get_logger
 from ..utils.progress_tracker import get_progress_tracker
 from .conflict_detector import Conflict
 from .source_tracker import SourceTracker
+
+
+def _hashable_key(value: Any) -> Any:
+    """Return a stable, hashable key for a conflicting value.
+
+    Conflicting values may be unhashable (e.g. ``dict`` or ``list``), which
+    breaks :class:`collections.Counter` and dict-key based aggregation used by
+    the voting and credibility-weighted strategies. Hashable values are returned
+    unchanged so existing behavior is preserved; unhashable values are mapped to
+    a stable JSON string key.
+    """
+    try:
+        hash(value)
+        return value
+    except TypeError:
+        try:
+            return json.dumps(value, sort_keys=True, default=str)
+        except (TypeError, ValueError):
+            return repr(value)
 
 
 class ResolutionStrategy(str, Enum):
@@ -361,9 +381,18 @@ class ConflictResolver:
                 resolution_notes="No conflicting values to resolve",
             )
 
-        # Count value occurrences
-        value_counts = Counter(conflict.conflicting_values)
-        most_common_value, count = value_counts.most_common(1)[0]
+        # Count value occurrences (using stable hashable keys so that
+        # unhashable values such as dict/list do not break Counter)
+        key_to_value: Dict[Any, Any] = {}
+        keys: List[Any] = []
+        for value in conflict.conflicting_values:
+            key = _hashable_key(value)
+            key_to_value.setdefault(key, value)
+            keys.append(key)
+
+        value_counts = Counter(keys)
+        most_common_key, count = value_counts.most_common(1)[0]
+        most_common_value = key_to_value[most_common_key]
 
         # Calculate confidence based on vote ratio
         total_votes = len(conflict.conflicting_values)
@@ -391,8 +420,10 @@ class ConflictResolver:
                 resolution_notes="Insufficient data for credibility-based resolution",
             )
 
-        # Weight values by source credibility
+        # Weight values by source credibility (keyed by stable hashable keys so
+        # that unhashable values such as dict/list can be used as map keys)
         value_weights: Dict[Any, float] = {}
+        key_to_value: Dict[Any, Any] = {}
 
         for i, value in enumerate(conflict.conflicting_values):
             source = conflict.sources[i] if i < len(conflict.sources) else {}
@@ -402,9 +433,11 @@ class ConflictResolver:
 
             weight = source_confidence * credibility
 
-            if value not in value_weights:
-                value_weights[value] = 0.0
-            value_weights[value] += weight
+            key = _hashable_key(value)
+            key_to_value.setdefault(key, value)
+            if key not in value_weights:
+                value_weights[key] = 0.0
+            value_weights[key] += weight
 
         # Get value with highest weight
         if not value_weights:
@@ -414,10 +447,11 @@ class ConflictResolver:
                 resolution_notes="Could not calculate credibility weights",
             )
 
-        resolved_value = max(value_weights.items(), key=lambda x: x[1])[0]
+        resolved_key = max(value_weights.items(), key=lambda x: x[1])[0]
+        resolved_value = key_to_value[resolved_key]
         total_weight = sum(value_weights.values())
         confidence = (
-            value_weights[resolved_value] / total_weight if total_weight > 0 else 0.0
+            value_weights[resolved_key] / total_weight if total_weight > 0 else 0.0
         )
 
         sources_used = [s.get("document", "unknown") for s in conflict.sources]
@@ -430,7 +464,7 @@ class ConflictResolver:
             sources_used=sources_used,
             resolution_notes=(
                 "Resolved by credibility-weighted voting "
-                f"(weight: {value_weights[resolved_value]:.2f})"
+                f"(weight: {value_weights[resolved_key]:.2f})"
             ),
         )
 

--- a/semantica/conflicts/conflict_resolver.py
+++ b/semantica/conflicts/conflict_resolver.py
@@ -73,18 +73,23 @@ def _hashable_key(value: Any) -> Any:
 
     Conflicting values may be unhashable (e.g. ``dict`` or ``list``), which
     breaks :class:`collections.Counter` and dict-key based aggregation used by
-    the voting and credibility-weighted strategies. Hashable values are returned
-    unchanged so existing behavior is preserved; unhashable values are mapped to
-    a stable JSON string key.
+    the voting and credibility-weighted strategies.
+
+    The key is *type-tagged* so that a serialized structure can never alias a
+    scalar value: e.g. the dict ``{"a": 1}`` and the string ``'{"a": 1}'`` map
+    to distinct keys instead of colliding. Hashable values keep their original
+    identity within the ``"h"`` tag (so equal scalars still aggregate together);
+    unhashable values are serialized to a stable JSON string under the ``"j"``
+    tag, falling back to ``repr()`` under the ``"r"`` tag when JSON fails.
     """
     try:
         hash(value)
-        return value
+        return ("h", type(value).__name__, value)
     except TypeError:
         try:
-            return json.dumps(value, sort_keys=True, default=str)
+            return ("j", json.dumps(value, sort_keys=True, default=str))
         except (TypeError, ValueError):
-            return repr(value)
+            return ("r", repr(value))
 
 
 class ResolutionStrategy(str, Enum):

--- a/tests/conflicts/test_conflicts.py
+++ b/tests/conflicts/test_conflicts.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from datetime import datetime
 from unittest.mock import MagicMock, patch
@@ -582,6 +583,38 @@ class TestConflictsModule(unittest.TestCase):
         # returned as the original list.
         self.assertEqual(result.resolved_value, val_b)
         self.assertIsInstance(result.resolved_value, list)
+
+    def test_voting_does_not_alias_struct_with_its_json_text(self):
+        """A dict and a string equal to its JSON text must not be merged.
+
+        Regression for PR #1208 review: type-tagged keys must keep a
+        serialized structure distinct from a scalar string that happens to
+        equal that serialization, so the majority string wins instead of the
+        single dict.
+        """
+        resolver = ConflictResolver()
+
+        struct = {"a": 1}
+        json_text = json.dumps(struct, sort_keys=True)  # '{"a": 1}'
+        conflict = Conflict(
+            conflict_id="c_alias_vote",
+            conflict_type=ConflictType.VALUE_CONFLICT,
+            entity_id="e1",
+            property_name="payload",
+            conflicting_values=[struct, json_text, json_text],
+            sources=[
+                {"document": "doc1", "confidence": 0.9},
+                {"document": "doc2", "confidence": 0.8},
+                {"document": "doc3", "confidence": 0.7},
+            ],
+        )
+
+        result = resolver.resolve_conflict(conflict, strategy="voting")
+        self.assertTrue(result.resolved)
+        # The two identical json_text strings are the true majority; they must
+        # not be aliased with the dict.
+        self.assertEqual(result.resolved_value, json_text)
+        self.assertIsInstance(result.resolved_value, str)
 
 
 if __name__ == "__main__":

--- a/tests/conflicts/test_conflicts.py
+++ b/tests/conflicts/test_conflicts.py
@@ -529,6 +529,60 @@ class TestConflictsModule(unittest.TestCase):
         self.assertEqual(trends[0]["trend"], "insufficient_data")
         self.assertEqual(trends[0]["conflict_count"], 1)
 
+    def test_resolve_by_voting_with_unhashable_values(self):
+        """Voting must handle unhashable values (dict/list) without crashing."""
+        resolver = ConflictResolver()
+
+        val_a = {"city": "New York", "zip": "10001"}
+        val_b = {"city": "Boston", "zip": "02101"}
+        conflict = Conflict(
+            conflict_id="c_unhashable_vote",
+            conflict_type=ConflictType.VALUE_CONFLICT,
+            entity_id="e1",
+            property_name="address",
+            conflicting_values=[val_a, val_a, val_b],
+            sources=[
+                {"document": "doc1", "confidence": 0.9},
+                {"document": "doc2", "confidence": 0.8},
+                {"document": "doc3", "confidence": 0.7},
+            ],
+        )
+
+        result = resolver.resolve_conflict(conflict, strategy="voting")
+        self.assertTrue(result.resolved)
+        # The majority value (val_a appears twice) must win and be returned
+        # as the original dict, not a stringified key.
+        self.assertEqual(result.resolved_value, val_a)
+        self.assertIsInstance(result.resolved_value, dict)
+
+    def test_resolve_by_credibility_with_unhashable_values(self):
+        """Credibility-weighted resolution must handle unhashable values."""
+        resolver = ConflictResolver()
+        resolver.source_tracker.set_source_credibility("doc_trusted", 1.0)
+        resolver.source_tracker.set_source_credibility("doc_flaky", 0.1)
+
+        val_a = ["tag1", "tag2"]
+        val_b = ["tag3"]
+        conflict = Conflict(
+            conflict_id="c_unhashable_cred",
+            conflict_type=ConflictType.VALUE_CONFLICT,
+            entity_id="e1",
+            property_name="tags",
+            conflicting_values=[val_a, val_a, val_b],
+            sources=[
+                {"document": "doc_flaky", "confidence": 0.9},
+                {"document": "doc_flaky", "confidence": 0.9},
+                {"document": "doc_trusted", "confidence": 0.9},
+            ],
+        )
+
+        result = resolver.resolve_conflict(conflict, strategy="credibility_weighted")
+        self.assertTrue(result.resolved)
+        # doc_trusted has far higher credibility, so val_b should win and be
+        # returned as the original list.
+        self.assertEqual(result.resolved_value, val_b)
+        self.assertIsInstance(result.resolved_value, list)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Fixes a `TypeError: unhashable type` crash in conflict resolution when a
`VALUE_CONFLICT` holds dict or list values.

`_resolve_by_voting` (via `collections.Counter`) and `_resolve_by_credibility`
(via dict keys) both required hashable values. Structured (dict/list) values
therefore crashed resolution.

## Changes
- Add module-level `_hashable_key(value)`: returns hashable values unchanged;
  for unhashable ones derives a stable key via
  `json.dumps(sort_keys=True, default=str)`, falling back to `repr()`.
- `_resolve_by_voting` and `_resolve_by_credibility` now aggregate by key while
  keeping a `key -> original value` map, returning the resolved value with its
  original type.
- The common all-string path is behaviourally unchanged.

## Tests
- `test_resolve_by_voting_with_unhashable_values` (dict values)
- `test_resolve_by_credibility_with_unhashable_values` (list values)
- Full `tests/conflicts/test_conflicts.py` suite: 21 passed.

## Known limitation
Extremely rare key collisions between a stringified structure and an equal
string value are possible but acceptable for de-duplication purposes.

Fixes #1207
