### PR TITLE
fix: preserve generation kwargs in relation extraction

### DIFF
--- a/semantica/semantic_extract/methods.py
+++ b/semantica/semantic_extract/methods.py
@@ -1906,13 +1906,10 @@ Entities found in text: {entities_str}"""
                 "[methods.extract_relations_llm] Calling llm.generate_typed (%s/%s)...",
                 provider, model,
             )
-        # Only forward minimal, safe parameters to provider calls
-        call_kwargs = {}
-        if "temperature" in kwargs:
-            call_kwargs["temperature"] = kwargs["temperature"]
-        if "verbose" in kwargs:
-            call_kwargs["verbose"] = kwargs["verbose"]
-
+        # Forward all caller-supplied generation kwargs so they reach
+        # generate_typed and the underlying provider API. max_retries is
+        # always set from the explicit parameter.
+        call_kwargs = kwargs.copy()
         call_kwargs["max_retries"] = max_retries
 
         # Select schema based on whether temporal extraction is requested

--- a/semantica/semantic_extract/methods.py
+++ b/semantica/semantic_extract/methods.py
@@ -140,6 +140,39 @@ _result_cache = ExtractionCache(
 if not config.get("cache_enabled", True):
     _result_cache.enabled = False
 
+# Generation kwargs that affect provider output and must therefore be part of
+# the cache key. This is the union of all parameters read by _add_if_set across
+# every provider in providers.py. Sensitive values (api_key, token, etc.) are
+# already filtered out by ExtractionCache._generate_key, so they need not be
+# excluded here.
+_GENERATION_CACHE_KEYS = frozenset({
+    "max_tokens",
+    "max_completion_tokens",
+    "temperature",
+    "top_p",
+    "top_k",
+    "seed",
+    "frequency_penalty",
+    "presence_penalty",
+    "stop",
+    "logit_bias",
+    "user",
+})
+
+
+def _generation_cache_params(kwargs: dict) -> dict:
+    """Return the subset of *kwargs* that affects generation output.
+
+    Only keys listed in ``_GENERATION_CACHE_KEYS`` are included so that
+    irrelevant or sensitive caller kwargs do not pollute the cache key.
+    Values that are ``None`` are omitted; a caller passing
+    ``temperature=None`` is equivalent to not passing it at all.
+    """
+    return {
+        k: v for k, v in kwargs.items()
+        if k in _GENERATION_CACHE_KEYS and v is not None
+    }
+
 # Try to import spaCy
 from ..utils.helpers import safe_import
 
@@ -957,6 +990,7 @@ def extract_entities_llm(
         "max_text_length": max_text_length,
         "structured_output_mode": structured_output_mode,
         "entity_types": kwargs.get("entity_types"),
+        **_generation_cache_params(kwargs),
     }
     cached_result = _result_cache.get("entities", text, **cache_params)
     if cached_result is not None:
@@ -1706,7 +1740,8 @@ def extract_relations_llm(
         "relation_types": kwargs.get("relation_types"),
         "extract_temporal_bounds": extract_temporal_bounds,
         # Include entities hash/str in cache key implicitly via **cache_params
-        "entities_hash": hash(tuple(sorted([e.text for e in entities]))) if entities else 0
+        "entities_hash": hash(tuple(sorted([e.text for e in entities]))) if entities else 0,
+        **_generation_cache_params(kwargs),
     }
     cached_result = _result_cache.get("relations", text, **cache_params)
     if cached_result is not None:
@@ -2361,7 +2396,8 @@ def extract_triplets_llm(
         "triplet_types": kwargs.get("triplet_types"),
         # Include entities/relations hash in cache key implicitly via **cache_params
         "entities_hash": hash(tuple(sorted([e.text for e in entities]))) if entities else 0,
-        "relations_hash": hash(tuple(sorted([str(r) for r in relations]))) if relations else 0
+        "relations_hash": hash(tuple(sorted([str(r) for r in relations]))) if relations else 0,
+        **_generation_cache_params(kwargs),
     }
     cached_result = _result_cache.get("triplets", text, **cache_params)
     if cached_result is not None:

--- a/semantica/semantic_extract/methods.py
+++ b/semantica/semantic_extract/methods.py
@@ -141,10 +141,11 @@ if not config.get("cache_enabled", True):
     _result_cache.enabled = False
 
 # Generation kwargs that affect provider output and must therefore be part of
-# the cache key. This is the union of all parameters read by _add_if_set across
-# every provider in providers.py. Sensitive values (api_key, token, etc.) are
-# already filtered out by ExtractionCache._generate_key, so they need not be
-# excluded here.
+# the cache key. This is the union of every generation-affecting parameter
+# read across providers.py, including params picked up outside _add_if_set
+# (e.g. AnthropicProvider's manual pass-through loop). Sensitive values
+# (api_key, token, etc.) are already filtered out by
+# ExtractionCache._generate_key, so they need not be excluded here.
 _GENERATION_CACHE_KEYS = frozenset({
     "max_tokens",
     "max_completion_tokens",
@@ -155,8 +156,15 @@ _GENERATION_CACHE_KEYS = frozenset({
     "frequency_penalty",
     "presence_penalty",
     "stop",
+    "stop_sequences",  # Anthropic/Gemini spelling of "stop"
     "logit_bias",
     "user",
+    "system",  # Anthropic system prompt
+    "metadata",  # Anthropic request metadata
+    "candidate_count",  # Gemini
+    "repeat_penalty",  # Ollama
+    "num_ctx",  # Ollama
+    "context_window",  # Ollama alias for num_ctx
 })
 
 

--- a/tests/reproduce_issue_176.py
+++ b/tests/reproduce_issue_176.py
@@ -234,5 +234,101 @@ class TestCacheKeyIncludesGenerationParams(unittest.TestCase):
         self.assertEqual(mock_llm.generate_typed.call_count, 2)
 
 
+class TestCacheKeyIncludesProviderSpecificGenerationParams(unittest.TestCase):
+    """Regression tests for provider-specific generation params that aren't part
+    of the common OpenAI-shaped kwargs (max_tokens, temperature, etc.) but still
+    change provider output and must therefore also change the cache key.
+
+    See providers.py: AnthropicProvider.generate/generate_structured read
+    'system' and 'stop_sequences' via a manual pass-through loop (not
+    _add_if_set); GeminiProvider.generate reads 'candidate_count' and
+    'stop_sequences'; OllamaProvider._build_options reads 'repeat_penalty' and
+    'num_ctx'/'context_window'.
+    """
+
+    def _make_mock_llm(self):
+        mock_llm = MagicMock()
+        mock_llm.is_available.return_value = True
+        resp = MagicMock()
+        resp.relations = []
+        mock_llm.generate_typed.return_value = resp
+        return mock_llm
+
+    @patch("semantica.semantic_extract.methods.create_provider")
+    def test_relations_different_system_prompt_bypass_cache(self, mock_create_provider):
+        """Anthropic 'system' prompt changes output; must not share a cache entry."""
+        from semantica.semantic_extract.methods import _result_cache
+        _result_cache.clear("relations")
+
+        mock_llm = self._make_mock_llm()
+        mock_create_provider.return_value = mock_llm
+
+        entities = [Entity(text="Foo", label="ORG", start_char=0, end_char=3)]
+
+        extract_relations_llm(
+            text="some text", entities=entities,
+            provider="anthropic", model="claude-3-sonnet-20240229",
+            system="Extract only ORG relations."
+        )
+        extract_relations_llm(
+            text="some text", entities=entities,
+            provider="anthropic", model="claude-3-sonnet-20240229",
+            system="Extract only PERSON relations."
+        )
+
+        self.assertEqual(
+            mock_llm.generate_typed.call_count, 2,
+            "Different 'system' prompts must produce different cache keys."
+        )
+
+    @patch("semantica.semantic_extract.methods.create_provider")
+    def test_relations_different_stop_sequences_bypass_cache(self, mock_create_provider):
+        """Anthropic/Gemini 'stop_sequences' must also be part of the cache key."""
+        from semantica.semantic_extract.methods import _result_cache
+        _result_cache.clear("relations")
+
+        mock_llm = self._make_mock_llm()
+        mock_create_provider.return_value = mock_llm
+
+        entities = [Entity(text="Foo", label="ORG", start_char=0, end_char=3)]
+
+        extract_relations_llm(
+            text="some text", entities=entities,
+            provider="anthropic", model="claude-3-sonnet-20240229",
+            stop_sequences=["\n\n"]
+        )
+        extract_relations_llm(
+            text="some text", entities=entities,
+            provider="anthropic", model="claude-3-sonnet-20240229",
+            stop_sequences=["STOP"]
+        )
+
+        self.assertEqual(mock_llm.generate_typed.call_count, 2)
+
+    @patch("semantica.semantic_extract.methods.create_provider")
+    def test_relations_different_repeat_penalty_bypass_cache(self, mock_create_provider):
+        """Ollama 'repeat_penalty' must also be part of the cache key."""
+        from semantica.semantic_extract.methods import _result_cache
+        _result_cache.clear("relations")
+
+        mock_llm = self._make_mock_llm()
+        mock_create_provider.return_value = mock_llm
+
+        entities = [Entity(text="Foo", label="ORG", start_char=0, end_char=3)]
+
+        extract_relations_llm(
+            text="some text", entities=entities,
+            provider="ollama", model="llama2",
+            repeat_penalty=1.0
+        )
+        extract_relations_llm(
+            text="some text", entities=entities,
+            provider="ollama", model="llama2",
+            repeat_penalty=1.5
+        )
+
+        self.assertEqual(mock_llm.generate_typed.call_count, 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/reproduce_issue_176.py
+++ b/tests/reproduce_issue_176.py
@@ -96,5 +96,143 @@ class TestMaxTokensPropagation(unittest.TestCase):
         self.assertIn("max_tokens", kwargs)
         self.assertEqual(kwargs["max_tokens"], 128000)
 
+
+class TestCacheKeyIncludesGenerationParams(unittest.TestCase):
+    """Regression tests for the cache-key bug: two calls with identical extraction
+    inputs but different generation settings must NOT share a cached result.
+
+    Before the fix, extract_relations_llm (and entities/triplets) built
+    cache_params without generation kwargs, so max_tokens=4096 and
+    max_tokens=128000 hashed to the same key. The second call would return the
+    first cached result without ever running generate_typed again.
+    """
+
+    def _make_mock_llm(self, relations=None, entities=None, triplets=None):
+        mock_llm = MagicMock()
+        mock_llm.is_available.return_value = True
+        resp = MagicMock()
+        resp.relations = relations if relations is not None else []
+        resp.entities = entities if entities is not None else []
+        resp.triplets = triplets if triplets is not None else []
+        mock_llm.generate_typed.return_value = resp
+        return mock_llm
+
+    @patch("semantica.semantic_extract.methods.create_provider")
+    def test_relations_different_max_tokens_bypass_cache(self, mock_create_provider):
+        """Two relation extraction calls with the same text/entities but different
+        max_tokens must each call generate_typed (2 calls total), not reuse the
+        first cached result."""
+        from semantica.semantic_extract.methods import _result_cache
+        _result_cache.clear("relations")
+
+        mock_llm = self._make_mock_llm()
+        mock_create_provider.return_value = mock_llm
+
+        entities = [Entity(text="Foo", label="ORG", start_char=0, end_char=3)]
+
+        extract_relations_llm(
+            text="some text", entities=entities,
+            provider="openai", model="gpt-4", max_tokens=4096
+        )
+        extract_relations_llm(
+            text="some text", entities=entities,
+            provider="openai", model="gpt-4", max_tokens=128000
+        )
+
+        # generate_typed must have been called twice — once per unique key
+        self.assertEqual(
+            mock_llm.generate_typed.call_count, 2,
+            "Different max_tokens values must produce different cache keys; "
+            "second call must not reuse the first cached result."
+        )
+
+    @patch("semantica.semantic_extract.methods.create_provider")
+    def test_relations_same_max_tokens_uses_cache(self, mock_create_provider):
+        """Two identical calls must reuse the cache (generate_typed called once)."""
+        from semantica.semantic_extract.methods import _result_cache
+        _result_cache.clear("relations")
+
+        mock_llm = self._make_mock_llm()
+        mock_create_provider.return_value = mock_llm
+
+        entities = [Entity(text="Foo", label="ORG", start_char=0, end_char=3)]
+
+        extract_relations_llm(
+            text="some text", entities=entities,
+            provider="openai", model="gpt-4", max_tokens=4096
+        )
+        extract_relations_llm(
+            text="some text", entities=entities,
+            provider="openai", model="gpt-4", max_tokens=4096
+        )
+
+        self.assertEqual(
+            mock_llm.generate_typed.call_count, 1,
+            "Identical calls must reuse the cache."
+        )
+
+    @patch("semantica.semantic_extract.methods.create_provider")
+    def test_relations_different_temperature_bypass_cache(self, mock_create_provider):
+        """Different temperature values must also produce different cache keys."""
+        from semantica.semantic_extract.methods import _result_cache
+        _result_cache.clear("relations")
+
+        mock_llm = self._make_mock_llm()
+        mock_create_provider.return_value = mock_llm
+
+        entities = [Entity(text="Bar", label="PERSON", start_char=0, end_char=3)]
+
+        extract_relations_llm(
+            text="other text", entities=entities,
+            provider="openai", model="gpt-4", temperature=0.0
+        )
+        extract_relations_llm(
+            text="other text", entities=entities,
+            provider="openai", model="gpt-4", temperature=1.0
+        )
+
+        self.assertEqual(mock_llm.generate_typed.call_count, 2)
+
+    @patch("semantica.semantic_extract.methods.create_provider")
+    def test_entities_different_max_tokens_bypass_cache(self, mock_create_provider):
+        """extract_entities_llm: different max_tokens must bypass cache."""
+        from semantica.semantic_extract.methods import _result_cache
+        _result_cache.clear("entities")
+
+        mock_llm = self._make_mock_llm()
+        mock_create_provider.return_value = mock_llm
+
+        extract_entities_llm(
+            text="some entity text", provider="openai", model="gpt-4",
+            max_tokens=4096
+        )
+        extract_entities_llm(
+            text="some entity text", provider="openai", model="gpt-4",
+            max_tokens=128000
+        )
+
+        self.assertEqual(mock_llm.generate_typed.call_count, 2)
+
+    @patch("semantica.semantic_extract.methods.create_provider")
+    def test_triplets_different_max_tokens_bypass_cache(self, mock_create_provider):
+        """extract_triplets_llm: different max_tokens must bypass cache."""
+        from semantica.semantic_extract.methods import _result_cache
+        _result_cache.clear("triplets")
+
+        mock_llm = self._make_mock_llm()
+        mock_create_provider.return_value = mock_llm
+
+        extract_triplets_llm(
+            text="some triplet text", provider="openai", model="gpt-4",
+            max_tokens=4096
+        )
+        extract_triplets_llm(
+            text="some triplet text", provider="openai", model="gpt-4",
+            max_tokens=128000
+        )
+
+        self.assertEqual(mock_llm.generate_typed.call_count, 2)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes LLM generation parameter propagation in relation extraction and ensures behavior-affecting generation parameters are correctly included in extraction cache keys.

This addresses two related issues:

1. `extract_relations_llm` was silently dropping caller-supplied generation parameters such as `max_tokens` before calling `generate_typed`.
2. Once those parameters are correctly forwarded, the extraction cache must distinguish calls that use different generation settings. Otherwise, a cached result generated with one configuration could be incorrectly returned for a later call using a different configuration.

The fix keeps generation behavior and cache identity consistent across entity, relation, and triplet extraction.

## Problem

### 1. Generation parameters were dropped in relation extraction

`extract_relations_llm` previously constructed provider kwargs using a small allowlist:

```python
call_kwargs = {}
if "temperature" in kwargs:
    call_kwargs["temperature"] = kwargs["temperature"]
if "verbose" in kwargs:
    call_kwargs["verbose"] = kwargs["verbose"]
```

This meant supported generation parameters such as `max_tokens`, `top_p`, `seed`, and `max_completion_tokens` were silently discarded before reaching `generate_typed`.

For example, a caller could provide:

```python
max_tokens=128000
```

but the relation extraction path would not forward it to the provider.

The implementation now uses:

```python
call_kwargs = kwargs.copy()
call_kwargs["max_retries"] = max_retries
```

This preserves caller-supplied generation parameters while ensuring the explicit `max_retries` argument takes precedence.

The same `call_kwargs` is used by the structured-output fallback, so both provider paths receive the corrected parameters.

### 2. Generation parameters were missing from extraction cache keys

After fixing parameter propagation, a related cache correctness issue became apparent.

The extraction cache is enabled by default and its key is derived from the explicitly supplied cache parameters. Previously, generation parameters were not included in the cache identity.

This meant calls such as:

```text
max_tokens=4096
```

and:

```text
max_tokens=128000
```

could use the same cache entry when all other extraction inputs were identical.

The second call could therefore return the result generated by the first call without invoking the provider with its requested generation settings.

This issue was identified during review and has been addressed as part of this PR.

## Changes

### Generation kwargs

* Preserve all caller-supplied generation kwargs in `extract_relations_llm`.
* Explicitly set `max_retries` after copying the kwargs.
* Keep the behavior consistent with the existing entity and triplet extraction implementations.
* Ensure both the normal `generate_typed` path and the structured-output fallback use the corrected kwargs.

### Cache keys

Added shared handling for behavior-affecting generation parameters used by the supported generation APIs.

The cache key now accounts for parameters including:

* `max_tokens`
* `max_completion_tokens`
* `temperature`
* `top_p`
* `top_k`
* `seed`
* `frequency_penalty`
* `presence_penalty`
* `stop`
* `logit_bias`
* `user`

Only supported generation parameters are included.

`None` values are omitted so that an unset parameter and an explicitly unset (`None`) parameter do not unnecessarily produce different cache entries.

Sensitive values such as API credentials are not included in the generation cache parameters, and the existing cache implementation continues to filter sensitive keys.

The cache-key handling is applied consistently to:

* `extract_entities_llm`
* `extract_relations_llm`
* `extract_triplets_llm`

This prevents the same class of cache collision across the three LLM extraction paths.

## Tests

Added focused regression coverage for cache behavior.

The tests verify that:

* Different `max_tokens` values bypass the existing cache entry.
* Identical `max_tokens` values reuse the cache.
* Different `temperature` values produce distinct cache behavior.
* Entity extraction distinguishes different `max_tokens` configurations.
* Triplet extraction distinguishes different `max_tokens` configurations.
* Existing `max_tokens` propagation tests continue to pass.

Focused test run:

```text
pytest tests/reproduce_issue_176.py -v
8 passed
```

Additional semantic extraction tests:

```text
32 passed, 3 failed
```

The three failures were verified as pre-existing on the base branch and are unrelated to these changes.

Also verified:

```text
git diff --check
```

with no whitespace errors.

## Scope

The changes are limited to the generation-parameter propagation and extraction-cache correctness issues described above.

Modified files:

```text
semantica/semantic_extract/methods.py
tests/reproduce_issue_176.py
```

No unrelated refactoring or provider-specific behavior changes are included.

## Why this is needed

The generation kwargs and cache identity must describe the same effective generation configuration.

Forwarding `max_tokens` and other generation settings without including them in the cache key would allow stale results generated under a different configuration to be returned.

This PR fixes both sides of that behavior so that:

**generation configuration → provider behavior → cache identity**

remain consistent.
