### PR TITLE
test(ner): fix NER configuration tests for the typed LLM extraction API

### DIFF
--- a/tests/test_ner_configurations.py
+++ b/tests/test_ner_configurations.py
@@ -33,10 +33,24 @@ class TestNERConfigurations(unittest.TestCase):
         # Mock LLM provider
         mock_provider = MagicMock()
         mock_provider.is_available.return_value = True
-        mock_provider.generate_structured.return_value = [
-            {"text": "Apple Inc.", "label": "ORG", "start": 0, "end": 10, "confidence": 0.95},
-            {"text": "Steve Jobs", "label": "PERSON", "start": 26, "end": 36, "confidence": 0.98}
+        # The LLM path uses generate_typed (Pydantic schema validation), not
+        # generate_structured. Build a typed response object whose .entities
+        # carries simple namespace-like items.
+        def _entity(text, label, start, end, confidence):
+            item = MagicMock()
+            item.text = text
+            item.label = label
+            item.start = start
+            item.end = end
+            item.confidence = confidence
+            return item
+
+        typed_response = MagicMock()
+        typed_response.entities = [
+            _entity("Apple Inc.", "ORG", 0, 10, 0.95),
+            _entity("Steve Jobs", "PERSON", 26, 36, 0.98),
         ]
+        mock_provider.generate_typed.return_value = typed_response
         mock_create_provider.return_value = mock_provider
         
         # Initialize extractor with LLM method
@@ -56,7 +70,7 @@ class TestNERConfigurations(unittest.TestCase):
         self.assertEqual(len(entities), 2)
         self.assertEqual(entities[0].text, "Apple Inc.")
         self.assertEqual(entities[0].label, "ORG")
-        self.assertEqual(entities[0].metadata["extraction_method"], "llm")
+        self.assertEqual(entities[0].metadata["extraction_method"], "llm_typed")
         self.assertEqual(entities[0].metadata["model"], "gpt-4")
 
     @patch('semantica.semantic_extract.methods.spacy')
@@ -183,7 +197,7 @@ class TestNERConfigurations(unittest.TestCase):
         
         self.assertTrue(len(entities) >= 2)
         texts = [e.text for e in entities]
-        self.assertIn("Apple Inc", texts) # Regex pattern does not capture the trailing dot
+        self.assertIn("Apple Inc.", texts)  # The ORG pattern includes the trailing dot via (?:\.|\b)
         # Actually methods.py regex: r"\b([A-Z][a-zA-Z]+(?:\s+[A-Z][a-zA-Z]+)*\s+(?:Inc|Corp|LLC|Ltd|Company))\b"
         # "Apple Inc." -> "Apple Inc" (dot is outside \b if not matched?)
         # Let's check the result strictly


### PR DESCRIPTION
## Summary

Two of the three failing tests tracked in #1059 were still red after #1070 was closed because their mocks targeted the pre-typed provider API:

- `test_ner_llm_config` mocked `generate_structured`, but the LLM path now goes through `generate_typed` with a Pydantic schema. This PR mocks the typed response (namespace items exposing `.text/.label/.start/.end/.confidence`) and expects `extraction_method == 'llm_typed'`.
- `test_ner_pattern_config` asserted `Apple Inc` without the trailing dot, but the ORG pattern captures it via `(?:\.|\b)`. The assertion now expects `Apple Inc.` to match current production behavior.

## Verification

- `tests/test_ner_configurations.py`: 8/8 passing locally.
- The remaining failures in `tests/semantic_extract/test_performance.py` reproduce on a clean main checkout and are unrelated to this change.

Fixes #1059

Signed-off-by: Yunare Maia <yunare@gmail.com>