### PR TITLE
fix(mcp): filter decisions by metadata category

### DIFF
--- a/semantica/mcp_server/__init__.py
+++ b/semantica/mcp_server/__init__.py
@@ -166,7 +166,11 @@ def _tool_query_decisions(args: dict) -> dict:
             results = graph.find_similar_decisions(query, max_results=limit)
         elif category:
             nodes = graph.find_nodes(node_type="decision")
-            results = [n for n in nodes if n.get("category") == category][:limit]
+            results = [
+                node
+                for node in nodes
+                if (node.get("metadata") or {}).get("category") == category
+            ][:limit]
         else:
             results = graph.find_nodes(node_type="decision")[:limit]
         return {"decisions": results if isinstance(results, list) else list(results)}

--- a/tests/test_mcp_server_decisions.py
+++ b/tests/test_mcp_server_decisions.py
@@ -1,0 +1,38 @@
+"""Regression tests for MCP decision queries."""
+
+import unittest
+
+from semantica import mcp_server
+from semantica.context import ContextGraph
+
+
+class TestQueryDecisionsTool(unittest.TestCase):
+    def setUp(self):
+        self._old_graph = mcp_server._graph
+        mcp_server._graph = ContextGraph(advanced_analytics=True)
+
+    def tearDown(self):
+        mcp_server._graph = self._old_graph
+
+    def test_category_filter_returns_decision_recorded_in_same_session(self):
+        """Decision categories are exposed by find_nodes inside metadata."""
+        recorded = mcp_server._tool_record_decision(
+            {
+                "category": "architecture",
+                "scenario": "Choose the decision-log persistence layer",
+                "reasoning": "Postgres provides durable transactional storage.",
+                "outcome": "postgres",
+                "confidence": 0.9,
+            }
+        )
+
+        result = mcp_server._tool_query_decisions({"category": "architecture"})
+
+        self.assertNotIn("error", result)
+        self.assertEqual(len(result["decisions"]), 1)
+        self.assertEqual(result["decisions"][0]["id"], recorded["decision_id"])
+        self.assertEqual(result["decisions"][0]["metadata"]["category"], "architecture")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1211. The MCP category filter now reads metadata.category, which is where find_nodes() exposes decision categories. Includes a same-session record-and-query regression test. Tests: python -m pytest tests/test_mcp_server_decisions.py tests/test_mcp_server_export_graph.py tests/test_mcp_server_version.py -q.