### PR TITLE
docs(cookbook): add index entries for notebooks 22-25

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -35,6 +35,7 @@ Essential guides to master the Semantica framework.
 - **[Vector Store](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/13_Vector_Store.ipynb)** — Setting up vector stores for similarity search and retrieval. *Intermediate*
 - **[Graph Store](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/09_Graph_Store.ipynb)** — Persisting knowledge graphs in Neo4j or FalkorDB. Topics: Neo4j, Cypher, Persistence · *Intermediate*
 - **[Ontology](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/14_Ontology.ipynb)** — Defining domain schemas and ontologies to structure your data. Topics: OWL, RDF, Schema Design · *Intermediate*
+- **[Seed Data](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/25_Seed_Data.ipynb)** — Bootstrapping a knowledge graph from trusted CSV, JSON, database, and API sources before extraction runs. Topics: SeedDataManager, Foundation Graphs · *Intermediate*
 
 
 ## Advanced Concepts
@@ -50,6 +51,9 @@ Deep dive into advanced features, customization, and complex workflows.
 - **[Multi-Source Integration](https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/06_Multi_Source_Data_Integration.ipynb)** — Merging data from disparate sources into a unified graph. Topics: Entity Resolution, Merging, Fusion · *Advanced*
 - **[Reasoning and Inference](https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/08_Reasoning_and_Inference.ipynb)** — Using logical reasoning to infer new knowledge from existing facts. Topics: Logic Rules, Inference Engines · *Advanced*
 - **[Temporal Knowledge Graphs](https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/10_Temporal_Knowledge_Graphs.ipynb)** — Modeling and querying data that changes over time. Topics: Time Series, Temporal Logic, Allen Algebra · *Advanced*
+- **[Provenance Tracking](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/22_Provenance_Tracking.ipynb)** — Audit-grade, W3C PROV-O-aligned tracking of where every entity, relationship, and chunk came from. Topics: PROV-O, Lineage, Checksums, Invalidation · *Advanced*
+- **[Reasoning Module](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/23_Reasoning.ipynb)** — Deriving new knowledge from existing facts with forward chaining, backward chaining, and Datalog strategies. Topics: Reasoner, Datalog, Explanations · *Advanced*
+- **[Change Management](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/24_Change_Management.ipynb)** — Versioning, audit trails, and data-integrity checks for knowledge graphs and ontologies. Topics: ChangeLogEntry, Version Storage, Data Integrity · *Advanced*
 
 
 ## How to Run


### PR DESCRIPTION
## What

Adds the four index entries promised in #1032 now that the notebook series has merged:

| Notebook | PR | Section | Level |
|---|---|---|---|
| 22_Provenance_Tracking.ipynb | #989 | Advanced Concepts | Advanced |
| 23_Reasoning.ipynb | #990 | Advanced Concepts | Advanced |
| 24_Change_Management.ipynb | #991 | Advanced Concepts | Advanced |
| 25_Seed_Data.ipynb | #992 | Core Tutorials | Intermediate |

## Why

The cookbook landing page (`docs/cookbook.md`) indexes notebooks up to 17 but none of the four module notebooks merged this week, so readers browsing the index cannot discover them. This is the follow-up committed in tracking issue #1032: "add `docs/cookbook.md` index entries for notebooks 22–25 once the series merges."

## Placement rationale

- **Seed Data → Core Tutorials**: bootstrapping a foundation graph from trusted sources is an early-stage workflow, in scope with the other foundational guides.
- **Provenance / Reasoning / Change Management → Advanced Concepts**: specialized module deep-dives, consistent with how `17_Conflict_Detection_and_Resolution` (also in `introduction/`) is indexed under Advanced Concepts.
- **Reasoning Module** entry is titled distinctly from the existing *Reasoning and Inference* entry (advanced/08) to keep the two notebooks unambiguous.

## Verification

- Entry format matches the existing list items exactly (title link → em-dash description → `Topics:` → italic level).
- All four `blob/main` URLs verified against `cookbook/introduction/` on current main.
- Descriptions and topics taken from each notebook's own overview cell (e.g. `Reasoner` facade / `DatalogReasoner` / `ExplanationGenerator` for #990; `ChangeLogEntry` / version storage / checksums for #991).

Closes the last open item of #1032.

Signed-off-by: LeonSGP43 <LeonSGP43@users.noreply.github.com>
