### PR TITLE
fix(explorer): surface server error detail in graph loading failures

### DIFF
--- a/explorer/src/workspaces/GraphWorkspace/useLoadGraph.ts
+++ b/explorer/src/workspaces/GraphWorkspace/useLoadGraph.ts
@@ -318,6 +318,20 @@ interface EdgeListResponse {
 
 const PAGE_LIMIT = 1000;
 
+/** Surface the server's `detail` message (e.g. auth/setup guidance) on non-OK responses. */
+async function fetchErrorDetail(response: Response): Promise<string> {
+  try {
+    const body: unknown = await response.json();
+    const detail = (body as { detail?: unknown } | null)?.detail;
+    if (typeof detail === "string" && detail.trim()) {
+      return ` — ${detail.trim()}`;
+    }
+  } catch {
+    // Non-JSON or unreadable body: fall back to the status-only message.
+  }
+  return "";
+}
+
 async function fetchAllNodes(
   signal: AbortSignal,
   onProgress?: (progress: GraphLoadProgress) => void,
@@ -335,7 +349,7 @@ async function fetchAllNodes(
 
     const response = await fetch(url.toString(), { signal });
     if (!response.ok) {
-      throw new Error(`Fetch failed: ${response.status}`);
+      throw new Error(`Fetch failed: ${response.status}${await fetchErrorDetail(response)}`);
     }
 
     const data: NodeListResponse = await response.json();
@@ -390,7 +404,7 @@ async function fetchAllEdges(
 
     const response = await fetch(url.toString(), { signal });
     if (!response.ok) {
-      throw new Error(`Fetch failed: ${response.status}`);
+      throw new Error(`Fetch failed: ${response.status}${await fetchErrorDetail(response)}`);
     }
 
     const data: EdgeListResponse = await response.json();


### PR DESCRIPTION
Closes #1256

## Problem

When the Explorer REST API returns a non-OK status, the graph loading hooks throw `Fetch failed: <status>` and discard the response body. The server's `detail` field often contains exactly the guidance the user needs — e.g. with an unconfigured `SEMANTICA_API_KEY`, `require_auth` returns:

> "Server is not configured for authentication. Set the SEMANTICA_API_KEY environment variable, or explicitly opt into unauthenticated access (development only) with SEMANTICA_ALLOW_ANONYMOUS=true."

… but the UI overlay only showed `Fetch failed: 503` plus a generic "check that the backend is running" hint, sending users down the wrong troubleshooting path (reported in #1256).

## Change

- `useLoadGraph.ts`: on non-OK responses in the nodes/edges fetch loops, read the JSON body and append its `detail` string to the thrown error. Non-JSON bodies degrade gracefully to the previous status-only message.
- `GraphLoadingOverlay` already renders the `{error}` detail line, so no UI changes were needed.

## Verification

- `bunx tsc --noEmit -p tsconfig.app.json` passes (clean, 0 errors).
- Manually reproduced the original failure (Explorer without `SEMANTICA_API_KEY`) and confirmed the server detail is now included in the error surfaced by the overlay.

Happy to adjust wording/format if maintainers prefer the detail surfaced differently (e.g. as a separate field in the progress/error state rather than appended to the message).