### PR TITLE
fix(security): resolve Scorecard vulnerability and token-permission alerts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,13 +10,15 @@ on:
 
 permissions:
   contents: read
-  security-events: write
-  actions: read
 
 jobs:
   analyze:
     name: Analyze Python
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # for github/codeql-action/upload-sarif below
+      actions: read           # for github/codeql-action/init's CodeQL bundle cache lookup
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -28,12 +28,14 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   MSDO:
     # currently only windows-latest is supported
     runs-on: windows-latest
+    permissions:
+      contents: read
+      security-events: write  # for github/codeql-action/upload-sarif below
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -2083,9 +2083,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4250,9 +4250,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
Closes 3 of the 5 open Scorecard code-scanning alerts introduced by #1266:

- **Vulnerabilities #5713** — `explorer/package-lock.json`: bumped `brace-expansion` (transitive via `minimatch`) 5.0.8 → 5.0.9 and `nanoid` (transitive via `postcss`) 3.3.16 → 3.3.18, fixing [GHSA-rgw5-rvv9-x895](https://osv.dev/GHSA-rgw5-rvv9-x895) and [GHSA-2v37-7h3g-55p8](https://osv.dev/GHSA-2v37-7h3g-55p8) (both DoS via unbounded/looping input). Both versions already satisfy the caret ranges their parents declare, so this is a lockfile-only change — verified with a clean `npm ci` (0 vulnerabilities).
- **Token-Permissions #5689** — `codeql.yml` had `security-events: write` and `actions: read` at workflow level; moved down to the single `analyze` job.
- **Token-Permissions #5690** — `defender-for-devops.yml` had `security-events: write` at workflow level; moved down to the single `MSDO` job.

Both workflows now default to `contents: read` at the top level with the write scope granted only where the SARIF upload step actually needs it — matching Scorecard's Token-Permissions ideal.

## Not fixed here (can't be addressed by a code change)
- **Token-Permissions #5688** (`security-scan.yml`) and **#5687** (`release.yml`) already follow the same read-only-top/write-at-job pattern. Scorecard's own docs note these are informational-only warnings for necessary write scopes (SARIF upload, GitHub Release/PyPI publish) and don't reduce the score — nothing to change.
- **Branch-Protection #5686** flags that `main`'s branch protection isn't at Scorecard's maximal tier (admin enforcement, stale-review dismissal, codeowners review, last-push approval). This is a repository Settings → Branches change, not something a PR can fix — flagging for a maintainer to decide on directly since it changes merge requirements for everyone.

## Test plan
- [x] `python -c "import json; json.load(open('explorer/package-lock.json'))"` — valid JSON
- [x] `npm ci` in `explorer/` — installs cleanly, `found 0 vulnerabilities`
- [x] `yaml.safe_load` on both edited workflow files
- [x] `.github/scripts/verify-action-pins.sh` — all 45 action refs still pass