### PR TITLE
fix: make LanguageDetector minimum text length configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Implements the deterministic core of ontology-based information extraction (OBIE; Wimalasuriya & Dou, 2010). No new runtime dependencies
   - New `tests/semantic_extract/test_schema_validator.py`
 
+### Changed
+
+- **`LanguageDetector`'s fallback is now `"unknown"` instead of `"en"`, and its minimum text length is configurable** (closes #1281) by @taoche
+  - **Breaking for anyone reading the fallback value.** `detect()`, `detect_with_confidence()`, `detect_multiple()`, `detect_batch()` and the `detect_language()` wrapper previously returned `"en"` whenever no detection was actually performed — text below the length threshold, empty text, `langdetect` not installed — or when detection raised. `"en"` is a valid ISO code, so a fabricated fallback was indistinguishable from a real English detection. They now return `UNKNOWN_LANGUAGE` (`"unknown"`), which is distinct from every ISO code. Nothing errors on this path, so callers relying on the old value get a different string silently: pass `LanguageDetector(default_language="en")` (or `detect_language(text, default_language="en")`) to restore the previous behavior
+  - `UNKNOWN_LANGUAGE` is exported from `semantica.normalize`. The out-of-band string is deliberate rather than the `Optional` treatment given to missing entity confidence in #1285: language codes flow into dict keys, filenames and `get_language_name()` lookups, so `None` here would trade an ambiguity for a crash surface
+  - **New `min_text_length` option** (default unchanged at 10 stripped characters), settable per instance via `LanguageDetector(min_text_length=...)`, per call via `**options` on every detection API, and through `detect_language()`. Ten characters is reasonable for Latin scripts and far too many for CJK — a 9-character Chinese string never reached `langdetect` at all
+  - `detect()` and `detect_with_confidence()` now delegate to `detect_multiple()`, so the length guard, the fallback and the error handling exist once rather than in three copies that can drift
+  - Invalid `min_text_length` values (`None`, non-numeric strings, negatives) degrade to the fallback with a warning instead of raising `TypeError` from the length comparison, which sits outside the detection exception handlers
+  - Unrecognized per-call option names (e.g. `min_text_len`) now warn once per name per instance instead of being silently absorbed by `**options`
+  - `detect_language()` copies the stored method config before merging per-call kwargs, so a one-call override no longer leaks into the shared `normalize_config`
+  - Docs: `docs/reference/normalize.md` and `semantica/normalize/normalize_usage.md`
+
 ## [0.7.0] - 2026-09-07
 
 ### Changed

--- a/docs/reference/normalize.md
+++ b/docs/reference/normalize.md
@@ -440,7 +440,19 @@ utf8_text = handle_encoding(raw_bytes, operation="convert")
     ```
 
     <Note>
-      `detect()` requires at least 10 characters for reliable detection. On shorter text it returns the `default_language` (default: `"en"`).
+      `detect()` skips detection on text shorter than `min_text_length` (default: 10 stripped characters) and returns the `default_language` instead. That fallback is `"unknown"` — the detector reports that it did not look rather than guessing a language. Both are configurable, per instance or per call:
+
+      ```python
+      # Lower the threshold for CJK, where 10 characters is far more than needed
+      detector = LanguageDetector(min_text_length=4)
+      detector.detect("短いテキスト")            # → "ja"
+
+      # Per-call override
+      LanguageDetector().detect("短いテキスト", min_text_length=4)   # → "ja"
+
+      # Opt back into assuming a language on text too short to examine
+      LanguageDetector(default_language="en").detect("Hi")          # → "en"
+      ```
     </Note>
 
     <Warning>

--- a/semantica/normalize/__init__.py
+++ b/semantica/normalize/__init__.py
@@ -143,7 +143,7 @@ from .entity_normalizer import (
     EntityNormalizer,
     NameVariantHandler,
 )
-from .language_detector import LanguageDetector
+from .language_detector import UNKNOWN_LANGUAGE, LanguageDetector
 from .methods import (
     clean_data,
     clean_text,
@@ -208,6 +208,7 @@ __all__ = [
     "TextCleaner",
     # Language detection
     "LanguageDetector",
+    "UNKNOWN_LANGUAGE",
     # Encoding handling
     "EncodingHandler",
     # Registry and Methods

--- a/semantica/normalize/language_detector.py
+++ b/semantica/normalize/language_detector.py
@@ -93,7 +93,10 @@ class LanguageDetector:
         self.config = config
         self.default_language = config.get("default_language", UNKNOWN_LANGUAGE)
         self.min_confidence = config.get("min_confidence", 0.5)
-        self.min_text_length = config.get("min_text_length", DEFAULT_MIN_TEXT_LENGTH)
+        self.min_text_length = self._normalize_min_text_length(
+            config.get("min_text_length", DEFAULT_MIN_TEXT_LENGTH),
+            DEFAULT_MIN_TEXT_LENGTH,
+        )
 
         if not LANGDETECT_AVAILABLE:
             self.logger.warning(
@@ -110,9 +113,28 @@ class LanguageDetector:
             f"Language detector initialized (default={self.default_language})"
         )
 
+    def _normalize_min_text_length(self, value: Any, fallback: int) -> int:
+        """Coerce a min_text_length value to a non-negative int.
+
+        Invalid values (None, non-numeric strings, ...) must degrade to the
+        fallback instead of raising during the length comparison, where no
+        detection exception handler protects the caller.
+        """
+        try:
+            return max(0, int(value))
+        except (TypeError, ValueError):
+            self.logger.warning(
+                f"Invalid min_text_length {value!r}, using {fallback}"
+            )
+            return fallback
+
     def _resolve_min_text_length(self, options: Dict[str, Any]) -> int:
         """Resolve the minimum text length, allowing per-call override."""
-        return options.get("min_text_length", self.min_text_length)
+        if "min_text_length" not in options:
+            return self.min_text_length
+        return self._normalize_min_text_length(
+            options["min_text_length"], self.min_text_length
+        )
 
     def _cannot_detect(self, text: str, options: Dict[str, Any]) -> bool:
         """True when detection cannot run for this input.

--- a/semantica/normalize/language_detector.py
+++ b/semantica/normalize/language_detector.py
@@ -29,7 +29,7 @@ License: MIT
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 try:
-    from langdetect import detect, detect_langs
+    from langdetect import detect_langs
     from langdetect.lang_detect_exception import LangDetectException
 
     LANGDETECT_AVAILABLE = True
@@ -44,9 +44,23 @@ from ..utils.progress_tracker import get_progress_tracker
 # Returned when no detection was performed (text too short, langdetect
 # unavailable) or detection failed. Distinct from every ISO language code,
 # so callers can never mistake a fallback for a detected language.
+#
+# Design note: unlike entity confidence (see semantic_extract.types, where
+# missing measurements are represented as None), the unknown language is an
+# out-of-band *string* rather than None. Language codes flow into dict keys,
+# file names and other string operations throughout the pipeline, so None
+# would trade one ambiguity for a crash surface; "unknown" stays inside the
+# str domain while remaining impossible to confuse with a real code. For
+# confidence there is no out-of-band float — every number is a plausible
+# score — hence None is the only honest representation there.
 UNKNOWN_LANGUAGE = "unknown"
 
 DEFAULT_MIN_TEXT_LENGTH = 10
+
+# Per-call options accepted by the detection APIs. Anything else is almost
+# certainly a typo (e.g. min_text_len) and is reported instead of being
+# silently ignored.
+KNOWN_DETECTION_OPTIONS = frozenset({"min_text_length"})
 
 
 class LanguageDetector:
@@ -97,6 +111,7 @@ class LanguageDetector:
             config.get("min_text_length", DEFAULT_MIN_TEXT_LENGTH),
             DEFAULT_MIN_TEXT_LENGTH,
         )
+        self._warned_options: set = set()
 
         if not LANGDETECT_AVAILABLE:
             self.logger.warning(
@@ -147,12 +162,28 @@ class LanguageDetector:
             return True
         return not LANGDETECT_AVAILABLE
 
+    def _warn_unknown_options(self, options: Dict[str, Any]) -> None:
+        """Report option names that no detection API understands.
+
+        **options would otherwise swallow typos silently (e.g. min_text_len),
+        making the caller believe an override took effect when nothing
+        happened. Warns once per unknown name per detector instance so batch
+        calls do not flood the log.
+        """
+        unknown = set(options) - KNOWN_DETECTION_OPTIONS - self._warned_options
+        if unknown:
+            self._warned_options |= unknown
+            self.logger.warning(
+                f"Ignoring unknown detection option(s) {sorted(unknown)}; "
+                f"supported options: {sorted(KNOWN_DETECTION_OPTIONS)}"
+            )
+
     def detect(self, text: str, **options) -> str:
         """
         Detect language of text.
 
-        This method detects the language of input text using langdetect.
-        Returns the default language if detection fails or text is too short.
+        Returns the most likely language code regardless of confidence; use
+        detect_with_confidence() to apply the min_confidence threshold.
 
         Args:
             text: Input text to analyze
@@ -169,20 +200,7 @@ class LanguageDetector:
             ``default_language`` (``"unknown"`` unless overridden) is returned
             as a fallback. The same fallback is returned if detection fails.
         """
-        if self._cannot_detect(text, options):
-            return self.default_language
-
-        try:
-            language = detect(text)
-            return language
-        except LangDetectException:
-            self.logger.warning(
-                f"Failed to detect language, using default: {self.default_language}"
-            )
-            return self.default_language
-        except Exception as e:
-            self.logger.error(f"Language detection error: {e}")
-            return self.default_language
+        return self.detect_multiple(text, top_n=1, **options)[0][0]
 
     def detect_with_confidence(self, text: str, **options) -> Tuple[str, float]:
         """
@@ -190,7 +208,8 @@ class LanguageDetector:
 
         This method detects the language of text and returns both the language
         code and confidence score. Only returns detected language if confidence
-        meets the minimum threshold.
+        meets the minimum threshold; otherwise the configured
+        ``default_language`` is returned with the observed confidence.
 
         Args:
             text: Input text to analyze
@@ -208,27 +227,10 @@ class LanguageDetector:
             ``(default_language, 0.0)`` as a fallback; the 0.0 confidence
             signals that no detection was performed.
         """
-        if self._cannot_detect(text, options):
-            return (self.default_language, 0.0)
-
-        try:
-            languages = detect_langs(text)
-            if languages:
-                top_language = languages[0]
-                if top_language.prob >= self.min_confidence:
-                    return (top_language.lang, top_language.prob)
-                else:
-                    return (self.default_language, top_language.prob)
-            else:
-                return (self.default_language, 0.0)
-        except LangDetectException:
-            self.logger.warning(
-                f"Failed to detect language, using default: {self.default_language}"
-            )
-            return (self.default_language, 0.0)
-        except Exception as e:
-            self.logger.error(f"Language detection error: {e}")
-            return (self.default_language, 0.0)
+        language, confidence = self.detect_multiple(text, top_n=1, **options)[0]
+        if confidence >= self.min_confidence:
+            return (language, confidence)
+        return (self.default_language, confidence)
 
     def detect_multiple(
         self, text: str, top_n: int = 3, **options
@@ -236,8 +238,9 @@ class LanguageDetector:
         """
         Detect top N languages with confidence scores.
 
-        This method detects multiple candidate languages for text, returning
-        the top N languages sorted by confidence.
+        This is the single detection core: detect() and
+        detect_with_confidence() delegate here, so guard, fallback and
+        error-handling semantics live in exactly one place.
 
         Args:
             text: Input text to analyze
@@ -255,6 +258,8 @@ class LanguageDetector:
             ``[(default_language, 0.0)]`` as a fallback; the 0.0 confidence
             signals that no detection was performed.
         """
+        self._warn_unknown_options(options)
+
         if self._cannot_detect(text, options):
             return [(self.default_language, 0.0)]
 

--- a/semantica/normalize/language_detector.py
+++ b/semantica/normalize/language_detector.py
@@ -11,6 +11,7 @@ Key Features:
     - Batch processing
     - Top N language detection
     - Language code to name mapping
+    - Configurable minimum text length with an "unknown" fallback
 
 Main Classes:
     - LanguageDetector: Language detection coordinator
@@ -76,6 +77,7 @@ class LanguageDetector:
         - Batch processing
         - Top N language detection
         - Language code to name mapping
+        - Configurable minimum text length with an "unknown" fallback
 
     Example Usage:
         >>> detector = LanguageDetector()
@@ -88,7 +90,8 @@ class LanguageDetector:
         """
         Initialize language detector.
 
-        Sets up the detector with default language and minimum confidence threshold.
+        Sets up the fallback language, the confidence threshold and the
+        minimum text length required to run detection.
 
         Args:
             **config: Configuration options:
@@ -111,7 +114,7 @@ class LanguageDetector:
             config.get("min_text_length", DEFAULT_MIN_TEXT_LENGTH),
             DEFAULT_MIN_TEXT_LENGTH,
         )
-        self._warned_options: set = set()
+        self._warned_options = set()
 
         if not LANGDETECT_AVAILABLE:
             self.logger.warning(

--- a/semantica/normalize/language_detector.py
+++ b/semantica/normalize/language_detector.py
@@ -41,6 +41,13 @@ from ..utils.exceptions import ProcessingError
 from ..utils.logging import get_logger
 from ..utils.progress_tracker import get_progress_tracker
 
+# Returned when no detection was performed (text too short, langdetect
+# unavailable) or detection failed. Distinct from every ISO language code,
+# so callers can never mistake a fallback for a detected language.
+UNKNOWN_LANGUAGE = "unknown"
+
+DEFAULT_MIN_TEXT_LENGTH = 10
+
 
 class LanguageDetector:
     """
@@ -71,7 +78,10 @@ class LanguageDetector:
 
         Args:
             **config: Configuration options:
-                - default_language: Default language code (default: "en")
+                - default_language: Language code returned when no detection
+                  was performed or detection failed (default:
+                  ``UNKNOWN_LANGUAGE``, i.e. ``"unknown"``). Set to a language
+                  code such as ``"en"`` to assume that language instead.
                 - min_confidence: Minimum confidence threshold (default: 0.5)
                 - min_text_length: Minimum stripped-text length required to run
                   detection (default: 10). Inputs shorter than this return the
@@ -81,9 +91,9 @@ class LanguageDetector:
         """
         self.logger = get_logger("language_detector")
         self.config = config
-        self.default_language = config.get("default_language", "en")
+        self.default_language = config.get("default_language", UNKNOWN_LANGUAGE)
         self.min_confidence = config.get("min_confidence", 0.5)
-        self.min_text_length = config.get("min_text_length", 10)
+        self.min_text_length = config.get("min_text_length", DEFAULT_MIN_TEXT_LENGTH)
 
         if not LANGDETECT_AVAILABLE:
             self.logger.warning(
@@ -100,9 +110,20 @@ class LanguageDetector:
             f"Language detector initialized (default={self.default_language})"
         )
 
-    def _min_text_length(self, options: Dict[str, Any]) -> int:
+    def _resolve_min_text_length(self, options: Dict[str, Any]) -> int:
         """Resolve the minimum text length, allowing per-call override."""
         return options.get("min_text_length", self.min_text_length)
+
+    def _cannot_detect(self, text: str, options: Dict[str, Any]) -> bool:
+        """True when detection cannot run for this input.
+
+        Detection is skipped when the stripped text is shorter than
+        ``min_text_length`` or when the langdetect library is unavailable;
+        callers must return the ``default_language`` fallback in that case.
+        """
+        if not text or len(text.strip()) < self._resolve_min_text_length(options):
+            return True
+        return not LANGDETECT_AVAILABLE
 
     def detect(self, text: str, **options) -> str:
         """
@@ -123,14 +144,10 @@ class LanguageDetector:
         Note:
             Inputs whose stripped length is below ``min_text_length``
             (default: 10) never reach the underlying detector; the configured
-            ``default_language`` is returned as a fallback. This fallback is
-            not a detection result. The same fallback is returned if
-            detection fails.
+            ``default_language`` (``"unknown"`` unless overridden) is returned
+            as a fallback. The same fallback is returned if detection fails.
         """
-        if not text or len(text.strip()) < self._min_text_length(options):
-            return self.default_language
-
-        if not LANGDETECT_AVAILABLE:
+        if self._cannot_detect(text, options):
             return self.default_language
 
         try:
@@ -169,10 +186,7 @@ class LanguageDetector:
             ``(default_language, 0.0)`` as a fallback; the 0.0 confidence
             signals that no detection was performed.
         """
-        if not text or len(text.strip()) < self._min_text_length(options):
-            return (self.default_language, 0.0)
-
-        if not LANGDETECT_AVAILABLE:
+        if self._cannot_detect(text, options):
             return (self.default_language, 0.0)
 
         try:
@@ -219,10 +233,7 @@ class LanguageDetector:
             ``[(default_language, 0.0)]`` as a fallback; the 0.0 confidence
             signals that no detection was performed.
         """
-        if not text or len(text.strip()) < self._min_text_length(options):
-            return [(self.default_language, 0.0)]
-
-        if not LANGDETECT_AVAILABLE:
+        if self._cannot_detect(text, options):
             return [(self.default_language, 0.0)]
 
         try:
@@ -318,6 +329,7 @@ class LanguageDetector:
                  Returns uppercase code if name not found.
         """
         language_names = {
+            UNKNOWN_LANGUAGE: "Unknown",
             "en": "English",
             "fr": "French",
             "de": "German",

--- a/semantica/normalize/language_detector.py
+++ b/semantica/normalize/language_detector.py
@@ -73,11 +73,17 @@ class LanguageDetector:
             **config: Configuration options:
                 - default_language: Default language code (default: "en")
                 - min_confidence: Minimum confidence threshold (default: 0.5)
+                - min_text_length: Minimum stripped-text length required to run
+                  detection (default: 10). Inputs shorter than this return the
+                  fallback (``default_language``) instead of a detected
+                  language. Lower this for language mixes where short inputs
+                  carry enough signal (e.g. CJK text).
         """
         self.logger = get_logger("language_detector")
         self.config = config
         self.default_language = config.get("default_language", "en")
         self.min_confidence = config.get("min_confidence", 0.5)
+        self.min_text_length = config.get("min_text_length", 10)
 
         if not LANGDETECT_AVAILABLE:
             self.logger.warning(
@@ -94,6 +100,10 @@ class LanguageDetector:
             f"Language detector initialized (default={self.default_language})"
         )
 
+    def _min_text_length(self, options: Dict[str, Any]) -> int:
+        """Resolve the minimum text length, allowing per-call override."""
+        return options.get("min_text_length", self.min_text_length)
+
     def detect(self, text: str, **options) -> str:
         """
         Detect language of text.
@@ -103,16 +113,21 @@ class LanguageDetector:
 
         Args:
             text: Input text to analyze
-            **options: Detection options (unused)
+            **options: Detection options:
+                - min_text_length: Override the instance-level minimum text
+                  length for this call
 
         Returns:
             str: Detected language code (e.g., "en", "fr", "de")
 
         Note:
-            Requires minimum text length of 10 characters for reliable detection.
-            Returns default_language if text is too short or detection fails.
+            Inputs whose stripped length is below ``min_text_length``
+            (default: 10) never reach the underlying detector; the configured
+            ``default_language`` is returned as a fallback. This fallback is
+            not a detection result. The same fallback is returned if
+            detection fails.
         """
-        if not text or len(text.strip()) < 10:
+        if not text or len(text.strip()) < self._min_text_length(options):
             return self.default_language
 
         if not LANGDETECT_AVAILABLE:
@@ -140,14 +155,21 @@ class LanguageDetector:
 
         Args:
             text: Input text to analyze
-            **options: Detection options (unused)
+            **options: Detection options:
+                - min_text_length: Override the instance-level minimum text
+                  length for this call
 
         Returns:
             tuple: (language_code, confidence_score) where:
                 - language_code: Detected language code
                 - confidence_score: Confidence score between 0.0 and 1.0
+
+        Note:
+            Inputs whose stripped length is below ``min_text_length`` return
+            ``(default_language, 0.0)`` as a fallback; the 0.0 confidence
+            signals that no detection was performed.
         """
-        if not text or len(text.strip()) < 10:
+        if not text or len(text.strip()) < self._min_text_length(options):
             return (self.default_language, 0.0)
 
         if not LANGDETECT_AVAILABLE:
@@ -184,13 +206,20 @@ class LanguageDetector:
         Args:
             text: Input text to analyze
             top_n: Number of top languages to return (default: 3)
-            **options: Detection options (unused)
+            **options: Detection options:
+                - min_text_length: Override the instance-level minimum text
+                  length for this call
 
         Returns:
             list: List of (language_code, confidence_score) tuples, sorted by
                   confidence (highest first)
+
+        Note:
+            Inputs whose stripped length is below ``min_text_length`` return
+            ``[(default_language, 0.0)]`` as a fallback; the 0.0 confidence
+            signals that no detection was performed.
         """
-        if not text or len(text.strip()) < 10:
+        if not text or len(text.strip()) < self._min_text_length(options):
             return [(self.default_language, 0.0)]
 
         if not LANGDETECT_AVAILABLE:

--- a/semantica/normalize/methods.py
+++ b/semantica/normalize/methods.py
@@ -714,10 +714,12 @@ def detect_language(
 
         detector = LanguageDetector(**config)
 
+        # kwargs were already consumed by the constructor above; forwarding
+        # them again would trip the detector's unknown-option warning
         if method == "confidence":
-            return detector.detect_with_confidence(text, **kwargs)
+            return detector.detect_with_confidence(text)
         else:
-            return detector.detect(text, **kwargs)
+            return detector.detect(text)
 
     except Exception as e:
         logger.error(f"Failed to detect language: {e}")

--- a/semantica/normalize/methods.py
+++ b/semantica/normalize/methods.py
@@ -707,7 +707,9 @@ def detect_language(
             return result
 
     try:
-        config = normalize_config.get_method_config("language")
+        # Copy before merging: get_method_config() returns the stored dict by
+        # reference, and per-call kwargs must not leak into the global config
+        config = dict(normalize_config.get_method_config("language"))
         config.update(kwargs)
 
         detector = LanguageDetector(**config)

--- a/semantica/normalize/normalize_usage.md
+++ b/semantica/normalize/normalize_usage.md
@@ -460,7 +460,9 @@ language = detector.detect("Bonjour le monde")
 
 Inputs whose stripped length is below `min_text_length` (default: 10) are not
 detected; the configured `default_language` is returned as a fallback (with a
-`0.0` confidence in the confidence-returning APIs). Lower the threshold for
+`0.0` confidence in the confidence-returning APIs). The fallback defaults to
+`"unknown"` so it can never be mistaken for a detected language — set
+`default_language="en"` to assume English instead. Lower the threshold for
 language mixes where short inputs carry enough signal, e.g. CJK text:
 
 ```python

--- a/semantica/normalize/normalize_usage.md
+++ b/semantica/normalize/normalize_usage.md
@@ -458,6 +458,22 @@ detector = LanguageDetector()
 language = detector.detect("Bonjour le monde")
 ```
 
+Inputs whose stripped length is below `min_text_length` (default: 10) are not
+detected; the configured `default_language` is returned as a fallback (with a
+`0.0` confidence in the confidence-returning APIs). Lower the threshold for
+language mixes where short inputs carry enough signal, e.g. CJK text:
+
+```python
+from semantica.normalize import LanguageDetector
+
+detector = LanguageDetector(min_text_length=5)
+language = detector.detect("你好，这是中文文本")  # zh-cn
+
+# Or override per call
+detector = LanguageDetector()
+language = detector.detect("你好，这是中文文本", min_text_length=5)
+```
+
 ### Confidence
 
 ```python

--- a/tests/normalize/test_language_detector.py
+++ b/tests/normalize/test_language_detector.py
@@ -37,6 +37,47 @@ class TestLanguageDetector(unittest.TestCase):
         self.assertEqual(lang, "en")
         self.assertGreater(conf, 0.5)
 
+    def test_default_min_text_length_preserved(self):
+        # Backward compatibility: default threshold stays at 10
+        self.assertEqual(self.detector.min_text_length, 10)
+        self.assertEqual(self.detector.detect("Short txt"), "en")
+
+    def test_short_text_fallback_has_zero_confidence(self):
+        # Fallback must be distinguishable from a genuine detection
+        lang, conf = self.detector.detect_with_confidence("Hi")
+        self.assertEqual((lang, conf), ("en", 0.0))
+        self.assertEqual(self.detector.detect_multiple("Hi"), [("en", 0.0)])
+
+    @unittest.skipUnless(LANGDETECT_AVAILABLE, "langdetect is not installed")
+    def test_short_non_latin_text_with_configured_threshold(self):
+        # 9 stripped chars: below the default threshold, silently falls back
+        text = "你好，这是中文文本"
+        self.assertEqual(self.detector.detect(text), "en")
+
+        # A configured threshold lets short CJK text reach the detector
+        detector = LanguageDetector(min_text_length=5)
+        self.assertTrue(detector.detect(text).startswith("zh"))
+
+        lang, conf = detector.detect_with_confidence(text)
+        self.assertTrue(lang.startswith("zh"))
+        self.assertGreater(conf, 0.5)
+
+        languages = detector.detect_multiple(text)
+        self.assertTrue(languages[0][0].startswith("zh"))
+
+    @unittest.skipUnless(LANGDETECT_AVAILABLE, "langdetect is not installed")
+    def test_min_text_length_per_call_override(self):
+        text = "你好，这是中文文本"
+        self.assertEqual(self.detector.detect(text), "en")
+        self.assertTrue(
+            self.detector.detect(text, min_text_length=5).startswith("zh")
+        )
+
+    def test_min_text_length_still_guards_empty_text(self):
+        detector = LanguageDetector(min_text_length=0)
+        self.assertEqual(detector.detect(""), "en")
+        self.assertEqual(detector.detect_with_confidence(""), ("en", 0.0))
+
     def test_get_language_name(self):
         self.assertEqual(self.detector.get_language_name("en"), "English")
         self.assertEqual(self.detector.get_language_name("fr"), "French")

--- a/tests/normalize/test_language_detector.py
+++ b/tests/normalize/test_language_detector.py
@@ -2,6 +2,7 @@ import unittest
 
 from semantica.normalize.language_detector import (
     LANGDETECT_AVAILABLE,
+    UNKNOWN_LANGUAGE,
     LanguageDetector,
 )
 
@@ -25,9 +26,13 @@ class TestLanguageDetector(unittest.TestCase):
             self.detector.detect("Dies ist ein einfacher deutscher Satz."), "de"
         )
 
-    def test_detect_short_text(self):
-        # Should return default for very short text
-        self.assertEqual(self.detector.detect("Hi"), "en")
+    def test_detect_short_text_returns_unknown(self):
+        # Undetected input must not masquerade as a detected language
+        self.assertEqual(self.detector.detect("Hi"), UNKNOWN_LANGUAGE)
+
+    def test_configured_default_language_restores_assumption(self):
+        detector = LanguageDetector(default_language="en")
+        self.assertEqual(detector.detect("Hi"), "en")
 
     @unittest.skipUnless(LANGDETECT_AVAILABLE, "langdetect is not installed")
     def test_detect_with_confidence(self):
@@ -40,19 +45,21 @@ class TestLanguageDetector(unittest.TestCase):
     def test_default_min_text_length_preserved(self):
         # Backward compatibility: default threshold stays at 10
         self.assertEqual(self.detector.min_text_length, 10)
-        self.assertEqual(self.detector.detect("Short txt"), "en")
+        self.assertEqual(self.detector.detect("Short txt"), UNKNOWN_LANGUAGE)
 
     def test_short_text_fallback_has_zero_confidence(self):
         # Fallback must be distinguishable from a genuine detection
         lang, conf = self.detector.detect_with_confidence("Hi")
-        self.assertEqual((lang, conf), ("en", 0.0))
-        self.assertEqual(self.detector.detect_multiple("Hi"), [("en", 0.0)])
+        self.assertEqual((lang, conf), (UNKNOWN_LANGUAGE, 0.0))
+        self.assertEqual(
+            self.detector.detect_multiple("Hi"), [(UNKNOWN_LANGUAGE, 0.0)]
+        )
 
     @unittest.skipUnless(LANGDETECT_AVAILABLE, "langdetect is not installed")
     def test_short_non_latin_text_with_configured_threshold(self):
-        # 9 stripped chars: below the default threshold, silently falls back
+        # 9 stripped chars: below the default threshold, falls back to unknown
         text = "你好，这是中文文本"
-        self.assertEqual(self.detector.detect(text), "en")
+        self.assertEqual(self.detector.detect(text), UNKNOWN_LANGUAGE)
 
         # A configured threshold lets short CJK text reach the detector
         detector = LanguageDetector(min_text_length=5)
@@ -68,19 +75,24 @@ class TestLanguageDetector(unittest.TestCase):
     @unittest.skipUnless(LANGDETECT_AVAILABLE, "langdetect is not installed")
     def test_min_text_length_per_call_override(self):
         text = "你好，这是中文文本"
-        self.assertEqual(self.detector.detect(text), "en")
+        self.assertEqual(self.detector.detect(text), UNKNOWN_LANGUAGE)
         self.assertTrue(
             self.detector.detect(text, min_text_length=5).startswith("zh")
         )
 
     def test_min_text_length_still_guards_empty_text(self):
         detector = LanguageDetector(min_text_length=0)
-        self.assertEqual(detector.detect(""), "en")
-        self.assertEqual(detector.detect_with_confidence(""), ("en", 0.0))
+        self.assertEqual(detector.detect(""), UNKNOWN_LANGUAGE)
+        self.assertEqual(
+            detector.detect_with_confidence(""), (UNKNOWN_LANGUAGE, 0.0)
+        )
 
     def test_get_language_name(self):
         self.assertEqual(self.detector.get_language_name("en"), "English")
         self.assertEqual(self.detector.get_language_name("fr"), "French")
+        self.assertEqual(
+            self.detector.get_language_name(UNKNOWN_LANGUAGE), "Unknown"
+        )
         self.assertEqual(self.detector.get_language_name("xx"), "XX")
 
 

--- a/tests/normalize/test_language_detector.py
+++ b/tests/normalize/test_language_detector.py
@@ -120,6 +120,38 @@ class TestLanguageDetector(unittest.TestCase):
         finally:
             normalize_config.set_method_config("language", **original)
 
+    def test_unknown_option_names_are_reported_not_swallowed(self):
+        from unittest.mock import patch
+
+        detector = LanguageDetector(min_text_length=5)
+        with patch.object(detector, "logger") as mock_logger:
+            # Typo'd option name: must warn instead of silently ignoring
+            detector.detect("Hi", min_text_len=1)
+            detector.detect("Hi", min_text_len=1)
+
+        warnings = [
+            call.args[0] for call in mock_logger.warning.call_args_list
+        ]
+        self.assertEqual(len(warnings), 1)  # once per name, not per call
+        self.assertIn("min_text_len", warnings[0])
+
+        # Valid option names must not warn (threshold high enough that the
+        # guard short-circuits before any langdetect call can log)
+        with patch.object(detector, "logger") as mock_logger:
+            detector.detect("Hi", min_text_length=100)
+        mock_logger.warning.assert_not_called()
+
+    @unittest.skipUnless(LANGDETECT_AVAILABLE, "langdetect is not installed")
+    def test_detect_apis_share_one_semantic_core(self):
+        # detect() and detect_with_confidence() delegate to detect_multiple(),
+        # so all three must agree on the same input
+        text = "Ceci est une phrase française simple."
+        top_lang, top_conf = self.detector.detect_multiple(text, top_n=1)[0]
+        self.assertEqual(self.detector.detect(text), top_lang)
+        lang, conf = self.detector.detect_with_confidence(text)
+        self.assertEqual(lang, top_lang)
+        self.assertGreater(conf, 0.5)
+
     def test_get_language_name(self):
         self.assertEqual(self.detector.get_language_name("en"), "English")
         self.assertEqual(self.detector.get_language_name("fr"), "French")

--- a/tests/normalize/test_language_detector.py
+++ b/tests/normalize/test_language_detector.py
@@ -87,6 +87,39 @@ class TestLanguageDetector(unittest.TestCase):
             detector.detect_with_confidence(""), (UNKNOWN_LANGUAGE, 0.0)
         )
 
+    def test_invalid_min_text_length_degrades_to_fallback(self):
+        # Invalid values must not raise TypeError during the length check
+        for invalid in (None, "abc", object()):
+            detector = LanguageDetector(min_text_length=invalid)
+            self.assertEqual(detector.min_text_length, 10)
+            self.assertEqual(detector.detect("Hi"), UNKNOWN_LANGUAGE)
+
+        # Invalid per-call override falls back to the instance value
+        detector = LanguageDetector(min_text_length=3)
+        self.assertEqual(
+            detector.detect("Hi", min_text_length=None), UNKNOWN_LANGUAGE
+        )
+
+        # Numeric-ish values are coerced; negatives clamp to zero
+        self.assertEqual(LanguageDetector(min_text_length="5").min_text_length, 5)
+        self.assertEqual(LanguageDetector(min_text_length=-1).min_text_length, 0)
+        self.assertEqual(LanguageDetector(min_text_length=2.9).min_text_length, 2)
+
+    def test_detect_language_wrapper_does_not_mutate_global_config(self):
+        from semantica.normalize.config import normalize_config
+        from semantica.normalize.methods import detect_language
+
+        original = dict(normalize_config.get_method_config("language"))
+        normalize_config.set_method_config("language", default_language="en")
+        try:
+            detect_language("Hi", min_text_length=1)
+            self.assertNotIn(
+                "min_text_length",
+                normalize_config.get_method_config("language"),
+            )
+        finally:
+            normalize_config.set_method_config("language", **original)
+
     def test_get_language_name(self):
         self.assertEqual(self.detector.get_language_name("en"), "English")
         self.assertEqual(self.detector.get_language_name("fr"), "French")


### PR DESCRIPTION
## Summary

`LanguageDetector` hard-coded a 10-character minimum stripped-text length in its detection APIs. Short non-English inputs (e.g. the 9-character `"你好，这是中文文本"`) never reached `langdetect` and silently returned the fallback, indistinguishable from a genuine English detection.

- Add a `min_text_length` configuration option (default unchanged at `10`), with per-call override via `**options` in all detection APIs and through the `detect_language()` convenience wrapper
- **Make the fallback honest**: when no detection was performed (below-threshold text, empty text, langdetect unavailable) or detection failed, return `UNKNOWN_LANGUAGE` (`"unknown"`) instead of `"en"`. `"unknown"` is distinct from every ISO code, so a fallback can never be mistaken for a detected language. Callers that want the previous behavior configure `LanguageDetector(default_language="en")`
- **Single detection core**: `detect()` and `detect_with_confidence()` now delegate to `detect_multiple()`, so guard, fallback and error-handling semantics live in exactly one place instead of being triplicated
- **Typos are reported, not swallowed**: unknown per-call option names (e.g. `min_text_len`) trigger a warning (once per name per instance) instead of being silently ignored by `**options`
- **Hardened boundaries**: invalid `min_text_length` values (None, non-numeric strings) degrade to the fallback with a warning instead of raising `TypeError`; `detect_language()` copies the stored method config before merging kwargs so per-call overrides no longer mutate the global `normalize_config`
- Document the fallback semantics and the deliberate string-sentinel vs `Optional` trade-off (vs. entity confidence in #1285); export `UNKNOWN_LANGUAGE` from `semantica.normalize`

```python
detector = LanguageDetector()
detector.detect("你好，这是中文文本")                    # "unknown" (was a fake "en")
detector.detect("你好，这是中文文本", min_text_length=5)  # "zh-cn"
```

> **Behavior change**: the default fallback is now `"unknown"` instead of `"en"`. Inside this repo `LanguageDetector` is only consumed via the config-driven `normalize.methods.detect_language()`, and no code branches on the `"en"` fallback. If you prefer to keep `"en"` as the out-of-the-box default for compatibility, I'm happy to flip the default back — the `unknown` semantics would then remain available via `default_language="unknown"`.

## Test plan

- [x] Regression tests in `tests/normalize/test_language_detector.py` cover: short non-Latin fallback + configured/per-call thresholds, `"unknown"` semantics with `0.0` confidence, `default_language="en"` compatibility, invalid threshold degradation, global-config leak, unknown-option warning, and agreement across the three detection APIs
- [x] `pytest tests/normalize/` — 93 passed

Closes #1281

🤖 Generated with [Claude Code](https://claude.com/claude-code)
