### PR TITLE
fix(llms): align structured return annotations

### DIFF
--- a/docs/guides/llm-integrations.md
+++ b/docs/guides/llm-integrations.md
@@ -70,15 +70,21 @@ The unified interface means you can prototype with Groq for speed, validate accu
 
 ## The Shared Interface
 
-Every provider exposes the same two methods:
+Every provider exposes the same interface:
 
 ```python
-provider.generate(prompt: str, **kwargs) -> str
-provider.generate_structured(prompt: str, **kwargs) -> Union[Dict[str, Any], List[Any]]
-provider.is_available() -> bool
+from typing import Protocol
+
+from semantica.llms import JSONValue
+
+
+class LLMProvider(Protocol):
+    def generate(self, prompt: str, **kwargs) -> str: ...
+    def generate_structured(self, prompt: str, **kwargs) -> JSONValue: ...
+    def is_available(self) -> bool: ...
 ```
 
-`generate()` returns a plain string. `generate_structured()` instructs the model to respond in JSON and returns a `dict` for a top-level object or a `list` for a top-level array. `is_available()` lets you health-check the provider before committing to a call. This is useful in retry logic and warm-up checks.
+`generate()` returns a plain string. `generate_structured()` instructs the model to respond in JSON and returns any valid JSON value: an object, array, string, number, boolean, or `None` for JSON `null`. `is_available()` lets you health-check the provider before committing to a call. This is useful in retry logic and warm-up checks.
 
 This means every place in Semantica that accepts an LLM — `query_with_reasoning()`, semantic extraction, custom reasoning loops — accepts any of these providers interchangeably.
 

--- a/docs/guides/llm-integrations.md
+++ b/docs/guides/llm-integrations.md
@@ -74,11 +74,11 @@ Every provider exposes the same two methods:
 
 ```python
 provider.generate(prompt: str, **kwargs) -> str
-provider.generate_structured(prompt: str, **kwargs) -> dict
+provider.generate_structured(prompt: str, **kwargs) -> Union[Dict[str, Any], List[Any]]
 provider.is_available() -> bool
 ```
 
-`generate()` returns a plain string. `generate_structured()` instructs the model to respond in JSON and returns a parsed `dict`. `is_available()` lets you health-check the provider before committing to a call — useful in retry logic and warm-up checks.
+`generate()` returns a plain string. `generate_structured()` instructs the model to respond in JSON and returns a `dict` for a top-level object or a `list` for a top-level array. `is_available()` lets you health-check the provider before committing to a call. This is useful in retry logic and warm-up checks.
 
 This means every place in Semantica that accepts an LLM — `query_with_reasoning()`, semantic extraction, custom reasoning loops — accepts any of these providers interchangeably.
 
@@ -107,7 +107,7 @@ verdict = groq.generate(
 print(verdict)
 # "True positive — volume and speed are consistent with T1087.002 domain enumeration."
 
-# Structured extraction — returns a parsed dict
+# Structured extraction
 entities = groq.generate_structured(
     "Extract threat actors and CVEs from: "
     "APT29 exploited CVE-2024-3400 in PAN-OS GlobalProtect."
@@ -711,7 +711,7 @@ for src in best["sources"]:
 
 **Using LLMs for deterministic pattern matching that regex can handle.** If your task is extracting email addresses, phone numbers, or other pattern-based entities, regular expressions are faster, cheaper, and more reliable than LLM extraction. Use LLMs when context, ambiguity, or domain knowledge matter for correct interpretation.
 
-**Not validating structured outputs.** The `generate_structured()` method returns parsed JSON, but LLMs can still produce malformed or incomplete structures. Always validate the returned dictionary against your expected schema before using the data downstream.
+**Not validating structured outputs.** The `generate_structured()` method returns parsed JSON, but LLMs can still produce malformed or incomplete structures. Always validate the returned value against your expected schema before using the data downstream.
 
 **Switching providers without testing prompt behavior.** Different models respond differently to the same prompt. A prompt optimized for GPT-4 may produce poor results with Llama or Claude. When switching providers, test your prompts and adjust temperature, instructions, or examples as needed.
 

--- a/semantica/llms/__init__.py
+++ b/semantica/llms/__init__.py
@@ -71,6 +71,7 @@ from .gemini import Gemini
 from .ollama import Ollama
 from .deepseek import DeepSeek
 from .novita import Novita
+from .types import JSONValue
 
 __all__ = [
     "Groq",
@@ -82,4 +83,5 @@ __all__ = [
     "Ollama",
     "DeepSeek",
     "Novita",
+    "JSONValue",
 ]

--- a/semantica/llms/anthropic.py
+++ b/semantica/llms/anthropic.py
@@ -4,11 +4,12 @@ Anthropic LLM Provider
 Wrapper for Anthropic Claude API provider with clean interface
 """
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional
 
 from ..semantic_extract.providers import AnthropicProvider
 from ..utils.exceptions import ProcessingError
 from ..utils.logging import get_logger
+from .types import JSONValue
 
 logger = get_logger("llms.anthropic")
 
@@ -67,7 +68,7 @@ class Anthropic:
             )
         return self.provider.generate(prompt, **kwargs)
 
-    def generate_structured(self, prompt: str, **kwargs) -> Union[Dict[str, Any], List[Any]]:
+    def generate_structured(self, prompt: str, **kwargs) -> JSONValue:
         """
         Generates structured JSON output.
 
@@ -76,8 +77,8 @@ class Anthropic:
             **kwargs: Generation options
 
         Returns:
-            Parsed JSON response. A dict for a top-level JSON object, or a
-            list if the model returns a top-level JSON array.
+            Parsed JSON response as an object, array, string, number, boolean,
+            or None.
 
         Raises:
             ProcessingError: If provider is not available or generation fails

--- a/semantica/llms/deepseek.py
+++ b/semantica/llms/deepseek.py
@@ -4,11 +4,12 @@ DeepSeek LLM Provider
 Wrapper for DeepSeek API provider with clean interface.
 """
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional
 
 from ..semantic_extract.providers import DeepSeekProvider
 from ..utils.exceptions import ProcessingError
 from ..utils.logging import get_logger
+from .types import JSONValue
 
 logger = get_logger("llms.deepseek")
 
@@ -67,7 +68,7 @@ class DeepSeek:
             )
         return self.provider.generate(prompt, **kwargs)
 
-    def generate_structured(self, prompt: str, **kwargs) -> Union[Dict[str, Any], List[Any]]:
+    def generate_structured(self, prompt: str, **kwargs) -> JSONValue:
         """
         Generate structured JSON output.
 
@@ -76,8 +77,8 @@ class DeepSeek:
             **kwargs: Generation options
 
         Returns:
-            Parsed JSON response. A dict for a top-level JSON object, or a
-            list if the model returns a top-level JSON array.
+            Parsed JSON response as an object, array, string, number, boolean,
+            or None.
 
         Raises:
             ProcessingError: If provider is not available or generation fails

--- a/semantica/llms/gemini.py
+++ b/semantica/llms/gemini.py
@@ -4,11 +4,12 @@ Gemini LLM Provider
 Wrapper for Google Gemini API provider with clean interface.
 """
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional
 
 from ..semantic_extract.providers import GeminiProvider
 from ..utils.exceptions import ProcessingError
 from ..utils.logging import get_logger
+from .types import JSONValue
 
 logger = get_logger("llms.gemini")
 
@@ -67,7 +68,7 @@ class Gemini:
             )
         return self.provider.generate(prompt, **kwargs)
 
-    def generate_structured(self, prompt: str, **kwargs) -> Union[Dict[str, Any], List[Any]]:
+    def generate_structured(self, prompt: str, **kwargs) -> JSONValue:
         """
         Generate structured JSON output.
 
@@ -76,8 +77,8 @@ class Gemini:
             **kwargs: Generation options
 
         Returns:
-            Parsed JSON response. A dict for a top-level JSON object, or a
-            list if the model returns a top-level JSON array.
+            Parsed JSON response as an object, array, string, number, boolean,
+            or None.
 
         Raises:
             ProcessingError: If provider is not available or parsing fails

--- a/semantica/llms/groq.py
+++ b/semantica/llms/groq.py
@@ -4,11 +4,12 @@ Groq LLM Provider
 Wrapper for Groq API provider with clean interface.
 """
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Optional
 
 from ..semantic_extract.providers import GroqProvider
 from ..utils.exceptions import ProcessingError
 from ..utils.logging import get_logger
+from .types import JSONValue
 
 logger = get_logger("llms.groq")
 
@@ -67,9 +68,7 @@ class Groq:
             )
         return self.provider.generate(prompt, **kwargs)
 
-    def generate_structured(
-        self, prompt: str, **kwargs
-    ) -> Union[Dict[str, Any], List[Any]]:
+    def generate_structured(self, prompt: str, **kwargs) -> JSONValue:
         """
         Generate structured JSON output.
 
@@ -78,8 +77,8 @@ class Groq:
             **kwargs: Generation options
 
         Returns:
-            Parsed JSON response. A dict for a top-level JSON object, or a
-            list if the model returns a top-level JSON array.
+            Parsed JSON response as an object, array, string, number, boolean,
+            or None.
 
         Raises:
             ProcessingError: If provider is not available or parsing fails

--- a/semantica/llms/groq.py
+++ b/semantica/llms/groq.py
@@ -4,7 +4,7 @@ Groq LLM Provider
 Wrapper for Groq API provider with clean interface.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from ..semantic_extract.providers import GroqProvider
 from ..utils.exceptions import ProcessingError
@@ -67,7 +67,9 @@ class Groq:
             )
         return self.provider.generate(prompt, **kwargs)
 
-    def generate_structured(self, prompt: str, **kwargs) -> Dict[str, Any]:
+    def generate_structured(
+        self, prompt: str, **kwargs
+    ) -> Union[Dict[str, Any], List[Any]]:
         """
         Generate structured JSON output.
 
@@ -76,7 +78,8 @@ class Groq:
             **kwargs: Generation options
 
         Returns:
-            Parsed JSON response as dictionary
+            Parsed JSON response. A dict for a top-level JSON object, or a
+            list if the model returns a top-level JSON array.
 
         Raises:
             ProcessingError: If provider is not available or parsing fails
@@ -86,4 +89,3 @@ class Groq:
                 "Groq provider not available. Set GROQ_API_KEY or pass api_key."
             )
         return self.provider.generate_structured(prompt, **kwargs)
-

--- a/semantica/llms/huggingface.py
+++ b/semantica/llms/huggingface.py
@@ -4,7 +4,7 @@ HuggingFace LLM Provider
 Wrapper for HuggingFace Transformers LLM provider with clean interface.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from ..semantic_extract.providers import HuggingFaceLLMProvider
 from ..utils.exceptions import ProcessingError
@@ -78,7 +78,9 @@ class HuggingFaceLLM:
             )
         return self.provider.generate(prompt, **kwargs)
 
-    def generate_structured(self, prompt: str, **kwargs) -> Dict[str, Any]:
+    def generate_structured(
+        self, prompt: str, **kwargs
+    ) -> Union[Dict[str, Any], List[Any]]:
         """
         Generate structured JSON output.
 
@@ -87,7 +89,8 @@ class HuggingFaceLLM:
             **kwargs: Generation options
 
         Returns:
-            Parsed JSON response as dictionary
+            Parsed JSON response. A dict for a top-level JSON object, or a
+            list if the model returns a top-level JSON array.
 
         Raises:
             ProcessingError: If provider is not available or parsing fails
@@ -97,4 +100,3 @@ class HuggingFaceLLM:
                 "HuggingFace LLM provider not available. Install transformers library."
             )
         return self.provider.generate_structured(prompt, **kwargs)
-

--- a/semantica/llms/huggingface.py
+++ b/semantica/llms/huggingface.py
@@ -4,11 +4,12 @@ HuggingFace LLM Provider
 Wrapper for HuggingFace Transformers LLM provider with clean interface.
 """
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Optional
 
 from ..semantic_extract.providers import HuggingFaceLLMProvider
 from ..utils.exceptions import ProcessingError
 from ..utils.logging import get_logger
+from .types import JSONValue
 
 logger = get_logger("llms.huggingface")
 
@@ -78,9 +79,7 @@ class HuggingFaceLLM:
             )
         return self.provider.generate(prompt, **kwargs)
 
-    def generate_structured(
-        self, prompt: str, **kwargs
-    ) -> Union[Dict[str, Any], List[Any]]:
+    def generate_structured(self, prompt: str, **kwargs) -> JSONValue:
         """
         Generate structured JSON output.
 
@@ -89,8 +88,8 @@ class HuggingFaceLLM:
             **kwargs: Generation options
 
         Returns:
-            Parsed JSON response. A dict for a top-level JSON object, or a
-            list if the model returns a top-level JSON array.
+            Parsed JSON response as an object, array, string, number, boolean,
+            or None.
 
         Raises:
             ProcessingError: If provider is not available or parsing fails

--- a/semantica/llms/litellm.py
+++ b/semantica/llms/litellm.py
@@ -5,10 +5,11 @@ Wrapper for LiteLLM library that provides unified access to 100+ LLM providers.
 Supports OpenAI, Anthropic, Groq, Azure, Bedrock, Vertex AI, and many more.
 """
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Optional
 
 from ..utils.exceptions import ProcessingError
 from ..utils.logging import get_logger
+from .types import JSONValue
 
 logger = get_logger("llms.litellm")
 
@@ -123,9 +124,7 @@ class LiteLLM:
             logger.error(f"LiteLLM generation failed: {e}")
             raise ProcessingError(f"LiteLLM generation failed: {e}")
 
-    def generate_structured(
-        self, prompt: str, **kwargs
-    ) -> Union[Dict[str, Any], List[Any]]:
+    def generate_structured(self, prompt: str, **kwargs) -> JSONValue:
         """
         Generate structured JSON output.
 
@@ -134,8 +133,8 @@ class LiteLLM:
             **kwargs: Generation options
 
         Returns:
-            Parsed JSON response. A dict for a top-level JSON object, or a
-            list if the model returns a top-level JSON array.
+            Parsed JSON response as an object, array, string, number, boolean,
+            or None.
 
         Raises:
             ProcessingError: If provider is not available or parsing fails

--- a/semantica/llms/litellm.py
+++ b/semantica/llms/litellm.py
@@ -5,7 +5,7 @@ Wrapper for LiteLLM library that provides unified access to 100+ LLM providers.
 Supports OpenAI, Anthropic, Groq, Azure, Bedrock, Vertex AI, and many more.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from ..utils.exceptions import ProcessingError
 from ..utils.logging import get_logger
@@ -123,7 +123,9 @@ class LiteLLM:
             logger.error(f"LiteLLM generation failed: {e}")
             raise ProcessingError(f"LiteLLM generation failed: {e}")
 
-    def generate_structured(self, prompt: str, **kwargs) -> Dict[str, Any]:
+    def generate_structured(
+        self, prompt: str, **kwargs
+    ) -> Union[Dict[str, Any], List[Any]]:
         """
         Generate structured JSON output.
 
@@ -132,7 +134,8 @@ class LiteLLM:
             **kwargs: Generation options
 
         Returns:
-            Parsed JSON response as dictionary
+            Parsed JSON response. A dict for a top-level JSON object, or a
+            list if the model returns a top-level JSON array.
 
         Raises:
             ProcessingError: If provider is not available or parsing fails
@@ -188,4 +191,3 @@ class LiteLLM:
         except Exception as e:
             logger.error(f"LiteLLM structured generation failed: {e}")
             raise ProcessingError(f"LiteLLM structured generation failed: {e}")
-

--- a/semantica/llms/novita.py
+++ b/semantica/llms/novita.py
@@ -4,11 +4,12 @@ Novita LLM Provider
 Wrapper for Novita AI's OpenAI-compatible API with clean interface.
 """
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional
 
 from ..semantic_extract.providers import NovitaProvider
 from ..utils.exceptions import ProcessingError
 from ..utils.logging import get_logger
+from .types import JSONValue
 
 logger = get_logger("llms.novita")
 
@@ -67,7 +68,7 @@ class Novita:
             )
         return self.provider.generate(prompt, **kwargs)
 
-    def generate_structured(self, prompt: str, **kwargs) -> Union[Dict[str, Any], List[Any]]:
+    def generate_structured(self, prompt: str, **kwargs) -> JSONValue:
         """
         Generate structured JSON output.
 
@@ -76,8 +77,8 @@ class Novita:
             **kwargs: Generation options
 
         Returns:
-            Parsed JSON response. A dict for a top-level JSON object, or a
-            list if the model returns a top-level JSON array.
+            Parsed JSON response as an object, array, string, number, boolean,
+            or None.
 
         Raises:
             ProcessingError: If provider is not available or generation fails

--- a/semantica/llms/ollama.py
+++ b/semantica/llms/ollama.py
@@ -4,11 +4,12 @@ Ollama LLM Provider
 Wrapper for local Ollama models with clean interface.
 """
 
-from typing import Any, Dict, List, Union
+from typing import Any
 
 from ..semantic_extract.providers import OllamaProvider
 from ..utils.exceptions import ProcessingError
 from ..utils.logging import get_logger
+from .types import JSONValue
 
 logger = get_logger("llms.ollama")
 
@@ -70,7 +71,7 @@ class Ollama:
             )
         return self.provider.generate(prompt, **kwargs)
 
-    def generate_structured(self, prompt: str, **kwargs) -> Union[Dict[str, Any], List[Any]]:
+    def generate_structured(self, prompt: str, **kwargs) -> JSONValue:
         """
         Generate structured JSON output.
 
@@ -79,8 +80,8 @@ class Ollama:
             **kwargs: Generation options
 
         Returns:
-            Parsed JSON response. A dict for a top-level JSON object, or a
-            list if the model returns a top-level JSON array.
+            Parsed JSON response as an object, array, string, number, boolean,
+            or None.
 
         Raises:
             ProcessingError: If provider is not available or parsing fails

--- a/semantica/llms/openai.py
+++ b/semantica/llms/openai.py
@@ -4,7 +4,7 @@ OpenAI LLM Provider
 Wrapper for OpenAI API provider with clean interface.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from ..semantic_extract.providers import OpenAIProvider
 from ..utils.exceptions import ProcessingError
@@ -67,7 +67,9 @@ class OpenAI:
             )
         return self.provider.generate(prompt, **kwargs)
 
-    def generate_structured(self, prompt: str, **kwargs) -> Dict[str, Any]:
+    def generate_structured(
+        self, prompt: str, **kwargs
+    ) -> Union[Dict[str, Any], List[Any]]:
         """
         Generate structured JSON output.
 
@@ -76,7 +78,8 @@ class OpenAI:
             **kwargs: Generation options
 
         Returns:
-            Parsed JSON response as dictionary
+            Parsed JSON response. A dict for a top-level JSON object, or a
+            list if the model returns a top-level JSON array.
 
         Raises:
             ProcessingError: If provider is not available or parsing fails
@@ -86,4 +89,3 @@ class OpenAI:
                 "OpenAI provider not available. Set OPENAI_API_KEY or pass api_key."
             )
         return self.provider.generate_structured(prompt, **kwargs)
-

--- a/semantica/llms/openai.py
+++ b/semantica/llms/openai.py
@@ -4,11 +4,12 @@ OpenAI LLM Provider
 Wrapper for OpenAI API provider with clean interface.
 """
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Optional
 
 from ..semantic_extract.providers import OpenAIProvider
 from ..utils.exceptions import ProcessingError
 from ..utils.logging import get_logger
+from .types import JSONValue
 
 logger = get_logger("llms.openai")
 
@@ -67,9 +68,7 @@ class OpenAI:
             )
         return self.provider.generate(prompt, **kwargs)
 
-    def generate_structured(
-        self, prompt: str, **kwargs
-    ) -> Union[Dict[str, Any], List[Any]]:
+    def generate_structured(self, prompt: str, **kwargs) -> JSONValue:
         """
         Generate structured JSON output.
 
@@ -78,8 +77,8 @@ class OpenAI:
             **kwargs: Generation options
 
         Returns:
-            Parsed JSON response. A dict for a top-level JSON object, or a
-            list if the model returns a top-level JSON array.
+            Parsed JSON response as an object, array, string, number, boolean,
+            or None.
 
         Raises:
             ProcessingError: If provider is not available or parsing fails

--- a/semantica/llms/types.py
+++ b/semantica/llms/types.py
@@ -1,0 +1,15 @@
+"""Shared types for LLM provider interfaces."""
+
+from typing import Dict, List, Union
+
+JSONValue = Union[
+    str,
+    int,
+    float,
+    bool,
+    None,
+    Dict[str, "JSONValue"],
+    List["JSONValue"],
+]
+
+__all__ = ["JSONValue"]

--- a/tests/test_llm_structured_return_annotations.py
+++ b/tests/test_llm_structured_return_annotations.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union, get_type_hints
+from typing import get_args
 
 import pytest
 
@@ -8,13 +8,12 @@ from semantica.llms import (
     Gemini,
     Groq,
     HuggingFaceLLM,
+    JSONValue,
     LiteLLM,
     Novita,
     Ollama,
     OpenAI,
 )
-
-EXPECTED_RETURN = Union[Dict[str, Any], List[Any]]
 
 
 @pytest.mark.parametrize(
@@ -32,6 +31,12 @@ EXPECTED_RETURN = Union[Dict[str, Any], List[Any]]
     ],
 )
 def test_generate_structured_return_annotation(provider_class):
-    hints = get_type_hints(provider_class.generate_structured)
+    annotations = provider_class.generate_structured.__annotations__
 
-    assert hints["return"] == EXPECTED_RETURN
+    assert annotations["return"] == JSONValue
+
+
+def test_json_value_includes_scalar_results():
+    scalar_types = {str, int, float, bool, type(None)}
+
+    assert scalar_types.issubset(set(get_args(JSONValue)))

--- a/tests/test_llm_structured_return_annotations.py
+++ b/tests/test_llm_structured_return_annotations.py
@@ -1,0 +1,37 @@
+from typing import Any, Dict, List, Union, get_type_hints
+
+import pytest
+
+from semantica.llms import (
+    Anthropic,
+    DeepSeek,
+    Gemini,
+    Groq,
+    HuggingFaceLLM,
+    LiteLLM,
+    Novita,
+    Ollama,
+    OpenAI,
+)
+
+EXPECTED_RETURN = Union[Dict[str, Any], List[Any]]
+
+
+@pytest.mark.parametrize(
+    "provider_class",
+    [
+        OpenAI,
+        Groq,
+        HuggingFaceLLM,
+        LiteLLM,
+        Anthropic,
+        Gemini,
+        DeepSeek,
+        Novita,
+        Ollama,
+    ],
+)
+def test_generate_structured_return_annotation(provider_class):
+    hints = get_type_hints(provider_class.generate_structured)
+
+    assert hints["return"] == EXPECTED_RETURN


### PR DESCRIPTION
## Description

Aligns the public `generate_structured()` return annotations across Semantica LLM wrappers with the existing structured-output contract.

The parsing paths return raw `json.loads()` results, so valid outputs include objects, arrays, strings, numbers, booleans, and `None` for JSON `null`. This PR introduces a shared recursive `JSONValue` type and applies it consistently without changing runtime parsing behavior.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues

Closes #1270

## Changes Made

- add and publicly export a recursive `JSONValue` type covering every valid JSON result
- use `JSONValue` for `generate_structured()` across all nine public LLM wrappers
- align wrapper docstrings and the shared LLM interface documentation
- make the documented Python interface self-contained and copy/pasteable
- add regression coverage for wrapper consistency and scalar JSON results

## Testing

- [x] Tested locally
- [x] Added tests for the corrected behavior
- [x] Package builds successfully (`python -m build`)

### Test Commands

```bash
pytest tests/test_llm_structured_return_annotations.py tests/test_llm_anthropic.py tests/test_llm_gemini.py tests/test_llm_deepseek.py tests/test_llm_novita.py tests/test_llm_ollama.py tests/test_issue_554_fixes.py tests/test_groq_integration.py tests/test_huggingface_impl.py tests/semantic_extract/test_provider_limits.py -q
# 94 passed

python -m mypy semantica/llms/types.py semantica/llms/__init__.py semantica/llms/openai.py semantica/llms/groq.py semantica/llms/huggingface.py semantica/llms/litellm.py semantica/llms/anthropic.py semantica/llms/gemini.py semantica/llms/deepseek.py semantica/llms/novita.py semantica/llms/ollama.py --follow-imports=skip --ignore-missing-imports
# Success: no issues found in 11 source files

python -m build
# Successfully built semantica-0.6.7.tar.gz and semantica-0.6.7-py3-none-any.whl
```

The initial implementation was also compared with the pre-change `main` full-suite baseline and introduced no new failures or errors. The review follow-up was rebased onto the latest `main` and verified with the 94 focused tests above.

## Documentation

- [x] Updated relevant documentation
- [x] Added a self-contained shared-interface example
- [ ] Updated API reference if adding new APIs
- [ ] Updated cookbook if adding new examples
- [ ] No documentation changes needed

## Breaking Changes

**Breaking Changes**: No

The runtime behavior and accepted structured-output shapes are unchanged. The public annotations and related documentation now match the existing parsing behavior.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented code where the behavior is not self-explanatory
- [x] My changes generate no new warnings
- [x] Package builds successfully

## Additional Notes

Repository-wide formatting, linting, and type-checking commands currently report pre-existing issues outside this PR. Black, isort, and flake8 pass on the new type module and regression test, targeted mypy passes across all changed LLM modules, and the diff remains limited to #1270 and its review feedback.