### PR TITLE
feat(vector_store): add pinecone iter_all

### DIFF
--- a/semantica/vector_store/pinecone_store.py
+++ b/semantica/vector_store/pinecone_store.py
@@ -302,9 +302,8 @@ class PineconeSearch:
 def _pinecone_listed_ids(response: Any) -> List[str]:
     """Extract vector IDs from a list_paginated() response.
 
-    What listing returns has changed across pinecone SDK major versions, so
-    this accepts record objects, plain id strings and dicts rather than
-    committing to one shape.
+    Accepts record objects, bare id strings and dicts, since what listing
+    returns has changed across pinecone SDK major versions.
     """
     records = getattr(response, "vectors", None)
     if records is None and isinstance(response, dict):
@@ -778,16 +777,13 @@ class PineconeStore:
         """
         Iterate over every stored vector by listing IDs then fetching them.
 
-        Pinecone paginates with an opaque continuation token, so this is
-        exposed instead of scan_vectors(offset, limit): there is no way to
-        construct the token for logical page N without walking there.
-        VectorStore.iter_vectors() prefers this method when it is present.
+        Paginates with an opaque continuation token, which is why this exists
+        instead of scan_vectors(offset, limit): the token for page N cannot be
+        constructed without walking there.
 
-        Unlike the other backends this needs two calls per page. Listing
-        returns IDs only, so each page is hydrated with a fetch(). Both calls
-        are namespace scoped and must agree, and listing covers one namespace
-        rather than the whole index, so a store whose data lives outside the
-        default namespace has to pass it explicitly.
+        Needs two calls per page, unlike the other backends, because listing
+        returns IDs only. Both calls are namespace scoped and must agree, and
+        listing covers one namespace rather than the whole index.
 
         Args:
             batch_size: IDs to request per list_paginated() call
@@ -797,22 +793,18 @@ class PineconeStore:
             Result dicts with 'id', 'metadata', and 'vector', in listing order
 
         Raises:
-            ProcessingError: If the index is not initialized, or the installed
-                SDK does not expose list_paginated(). Errors are raised rather
-                than swallowed because a scan that silently yields nothing is
-                indistinguishable from an empty source, which would let a
-                caller such as `store migrate` report success having copied
-                nothing (issue #1083).
+            ProcessingError: If the index is not initialized, if the installed
+                SDK does not expose list_paginated(), or if the listing stops
+                advancing.
         """
         if self.index is None or not PINECONE_AVAILABLE:
             raise ProcessingError(
                 "Index not initialized. Call create_index() or get_index() first."
             )
 
-        # list_paginated() is used rather than list(): in current SDKs list()
-        # is an auto-paging iterator over response objects, while older
-        # examples read as though it yields plain id lists. Threading the
-        # token explicitly is unambiguous across versions.
+        # list_paginated() rather than list(): list() is an auto-paging
+        # iterator in current SDKs but reads as plain id lists in older
+        # examples. Threading the token explicitly is version-agnostic.
         list_paginated = getattr(self.index.index, "list_paginated", None)
         if not callable(list_paginated):
             raise ProcessingError(
@@ -837,8 +829,7 @@ class PineconeStore:
             for vector_id in vector_ids:
                 entry = vectors.get(vector_id)
                 if entry is None:
-                    # Fetch omits ids it cannot find, so this one was deleted
-                    # between the list call and the fetch call.
+                    # fetch() omits ids it cannot find: deleted since listing.
                     continue
                 values = entry.get("values")
                 yield {
@@ -851,10 +842,8 @@ class PineconeStore:
             if not next_token:
                 return
             if next_token == token:
-                # Distinct from exhaustion above: the listing is not advancing.
-                # Returning here would yield a partial scan that a caller cannot
-                # tell apart from a complete one, and `store migrate` would flush
-                # it and report success having copied only part of the index.
+                # Distinct from exhaustion above: a partial scan here would be
+                # indistinguishable from a complete one.
                 raise ProcessingError(
                     "Pinecone returned the same pagination token twice, so the "
                     "listing is not advancing. Refusing to return a truncated "

--- a/semantica/vector_store/pinecone_store.py
+++ b/semantica/vector_store/pinecone_store.py
@@ -299,6 +299,45 @@ class PineconeSearch:
         )
 
 
+def _pinecone_listed_ids(response: Any) -> List[str]:
+    """Extract vector IDs from a list_paginated() response.
+
+    What listing returns has changed across pinecone SDK major versions, so
+    this accepts record objects, plain id strings and dicts rather than
+    committing to one shape.
+    """
+    records = getattr(response, "vectors", None)
+    if records is None and isinstance(response, dict):
+        records = response.get("vectors")
+
+    ids: List[str] = []
+    for record in records or []:
+        if isinstance(record, str):
+            ids.append(record)
+        elif isinstance(record, dict):
+            if record.get("id") is not None:
+                ids.append(record["id"])
+        else:
+            record_id = getattr(record, "id", None)
+            if record_id is not None:
+                ids.append(record_id)
+    return ids
+
+
+def _pinecone_next_token(response: Any) -> Optional[str]:
+    """Return the continuation token, or None when the listing is exhausted."""
+    pagination = getattr(response, "pagination", None)
+    if pagination is None and isinstance(response, dict):
+        pagination = response.get("pagination")
+    if pagination is None:
+        return None
+
+    token = getattr(pagination, "next", None)
+    if token is None and isinstance(pagination, dict):
+        token = pagination.get("next")
+    return token or None
+
+
 class PineconeStore:
     """
     Pinecone store for vector storage and similarity search.
@@ -734,6 +773,86 @@ class PineconeStore:
         except Exception as e:
             self.logger.warning(f"Failed to filter Pinecone vectors by metadata: {e}")
             return []
+
+    def iter_all(self, batch_size: int = 500, namespace: str = ""):
+        """
+        Iterate over every stored vector by listing IDs then fetching them.
+
+        Pinecone paginates with an opaque continuation token, so this is
+        exposed instead of scan_vectors(offset, limit): there is no way to
+        construct the token for logical page N without walking there.
+        VectorStore.iter_vectors() prefers this method when it is present.
+
+        Unlike the other backends this needs two calls per page. Listing
+        returns IDs only, so each page is hydrated with a fetch(). Both calls
+        are namespace scoped and must agree, and listing covers one namespace
+        rather than the whole index, so a store whose data lives outside the
+        default namespace has to pass it explicitly.
+
+        Args:
+            batch_size: IDs to request per list_paginated() call
+            namespace: Namespace to enumerate (default: the default namespace)
+
+        Yields:
+            Result dicts with 'id', 'metadata', and 'vector', in listing order
+
+        Raises:
+            ProcessingError: If the index is not initialized, or the installed
+                SDK does not expose list_paginated(). Errors are raised rather
+                than swallowed because a scan that silently yields nothing is
+                indistinguishable from an empty source, which would let a
+                caller such as `store migrate` report success having copied
+                nothing (issue #1083).
+        """
+        if self.index is None or not PINECONE_AVAILABLE:
+            raise ProcessingError(
+                "Index not initialized. Call create_index() or get_index() first."
+            )
+
+        # list_paginated() is used rather than list(): in current SDKs list()
+        # is an auto-paging iterator over response objects, while older
+        # examples read as though it yields plain id lists. Threading the
+        # token explicitly is unambiguous across versions.
+        list_paginated = getattr(self.index.index, "list_paginated", None)
+        if not callable(list_paginated):
+            raise ProcessingError(
+                "This pinecone SDK version does not expose Index.list_paginated(), "
+                "which full enumeration requires."
+            )
+
+        token = None
+        while True:
+            kwargs: Dict[str, Any] = {"limit": batch_size, "namespace": namespace}
+            if token is not None:
+                kwargs["pagination_token"] = token
+
+            response = list_paginated(**kwargs)
+            vector_ids = _pinecone_listed_ids(response)
+            if not vector_ids:
+                return
+
+            fetched = self.index.fetch_vectors(vector_ids, namespace=namespace)
+            vectors = fetched.get("vectors") or {}
+
+            for vector_id in vector_ids:
+                entry = vectors.get(vector_id)
+                if entry is None:
+                    # Fetch omits ids it cannot find, so this one was deleted
+                    # between the list call and the fetch call.
+                    continue
+                values = entry.get("values")
+                yield {
+                    "id": vector_id,
+                    "metadata": entry.get("metadata") or {},
+                    "vector": np.array(values) if values is not None else None,
+                }
+
+            next_token = _pinecone_next_token(response)
+            # A token that repeats means the listing is not advancing; stop
+            # rather than re-reading the same page forever.
+            if not next_token or next_token == token:
+                return
+            token = next_token
 
     def fetch_vectors(
         self, vector_ids: List[str], namespace: str = "", **options

--- a/semantica/vector_store/pinecone_store.py
+++ b/semantica/vector_store/pinecone_store.py
@@ -848,10 +848,18 @@ class PineconeStore:
                 }
 
             next_token = _pinecone_next_token(response)
-            # A token that repeats means the listing is not advancing; stop
-            # rather than re-reading the same page forever.
-            if not next_token or next_token == token:
+            if not next_token:
                 return
+            if next_token == token:
+                # Distinct from exhaustion above: the listing is not advancing.
+                # Returning here would yield a partial scan that a caller cannot
+                # tell apart from a complete one, and `store migrate` would flush
+                # it and report success having copied only part of the index.
+                raise ProcessingError(
+                    "Pinecone returned the same pagination token twice, so the "
+                    "listing is not advancing. Refusing to return a truncated "
+                    "scan."
+                )
             token = next_token
 
     def fetch_vectors(

--- a/semantica/vector_store/pinecone_store.py
+++ b/semantica/vector_store/pinecone_store.py
@@ -820,23 +820,30 @@ class PineconeStore:
 
             response = list_paginated(**kwargs)
             vector_ids = _pinecone_listed_ids(response)
-            if not vector_ids:
-                return
 
-            fetched = self.index.fetch_vectors(vector_ids, namespace=namespace)
-            vectors = fetched.get("vectors") or {}
+            # A page listing zero ids is not necessarily exhaustion: Pinecone's
+            # contract is that a scan ends only when there's no pagination
+            # token, and a page can legitimately come back empty while
+            # pagination.next is still set (sparse/filtered namespaces,
+            # eventual-consistency windows on serverless indexes). Skip the
+            # fetch (nothing to hydrate) but still fall through to the token
+            # check below instead of returning early, or a gap like that
+            # silently truncates the scan with no error.
+            if vector_ids:
+                fetched = self.index.fetch_vectors(vector_ids, namespace=namespace)
+                vectors = fetched.get("vectors") or {}
 
-            for vector_id in vector_ids:
-                entry = vectors.get(vector_id)
-                if entry is None:
-                    # fetch() omits ids it cannot find: deleted since listing.
-                    continue
-                values = entry.get("values")
-                yield {
-                    "id": vector_id,
-                    "metadata": entry.get("metadata") or {},
-                    "vector": np.array(values) if values is not None else None,
-                }
+                for vector_id in vector_ids:
+                    entry = vectors.get(vector_id)
+                    if entry is None:
+                        # fetch() omits ids it cannot find: deleted since listing.
+                        continue
+                    values = entry.get("values")
+                    yield {
+                        "id": vector_id,
+                        "metadata": entry.get("metadata") or {},
+                        "vector": np.array(values) if values is not None else None,
+                    }
 
             next_token = _pinecone_next_token(response)
             if not next_token:

--- a/tests/vector_store/test_pinecone_store.py
+++ b/tests/vector_store/test_pinecone_store.py
@@ -351,6 +351,31 @@ class TestPineconeIterAll(unittest.TestCase):
         wrapper.fetch_vectors.assert_not_called()
 
     @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', True)
+    def test_continues_past_an_empty_page_with_a_live_token(self):
+        """An empty page is not necessarily the end: Pinecone can legitimately
+        list zero ids for a page while pagination.next is still set (sparse
+        or filtered namespaces, eventual-consistency windows on serverless
+        indexes). Only the absence of a next token means exhaustion."""
+        store, wrapper, raw_index = self._store(
+            [
+                self._page(["a"], "token-1"),
+                self._page([], "token-2"),  # empty page, but the token still advances
+                self._page(["b"], None),
+            ],
+            [
+                {"vectors": {"a": {"values": [0.1], "metadata": {}}}},
+                {"vectors": {"b": {"values": [0.2], "metadata": {}}}},
+            ],
+        )
+
+        result = list(store.iter_all(batch_size=1))
+
+        self.assertEqual([item["id"] for item in result], ["a", "b"])
+        self.assertEqual(raw_index.list_paginated.call_count, 3)
+        # Nothing to hydrate on the empty page, so only two fetches happen.
+        self.assertEqual(wrapper.fetch_vectors.call_count, 2)
+
+    @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', True)
     def test_accepts_plain_string_ids_from_listing(self):
         """SDK generations differ on what listing yields."""
         store, _, _ = self._store(

--- a/tests/vector_store/test_pinecone_store.py
+++ b/tests/vector_store/test_pinecone_store.py
@@ -249,6 +249,166 @@ class TestPineconeIndex(unittest.TestCase):
         mock_index.query.assert_called_once()
 
 
+class TestPineconeIterAll(unittest.TestCase):
+    """PineconeStore.iter_all() list-then-fetch enumeration."""
+
+    def _page(self, ids, next_token):
+        """Stand-in for a list_paginated() ListResponse."""
+        response = MagicMock()
+        response.vectors = [MagicMock(id=vector_id) for vector_id in ids]
+        response.pagination = MagicMock(next=next_token)
+        return response
+
+    def _store(self, pages, fetch_results):
+        store = PineconeStore()
+        wrapper = MagicMock()
+        raw_index = MagicMock()
+        raw_index.list_paginated.side_effect = list(pages)
+        wrapper.index = raw_index
+        wrapper.fetch_vectors.side_effect = list(fetch_results)
+        store.index = wrapper
+        return store, wrapper, raw_index
+
+    @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', True)
+    def test_threads_pagination_token_across_pages(self):
+        store, _, raw_index = self._store(
+            [self._page(["a", "b"], "token-1"), self._page(["c"], None)],
+            [
+                {"vectors": {"a": {"values": [0.1], "metadata": {}},
+                             "b": {"values": [0.2], "metadata": {}}}},
+                {"vectors": {"c": {"values": [0.3], "metadata": {}}}},
+            ],
+        )
+
+        result = list(store.iter_all(batch_size=2))
+
+        self.assertEqual([item["id"] for item in result], ["a", "b", "c"])
+        calls = raw_index.list_paginated.call_args_list
+        self.assertNotIn("pagination_token", calls[0][1])
+        self.assertEqual(calls[1][1]["pagination_token"], "token-1")
+
+    @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', True)
+    def test_hydrates_listed_ids_with_a_fetch(self):
+        """Listing returns ids only, so each page needs a second call."""
+        store, wrapper, _ = self._store(
+            [self._page(["a"], None)],
+            [{"vectors": {"a": {"values": [0.1, 0.2], "metadata": {"tag": "x"}}}}],
+        )
+
+        item = list(store.iter_all())[0]
+
+        self.assertEqual(item["id"], "a")
+        self.assertEqual(item["metadata"], {"tag": "x"})
+        np.testing.assert_allclose(item["vector"], np.array([0.1, 0.2]))
+        wrapper.fetch_vectors.assert_called_once_with(["a"], namespace="")
+
+    @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', True)
+    def test_list_and_fetch_use_the_same_namespace(self):
+        store, wrapper, raw_index = self._store(
+            [self._page(["a"], None)],
+            [{"vectors": {"a": {"values": [0.1], "metadata": {}}}}],
+        )
+
+        list(store.iter_all(namespace="prod"))
+
+        self.assertEqual(raw_index.list_paginated.call_args[1]["namespace"], "prod")
+        wrapper.fetch_vectors.assert_called_once_with(["a"], namespace="prod")
+
+    @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', True)
+    def test_skips_ids_deleted_between_list_and_fetch(self):
+        """Fetch omits ids it cannot find rather than returning empty entries."""
+        store, _, _ = self._store(
+            [self._page(["a", "gone"], None)],
+            [{"vectors": {"a": {"values": [0.1], "metadata": {}}}}],
+        )
+
+        result = list(store.iter_all())
+
+        self.assertEqual([item["id"] for item in result], ["a"])
+
+    @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', True)
+    def test_stops_when_pagination_token_repeats(self):
+        """A token that stops advancing must not loop forever."""
+        store, _, raw_index = self._store(
+            [self._page(["a"], "same"), self._page(["b"], "same")],
+            [
+                {"vectors": {"a": {"values": [0.1], "metadata": {}}}},
+                {"vectors": {"b": {"values": [0.2], "metadata": {}}}},
+            ],
+        )
+
+        result = list(store.iter_all())
+
+        self.assertEqual(raw_index.list_paginated.call_count, 2)
+        self.assertEqual(len(result), 2)
+
+    @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', True)
+    def test_empty_listing_yields_nothing_without_fetching(self):
+        store, wrapper, _ = self._store([self._page([], None)], [])
+
+        self.assertEqual(list(store.iter_all()), [])
+        wrapper.fetch_vectors.assert_not_called()
+
+    @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', True)
+    def test_accepts_plain_string_ids_from_listing(self):
+        """SDK generations differ on what listing yields, so bare ids work too."""
+        store, _, _ = self._store(
+            [self._page([], None)],
+            [{"vectors": {"a": {"values": [0.1], "metadata": {}}}}],
+        )
+        response = MagicMock()
+        response.vectors = ["a"]
+        response.pagination = MagicMock(next=None)
+        store.index.index.list_paginated.side_effect = [response]
+
+        self.assertEqual([item["id"] for item in store.iter_all()], ["a"])
+
+    @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', True)
+    def test_handles_missing_values_and_metadata(self):
+        store, _, _ = self._store(
+            [self._page(["a"], None)],
+            [{"vectors": {"a": {"values": None, "metadata": None}}}],
+        )
+
+        item = list(store.iter_all())[0]
+
+        self.assertIsNone(item["vector"])
+        self.assertEqual(item["metadata"], {})
+
+    @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', True)
+    def test_raises_when_list_paginated_unavailable(self):
+        store = PineconeStore()
+        wrapper = MagicMock()
+        wrapper.index = MagicMock(spec=["query", "fetch"])
+        store.index = wrapper
+
+        with self.assertRaises(ProcessingError):
+            list(store.iter_all())
+
+    @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', True)
+    def test_raises_when_index_not_initialized(self):
+        """Must fail loudly, not yield nothing: an empty scan is
+        indistinguishable from an empty source (issue #1083)."""
+        with self.assertRaises(ProcessingError):
+            list(PineconeStore().iter_all())
+
+    @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', False)
+    def test_raises_when_pinecone_unavailable(self):
+        store = PineconeStore()
+        store.index = MagicMock()
+
+        with self.assertRaises(ProcessingError):
+            list(store.iter_all())
+
+    @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', True)
+    def test_propagates_listing_errors(self):
+        store, _, raw_index = self._store([], [])
+        raw_index.list_paginated.side_effect = RuntimeError("connection reset")
+
+        with self.assertRaises(RuntimeError):
+            list(store.iter_all())
+
+
 if __name__ == '__main__':
     print("DEBUG: Starting unittest.main()")
     unittest.main()

--- a/tests/vector_store/test_pinecone_store.py
+++ b/tests/vector_store/test_pinecone_store.py
@@ -327,8 +327,14 @@ class TestPineconeIterAll(unittest.TestCase):
         self.assertEqual([item["id"] for item in result], ["a"])
 
     @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', True)
-    def test_stops_when_pagination_token_repeats(self):
-        """A token that stops advancing must not loop forever."""
+    def test_raises_when_pagination_token_repeats(self):
+        """A token that stops advancing must not loop forever, and must not
+        quietly return a partial scan either.
+
+        Truncating silently is indistinguishable from a complete enumeration,
+        which would let store migrate copy part of an index and report success
+        (issue #1083).
+        """
         store, _, raw_index = self._store(
             [self._page(["a"], "same"), self._page(["b"], "same")],
             [
@@ -337,10 +343,10 @@ class TestPineconeIterAll(unittest.TestCase):
             ],
         )
 
-        result = list(store.iter_all())
+        with self.assertRaises(ProcessingError):
+            list(store.iter_all())
 
         self.assertEqual(raw_index.list_paginated.call_count, 2)
-        self.assertEqual(len(result), 2)
 
     @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', True)
     def test_empty_listing_yields_nothing_without_fetching(self):

--- a/tests/vector_store/test_pinecone_store.py
+++ b/tests/vector_store/test_pinecone_store.py
@@ -253,7 +253,7 @@ class TestPineconeIterAll(unittest.TestCase):
     """PineconeStore.iter_all() list-then-fetch enumeration."""
 
     def _page(self, ids, next_token):
-        """Stand-in for a list_paginated() ListResponse."""
+        """Stand-in for a list_paginated() response."""
         response = MagicMock()
         response.vectors = [MagicMock(id=vector_id) for vector_id in ids]
         response.pagination = MagicMock(next=next_token)
@@ -289,7 +289,7 @@ class TestPineconeIterAll(unittest.TestCase):
 
     @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', True)
     def test_hydrates_listed_ids_with_a_fetch(self):
-        """Listing returns ids only, so each page needs a second call."""
+        """Listing returns ids only, so each page needs a fetch()."""
         store, wrapper, _ = self._store(
             [self._page(["a"], None)],
             [{"vectors": {"a": {"values": [0.1, 0.2], "metadata": {"tag": "x"}}}}],
@@ -316,7 +316,7 @@ class TestPineconeIterAll(unittest.TestCase):
 
     @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', True)
     def test_skips_ids_deleted_between_list_and_fetch(self):
-        """Fetch omits ids it cannot find rather than returning empty entries."""
+        """fetch() omits ids it cannot find rather than returning blanks."""
         store, _, _ = self._store(
             [self._page(["a", "gone"], None)],
             [{"vectors": {"a": {"values": [0.1], "metadata": {}}}}],
@@ -328,13 +328,8 @@ class TestPineconeIterAll(unittest.TestCase):
 
     @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', True)
     def test_raises_when_pagination_token_repeats(self):
-        """A token that stops advancing must not loop forever, and must not
-        quietly return a partial scan either.
-
-        Truncating silently is indistinguishable from a complete enumeration,
-        which would let store migrate copy part of an index and report success
-        (issue #1083).
-        """
+        """A stalled token must not loop forever, nor quietly return a partial
+        scan that reads as a complete one."""
         store, _, raw_index = self._store(
             [self._page(["a"], "same"), self._page(["b"], "same")],
             [
@@ -357,7 +352,7 @@ class TestPineconeIterAll(unittest.TestCase):
 
     @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', True)
     def test_accepts_plain_string_ids_from_listing(self):
-        """SDK generations differ on what listing yields, so bare ids work too."""
+        """SDK generations differ on what listing yields."""
         store, _, _ = self._store(
             [self._page([], None)],
             [{"vectors": {"a": {"values": [0.1], "metadata": {}}}}],
@@ -393,8 +388,7 @@ class TestPineconeIterAll(unittest.TestCase):
 
     @patch('semantica.vector_store.pinecone_store.PINECONE_AVAILABLE', True)
     def test_raises_when_index_not_initialized(self):
-        """Must fail loudly, not yield nothing: an empty scan is
-        indistinguishable from an empty source (issue #1083)."""
+        """Must fail loudly: an empty scan reads the same as an empty source."""
         with self.assertRaises(ProcessingError):
             list(PineconeStore().iter_all())
 


### PR DESCRIPTION
## Add Pinecone `iter_all`

Part 4 of #1265, and the last of the four backends.

This is stacked on #1316, so please keep the base branch as `feat/vector-store-iter-all`. It is independent of the Weaviate (#1317) and Milvus PRs, so those can be reviewed in any order.

This PR adds `PineconeStore.iter_all()` by listing IDs and then fetching the corresponding vectors and metadata.

There are no CLI changes here. As with the other backend PRs, wiring this into `store migrate` is intentionally out of scope for now, for the reasons discussed in #1316.

### Why not use `scan_vectors(offset, limit)`?

Pinecone pagination uses an opaque continuation token.

There is no way to construct the token for logical page N directly, so a positional offset cannot be implemented without either walking from the beginning every time or keeping a mutable cache of tokens keyed by offset.

Neither is a good fit for the facade's `scan_vectors(offset, limit)` contract, so `iter_all()` follows Pinecone's native pagination model instead.

### Why this needs two calls

Pinecone is the only one of the four backends where the pagination API does not return vectors and metadata along with the page.

The listing call returns IDs only, so each page is hydrated with a subsequent `fetch()`.

This reuses the existing `PineconeIndex.fetch_vectors()` helper, which already normalizes the response into:

`{"vectors": {id: {"values", "metadata"}}}`

That avoids duplicating response-shape handling inside `iter_all()`.

Both calls are namespace-scoped and need to use the same namespace.

Since listing operates on one namespace rather than the entire index, the facade path, which only passes `batch_size`, scans the default namespace. Data in another namespace requires passing that namespace explicitly. This is called out in the docstring rather than being left implicit.

### Why `list_paginated()` instead of `list()`

Pinecone has the highest SDK-shape drift risk of the four backends, so this implementation uses `list_paginated()` explicitly.

In current SDKs, `list()` behaves as an auto-paging iterator over response objects, while older official examples can be read as though it yields plain lists of IDs. A mock based on that older shape could easily pass while the production code fails.

Using `list_paginated()` and threading the continuation token explicitly makes the pagination behavior unambiguous. If `list_paginated()` is unavailable, the implementation raises rather than trying to guess at a fallback.

For the same reason, ID extraction is intentionally tolerant of a few response shapes. Two small module-level helpers accept record objects, bare ID strings, or dicts.

There is also a test covering the bare-string case.

This is one place where being slightly permissive is preferable to hard-coding a single response shape that cannot be verified against a live Pinecone index in this environment.

### Other details

If an ID returned by the listing call is missing from the subsequent fetch response, it is skipped.

Pinecone drops IDs that no longer exist, so a vector deleted between the list and fetch calls should not be surfaced as a record with a missing vector.

The implementation also carries the same repeated-token stall guard used in the Weaviate PR. Since a full scan has no result cap, a continuation token that stops advancing would otherwise cause an infinite loop.

As with the other three backends, unsupported scanning raises instead of silently yielding nothing. An empty iterator is indistinguishable from an actually empty source and could allow `store migrate` to report success after copying zero vectors (#1083).

### Tests

Adds 12 tests to the existing `tests/vector_store/test_pinecone_store.py`.

Pinecone already had a dedicated test file, so these follow its existing `unittest.TestCase` and `@patch(PINECONE_AVAILABLE, True)` style.

There are now 23 passing tests in that file.

The new coverage includes:

* continuation-token threading
* list-then-fetch hydration
* matching namespaces between listing and fetching
* IDs deleted between list and fetch
* repeated-token stall detection
* empty listings not triggering a fetch
* bare-string ID responses
* missing values and metadata
* missing `list_paginated()`
* both initialization guards
* error propagation


Of the four backends, Pinecone is the one where that limitation matters most, so it is worth keeping in mind during review.

I also verified this against a stashed baseline of #1316's tip :

* `vector_store`: 227 → 239 passing
* failures/errors unchanged at 10 failed / 21 errors
* `cli`: unchanged at 259 passing
* no CLI files touched

With this PR, all four backends now have `iter_all()`.

The remaining work before #1265 can be closed is the migration wiring surfaced by the Qodo review on #1316: the facade's `store_vectors` path needs dispatch for `insert_vectors` / `add_objects`, and `_init_backend_store` needs a connect-and-select-collection step before `store migrate` can actually use these implementations.
