### PR TITLE
fix(ci): unblock py3.9 install matrix and raise Scorecard pinning/signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           diff \
             <(grep -E '^[a-zA-Z0-9._-]+==' requirements-ci.txt | sed 's/ \\$//') \
             <(grep -E '^[a-zA-Z0-9._-]+==' /tmp/requirements-ci-check.txt)
-      - run: pip install build
+      - run: pip install build==1.6.0
       # wheel is build-time only (not in requirements-ci.txt) — install the
       # same pinned version [build-system] declares so --no-isolation works.
       - run: pip install wheel==0.48.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       cancel-in-progress: false
     permissions:
       contents: write      # for the GitHub Release
-      id-token: write      # for PyPI Trusted Publishing (OIDC) and attestation signing
+      id-token: write      # for PyPI Trusted Publishing (OIDC), attestation signing, and Sigstore
       attestations: write  # for SLSA build provenance
     # If you add another job to this workflow, give it its own explicit
     # `permissions:` block rather than relying on the workflow-level default
@@ -40,7 +40,7 @@ jobs:
       # build runs against the same versions CI tests against.
       - name: Install pinned build dependencies
         run: pip install -r requirements-ci.txt
-      - run: pip install build
+      - run: pip install build==1.6.0
       # wheel is build-time only (not in requirements-ci.txt) — install the
       # same pinned version [build-system] declares so --no-isolation works.
       - run: pip install wheel==0.48.0
@@ -71,7 +71,19 @@ jobs:
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
         with:
           subject-path: 'dist/*'
+      # attest-build-provenance publishes to the GH attestations API only, which
+      # OpenSSF Scorecard's Signed-Releases check does not inspect - it looks for
+      # signature files attached as release assets. Sign here too so
+      # `dist/*.sigstore.json` bundles ship alongside the wheel/sdist on the
+      # GitHub Release itself.
+      - name: Sign artifacts with Sigstore
+        uses: sigstore/gh-action-sigstore-python@790bc6befb9d733738f18d8f895854b453640ec9 # v3.5.0
+        with:
+          inputs: dist/*.whl dist/*.tar.gz
       - uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
-          files: dist/*
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
+            dist/*.sigstore.json
       - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,9 @@ jobs:
       - name: Sign artifacts with Sigstore
         uses: sigstore/gh-action-sigstore-python@790bc6befb9d733738f18d8f895854b453640ec9 # v3.5.0
         with:
-          inputs: dist/*.whl dist/*.tar.gz
+          inputs: |
+            dist/*.whl
+            dist/*.tar.gz
       - uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           files: |

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -52,7 +52,7 @@ jobs:
           # Tooling AFTER the pinned set: installing safety/bandit/semgrep/jq
           # first lets the pinned requirements overwrite their transitive deps
           # (e.g. rich), which breaks the safety CLI at runtime.
-          pip install safety bandit semgrep jq
+          pip install safety==3.8.1 bandit==1.9.4 semgrep==1.175.0 jq==1.12.0
 
       - name: Run Safety Check (Package Vulnerabilities)
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,6 +37,6 @@ jobs:
       # pyproject.toml changes under review. The schedule/workflow_dispatch
       # runs stay non-blocking until a full pass over pre-existing findings
       # across the whole [all] tree has been done.
-      - run: pip install pip-audit
+      - run: pip install pip-audit==2.10.1
       - run: pip-audit -r requirements-ci.txt
         continue-on-error: ${{ github.event_name != 'pull_request' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:26-alpine AS frontend-builder
+FROM node:26-alpine@sha256:2d984a15c9b54fd0aeb608b8e0d0d83529eb34d2966db27a1fb4f1edc3d298a3 AS frontend-builder
 
 WORKDIR /app
 COPY explorer/package*.json ./explorer/
@@ -9,7 +9,7 @@ RUN npm ci
 COPY explorer/ ./
 RUN mkdir -p /app/semantica && npm run build
 
-FROM python:3.13-slim AS runtime
+FROM python:3.13-slim@sha256:7ce4b6dfe35e55397b7cda544f8a13f191b7ae28dc5aad71fe664dbc9bc2623f AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,14 @@ dependencies = [
   "scipy>=1.13.1",
   "scikit-learn>=1.7.2",
   "umap-learn>=0.5.12",
-  "spacy>=3.4.0",
+  # thinc (spacy's core dep) dropped Python 3.9 wheels at 8.3.10, and later
+  # spacy patch releases (3.8.8+) require thinc>=8.3.9-only-on-3.10+ ranges,
+  # which forces a source build that fails outright on 3.9 (see Install
+  # Matrix run history). Capping both keeps 3.9 on the last wheel-compatible
+  # pair; 3.10+ is left unconstrained to always get the latest spacy/thinc.
+  "spacy>=3.4.0,<3.8.8; python_version < '3.10'",
+  "spacy>=3.4.0; python_version >= '3.10'",
+  "thinc<8.3.5; python_version < '3.10'",
   "transformers>=4.20.0",
   "torch>=1.13.1",
   "sentence-transformers>=2.2.0",


### PR DESCRIPTION
## Summary
- **Install Matrix failure**: `pip install semantica` failed on Python 3.9 (all three OSes) because `spacy` had no upper bound, so pip resolved spacy 3.8.16 whose `thinc>=8.3.12` requirement has no cp39 wheels and no working sdist build path either. Caps `spacy<3.8.8` and adds `thinc<8.3.5` for `python_version < '3.10'`; py3.10+ stays unconstrained. Verified with `pip install --dry-run --python-version 3.9` against manylinux, win_amd64, and macosx_arm64 — all resolve to prebuilt wheels (spacy 3.8.7 + thinc 8.3.4), no source builds needed.
- **OpenSSF Scorecard — Pinned-Dependencies**: `Dockerfile`'s `FROM node:26-alpine` and `FROM python:3.13-slim` were unpinned by digest (this was the actual cause of the low score — all GitHub Actions were already SHA-pinned). Pinned both to their current digests, and pinned five previously-unversioned `pip install` tool calls in CI (`build`, `safety`, `bandit`, `semgrep`, `jq`, `pip-audit`).
- **OpenSSF Scorecard — Signed-Releases**: `attest-build-provenance` only publishes to the GH attestations API, which Scorecard's Signed-Releases check doesn't inspect (it looks for signature files attached as release assets). Added a Sigstore signing step so `dist/*.sigstore.json` bundles ship alongside the wheel/sdist on the GitHub Release.

Not addressed here (require repo-owner action, not code): Branch-Protection and Code-Review settings, CII-Best-Practices badge application, and Fuzzing (OSS-Fuzz integration). Dangerous-Workflow scored 0 on the last report but I couldn't reproduce a real script-injection/unsafe-checkout pattern in any workflow — worth re-checking the score after this lands.

## Test plan
- [ ] Install Matrix workflow passes on py3.9/3.10/3.11/3.12 across ubuntu/macos/windows
- [ ] `docker build .` succeeds with the digest-pinned base images
- [ ] Release workflow's Sigstore signing step succeeds and `.sigstore.json` files land on the next tagged release
- [ ] Re-run OpenSSF Scorecard and confirm Pinned-Dependencies / Signed-Releases scores rise