### PR TITLE
fix(ci): drop unpinnable benchmarks/requirements.txt install

### DIFF
--- a/.github/requirements/benchmark-extra.in
+++ b/.github/requirements/benchmark-extra.in
@@ -11,3 +11,4 @@ python-docx
 beautifulsoup4
 chardet
 langdetect
+en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl

--- a/.github/requirements/benchmark-extra.txt
+++ b/.github/requirements/benchmark-extra.txt
@@ -408,6 +408,9 @@ cuda-toolkit==13.0.3.0 \
     # via
     #   -c requirements-ci.txt
     #   torch
+en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl \
+    --hash=sha256:1932429db727d4bff3deed6b34cfc05df17794f4a52eeb26cf8928f7c1a0fb85
+    # via -r .github/requirements/benchmark-extra.in
 et-xmlfile==2.0.0 \
     --hash=sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa \
     --hash=sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -44,11 +44,15 @@ jobs:
           pip install -r .github/requirements/pep517-build.txt --require-hashes
           pip install --no-deps --no-build-isolation -e .
           pip install -r .github/requirements/base-deps.txt --require-hashes
-          # NOTE: benchmarks/ does not currently exist in this repo, so this
-          # step and the run below it fail on any real invocation - pre-existing,
-          # unrelated to this pinning change. Left as-is since there's nothing
-          # to hash without knowing what belongs there.
-          pip install -r benchmarks/requirements.txt
+          # NOTE: benchmarks/ does not currently exist in this repo (neither
+          # requirements.txt nor benchmarks_runner.py below), so this job
+          # already fails on any real invocation - pre-existing, unrelated to
+          # this pinning change. The `pip install -r benchmarks/requirements.txt`
+          # step that used to be here is dropped rather than fixed: there's
+          # nothing to hash-pin without knowing what that file should
+          # contain, and an unpinned install here would just re-trip
+          # Scorecard's Pinned-Dependencies check for no real benefit, since
+          # the job can't run to completion regardless.
           python -m spacy download en_core_web_sm
           pip install -r .github/requirements/benchmark-extra.txt --require-hashes
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -53,7 +53,11 @@ jobs:
           # contain, and an unpinned install here would just re-trip
           # Scorecard's Pinned-Dependencies check for no real benefit, since
           # the job can't run to completion regardless.
-          python -m spacy download en_core_web_sm
+          #
+          # `python -m spacy download en_core_web_sm` fetches an unpinned,
+          # unhashed wheel from spacy-models' GitHub releases - replaced with
+          # a hash-pinned direct-URL install of the same 3.8.0 model (matches
+          # the spacy==3.8.15 pinned in base-deps.txt) via benchmark-extra.txt.
           pip install -r .github/requirements/benchmark-extra.txt --require-hashes
 
       - name: Execute Benchmarks (Real Mode)


### PR DESCRIPTION
## Summary
Fixes Scorecard Pinned-Dependencies alert #6082 on `benchmark.yml:51`. `pip install -r benchmarks/requirements.txt` can't be hash-pinned because `benchmarks/` doesn't exist anywhere in this repo (flagged as a pre-existing issue in prior PRs). Dropped the line rather than leave it unpinned - the job already fails on the very next real step (`benchmarks/benchmarks_runner.py`, also missing), so it wasn't doing anything useful.

## Also closed on this pass (no PR needed, done directly via the API)
- **#6099** (Dockerfile, Pinned-Dependencies): `pip install --no-deps --no-build-isolation .` installs our own git-tracked source and fetches nothing external. Confirmed pip rejects `--hash`/`--require-hashes` on local directory targets outright - there's no real third-party dependency here to pin. Dismissed as won't-fix with that reasoning; this is the one remaining case the check structurally can't distinguish from a real unpinned fetch.
- **#6112-#6115** (Checkov, k8s namespace/seccomp on the Helm chart): same root cause as #6035/#6036 dismissed yesterday - these files already carry the `checkov.io/skip1` annotation that correctly suppresses the check (re-verified: unchanged since the earlier real checkov+helm run and CI log that confirmed `SKIPPED`). GitHub just isn't correlating Checkov's SARIF suppressions reliably, so it opens fresh alert numbers on every rescan. Dismissed as false positive.

## Still open - need non-code action, not something a PR can close
- **Fuzzing** (#5714): needs a real OSS-Fuzz integration.
- **CII-Best-Practices** (#5715): needs applying for the OpenSSF badge on bestpractices.dev.