### PR TITLE
fix(plugins): declare agents as an array of file paths in plugin.json

### DIFF
--- a/plugins/.claude-plugin/plugin.json
+++ b/plugins/.claude-plugin/plugin.json
@@ -25,5 +25,9 @@
     "mcp"
   ],
   "skills": "./skills",
-  "agents": "./agents"
+  "agents": [
+    "./agents/decision-advisor.md",
+    "./agents/explainability.md",
+    "./agents/kg-assistant.md"
+  ]
 }

--- a/tests/test_plugin_manifest.py
+++ b/tests/test_plugin_manifest.py
@@ -1,0 +1,50 @@
+"""
+Test for the Claude Code plugin manifest (Issue #1350).
+
+Claude Code's plugin schema requires "agents" to be an array of .md file
+paths (a bare directory string is rejected with "agents: Invalid input"),
+while "skills" may be a directory string. This guards the manifest shape
+so the bundled plugin stays installable.
+"""
+import json
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = REPO_ROOT / "plugins" / ".claude-plugin" / "plugin.json"
+
+
+class TestPluginManifest(unittest.TestCase):
+    """Validate plugins/.claude-plugin/plugin.json against Claude Code's schema shape."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        cls.plugin_root = MANIFEST.parent.parent
+
+    def test_agents_is_list_of_md_file_paths(self):
+        agents = self.manifest["agents"]
+        self.assertIsInstance(
+            agents, list,
+            'Claude Code rejects "agents" unless it is an array of .md file paths',
+        )
+        self.assertTrue(agents, "agents list should not be empty")
+        for entry in agents:
+            self.assertIsInstance(entry, str)
+            self.assertTrue(entry.endswith(".md"), f"{entry} is not a .md file path")
+            path = self.plugin_root / entry
+            self.assertTrue(path.is_file(), f"{entry} does not exist under plugins/")
+
+    def test_agents_list_covers_all_agent_files(self):
+        declared = {Path(entry).name for entry in self.manifest["agents"]}
+        on_disk = {p.name for p in (self.plugin_root / "agents").glob("*.md")}
+        self.assertEqual(declared, on_disk)
+
+    def test_skills_directory_exists(self):
+        skills = self.manifest["skills"]
+        self.assertIsInstance(skills, str)
+        self.assertTrue((self.plugin_root / skills).is_dir())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

`plugins/.claude-plugin/plugin.json` declares `"agents": "./agents"`. Claude Code's plugin schema rejects a bare directory string for `agents` (`Validation errors: agents: Invalid input`), so the bundled plugin cannot be installed at all. Unlike `skills`, which accepts a directory string, `agents` must be an array of `.md` file paths.

This replaces the string with the explicit list of the three agent files, exactly as suggested in the issue.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1350

## Changes Made

- `plugins/.claude-plugin/plugin.json`: `"agents"` is now `["./agents/decision-advisor.md", "./agents/explainability.md", "./agents/kg-assistant.md"]`
- `tests/test_plugin_manifest.py` (new): guards the manifest shape — `agents` is a non-empty array of existing `.md` paths that stays in sync with the files in `plugins/agents/`, and the `skills` directory exists

## Testing

- [x] Tested locally
- [x] Added tests for new functionality

Verified with the official validator (Claude Code 2.1.231):

```console
$ claude plugin validate plugins   # before
✘ plugins[0] plugin.json → agents: Invalid input

$ claude plugin validate plugins   # after
✔ Validation passed with warnings
```

(The remaining warning — missing marketplace description — is pre-existing and out of scope.)

```bash
python3 -m unittest tests.test_plugin_manifest -v   # 3 tests, OK
```

The new test fails on the old manifest and passes with this change.

## Documentation

- [x] No documentation changes needed
