### PR TITLE
Align enforce_decision_policy default reasoning limit with record_decision

### DIFF
--- a/semantica/context/context_graph.py
+++ b/semantica/context/context_graph.py
@@ -4649,7 +4649,7 @@ class ContextGraph:
             "min_confidence": 0.7,
             "required_outcomes": ["approved", "rejected", "flagged"],
             "required_metadata": ["decision_maker"],
-            "max_reasoning_length": 1000
+            "max_reasoning_length": 10000
         }
         
         rules = policy_rules or default_rules
@@ -4669,8 +4669,8 @@ class ContextGraph:
         
         # Check reasoning length
         reasoning = decision_data.get("reasoning", "")
-        if len(reasoning) > rules.get("max_reasoning_length", 1000):
-            warnings.append(f"Reasoning too long: {len(reasoning)} characters")
+        if len(reasoning.strip()) > rules.get("max_reasoning_length", 10000):
+            warnings.append(f"Reasoning too long: {len(reasoning.strip())} characters")
         
         return {
             "compliant": len(violations) == 0,

--- a/tests/test_030_context_graph_realworld_extended.py
+++ b/tests/test_030_context_graph_realworld_extended.py
@@ -495,6 +495,19 @@ class TestContextGraphAdvancedDecisionMethods:
         assert len(result["warnings"]) == 0
         assert result["compliant"] is True
 
+    def test_enforce_decision_policy_reasoning_exactly_at_storage_limit_no_warning(self):
+        g = ContextGraph()
+        decision_data = {
+            "outcome": "approved",
+            "confidence": 0.85,
+            "reasoning": "X" * 10000,  # Exactly at record_decision's 10000-char limit
+            "decision_maker": "bot",
+        }
+        result = g.enforce_decision_policy(decision_data)
+        # The limit is inclusive: exactly 10000 characters must not warn.
+        assert len(result["warnings"]) == 0
+        assert result["compliant"] is True
+
     def test_enforce_decision_policy_reasoning_above_storage_limit_warning(self):
         g = ContextGraph()
         decision_data = {

--- a/tests/test_030_context_graph_realworld_extended.py
+++ b/tests/test_030_context_graph_realworld_extended.py
@@ -481,17 +481,81 @@ class TestContextGraphAdvancedDecisionMethods:
         assert result["compliant"] is True
         assert len(result["violations"]) == 0
 
-    def test_enforce_decision_policy_long_reasoning_warning(self):
+    def test_enforce_decision_policy_reasoning_within_storage_limit_no_warning(self):
         g = ContextGraph()
         decision_data = {
             "outcome": "approved",
             "confidence": 0.85,
-            "reasoning": "X" * 1500,  # Exceeds default 1000 char limit
+            "reasoning": "X" * 1500,  # Within record_decision's 10000-char limit
+            "decision_maker": "bot",
+        }
+        result = g.enforce_decision_policy(decision_data)
+        # record_decision accepts reasoning up to 10000 characters, so the
+        # default policy must not warn on input that storage considers valid.
+        assert len(result["warnings"]) == 0
+        assert result["compliant"] is True
+
+    def test_enforce_decision_policy_reasoning_above_storage_limit_warning(self):
+        g = ContextGraph()
+        decision_data = {
+            "outcome": "approved",
+            "confidence": 0.85,
+            "reasoning": "X" * 10001,  # Exceeds record_decision's 10000-char limit
             "decision_maker": "bot",
         }
         result = g.enforce_decision_policy(decision_data)
         # Should generate a warning (long reasoning) but may still be compliant
         assert len(result["warnings"]) > 0
+
+    def test_enforce_decision_policy_custom_max_reasoning_length(self):
+        g = ContextGraph()
+        decision_data = {
+            "outcome": "approved",
+            "confidence": 0.85,
+            "reasoning": "X" * 600,  # Exceeds the custom 500-char limit
+            "decision_maker": "bot",
+        }
+        custom_rules = {"max_reasoning_length": 500}
+        result = g.enforce_decision_policy(decision_data, policy_rules=custom_rules)
+        assert len(result["warnings"]) > 0
+
+    def test_enforce_decision_policy_reasoning_length_ignores_surrounding_whitespace(self):
+        g = ContextGraph()
+        reasoning = " " + "X" * 9999 + " "  # 10001 raw chars, 9999 after strip
+        decision_data = {
+            "outcome": "approved",
+            "confidence": 0.85,
+            "reasoning": reasoning,
+            "decision_maker": "bot",
+        }
+        result = g.enforce_decision_policy(decision_data)
+        # Matches record_decision, which measures reasoning after stripping
+        # surrounding whitespace.
+        assert len(result["warnings"]) == 0
+
+    def test_enforce_decision_policy_matches_record_decision_reasoning_limit(self):
+        g = ContextGraph()
+        g.record_decision(
+            category="loan_approval",
+            scenario="Application review",
+            reasoning="X" * 5000,  # Accepted by record_decision (<= 10000)
+            outcome="approved",
+            confidence=0.85,
+            decision_maker="underwriter_ai",
+        )
+        result = g.enforce_decision_policy(
+            {
+                "category": "loan_approval",
+                "outcome": "approved",
+                "confidence": 0.85,
+                "reasoning": "X" * 5000,
+                "decision_maker": "underwriter_ai",
+            }
+        )
+        # A decision that record_decision accepts must not trigger warnings
+        # under the default policy rules.
+        assert len(result["warnings"]) == 0
+        assert result["compliant"] is True
 
     def test_find_precedents_by_scenario_returns_list(self):
         g, _ = self._build_loan_graph()


### PR DESCRIPTION
## Description
`record_decision` accepts reasoning up to 10,000 characters (raising `ValueError` beyond that), but `enforce_decision_policy`'s default `max_reasoning_length` was 1,000. As a result, any decision with reasoning between 1,000 and 10,000 characters was valid to record yet triggered a spurious warning under the default policy.

This PR aligns the default policy limit with the storage limit:
- `default_rules["max_reasoning_length"]`: 1000 → 10000, and the same value for the `rules.get` fallback
- the length check now measures `len(reasoning.strip())`, matching `record_decision`'s validation (previously the raw string length was measured)

Custom `policy_rules` with a stricter `max_reasoning_length` continue to work exactly as before.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues
Fixes #1362

## Changes Made
- `semantica/context/context_graph.py` (`enforce_decision_policy`):
  - Default `max_reasoning_length` raised from 1000 to 10000 to match `record_decision`'s hard limit
  - `rules.get` fallback value updated from 1000 to 10000 for consistency
  - Reasoning length measured after stripping surrounding whitespace (both the comparison and the warning message)
- `tests/test_030_context_graph_realworld_extended.py`:
  - Updated the test that pinned the old 1000-char default (`test_enforce_decision_policy_long_reasoning_warning` → `test_enforce_decision_policy_reasoning_within_storage_limit_no_warning`: 1500-char reasoning under the default policy now expects no warnings and `compliant=True`)
  - Added `test_enforce_decision_policy_reasoning_above_storage_limit_warning` (10001 chars still warns)
  - Added `test_enforce_decision_policy_custom_max_reasoning_length` (custom stricter limit still warns)
  - Added `test_enforce_decision_policy_reasoning_length_ignores_surrounding_whitespace` (10001 raw chars / 9999 after strip → no warning, matching `record_decision`)
  - Added `test_enforce_decision_policy_matches_record_decision_reasoning_limit` (integration: a decision accepted by `record_decision` produces no warnings under the default policy)

## Testing
- New/updated tests verified with TDD: the three alignment tests fail on the parent commit (old default 1000 produced spurious warnings) and all pass with this change:
  - `.venv312/bin/python -m pytest tests/test_030_context_graph_realworld_extended.py -k "enforce_decision_policy" -q` → 9 passed
- Full file: `tests/test_030_context_graph_realworld_extended.py` → 102 passed, 7 skipped
- Directory baseline comparison: `tests/context/` shows identical results before and after this change (pre-existing environment failures unrelated to this fix)

## Documentation
No public API surface changed (default rule value only); no documentation references the old 1000 default, so no doc updates are required.

## Breaking Changes
None. Over-limit reasoning only ever produced a warning (never a violation), so `compliant` results are unchanged; the only behavioral difference is the removal of spurious warnings in the 1000–10000 character range.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A — no stale docs)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
Two related observations (out of scope for this PR, noting for maintainers):
- The 10000 limit is duplicated as a magic number in `record_decision` and `enforce_decision_policy`; extracting a module-level constant would prevent future drift (the root cause of this bug).
- `rules = policy_rules or default_rules` returns the default dict by reference and treats an empty dict as "use defaults", which may be worth tightening separately.
