### PR TITLE
fix(ci): scan requirements-ci.txt directly in Safety check to avoid cuda-toolkit crash

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -45,9 +45,11 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r .github/requirements/bootstrap.txt --require-hashes
-          # Install the pinned dependency set FIRST so Safety scans Semantica's
-          # exact CI/release dependency tree (requirements-ci.txt is generated
-          # from pyproject.toml extras, so this covers the project's real deps).
+          # requirements-ci.txt (generated from pyproject.toml extras) is what
+          # Safety scans below. Bandit/Semgrep's static analysis of semantica/
+          # doesn't need it installed, but it goes FIRST regardless so it can
+          # overwrite the tooling's own transitive deps installed after it,
+          # not the other way around (see the next comment).
           pip install -r requirements-ci.txt --require-hashes
           # Tooling AFTER the pinned set: installing safety/bandit/semgrep/jq
           # first lets the pinned requirements overwrite their transitive deps
@@ -60,7 +62,21 @@ jobs:
           # (json/text/screen/...), not a file path. Writing JSON to a file
           # now requires --save-json; the previous `--output safety-report.json`
           # usage was silently invalid and never produced a report.
-          safety check --save-json safety-report.json || true
+          #
+          # NOTE: Scan requirements-ci.txt directly (-r) rather than the live
+          # environment. A bare `safety check` walks installed package metadata
+          # via importlib.metadata, and cuda-toolkit's wheel (a metapackage
+          # with ~20 conditional Requires-Dist entries for its NVIDIA
+          # sub-packages) crashes that path with "Unhandled exception
+          # happened: 'cuda-toolkit'" (an unguarded lookup somewhere in
+          # Safety's dependency-graph handling — reproduced locally against
+          # Safety 3.8.1). Scanning the requirements file instead avoids that
+          # code path entirely: verified against the actual requirements-ci.txt
+          # (400 packages, cuda-toolkit included) completing cleanly with a
+          # valid report. It's also more precise than the environment scan,
+          # which incidentally also picked up CI-only tooling (safety's,
+          # bandit's, semgrep's own dependencies) installed alongside it.
+          safety check -r requirements-ci.txt --save-json safety-report.json || true
 
           # Guard 1: fail loudly if Safety exited before writing a report at all
           # (network error, API auth failure, tool crash). Without this check a


### PR DESCRIPTION
## Problem

The `Security Scan / security-scan` job has been failing (surfaced on PR #1357's CI run) with:

```
Unhandled exception happened: 'cuda-toolkit'
Error: Safety scan produced no report (safety-report.json is missing or empty).
```

## Root cause

`safety check` (with no `-r` flag) scans the **live installed environment** by walking installed package metadata via `importlib.metadata`. `cuda-toolkit` (a transitive dependency pulled in by `torch` in `requirements-ci.txt`) is a metapackage whose wheel declares ~20 conditional `Requires-Dist` entries for its NVIDIA sub-packages (gated by `sys_platform`/`platform_machine` markers). Something in Safety's dependency-graph handling for this shape of metadata does an unguarded lookup and crashes with a generic `KeyError`-style message.

I reproduced this locally against `safety==3.8.1` (the version pinned in `.github/requirements/security-scan-tools.txt`) and confirmed the crash is specific to the **environment-scan** code path:

- `safety check -r <file>` against a file containing just `cuda-toolkit==13.0.3.0`: no crash.
- `safety check -r <file>` against all 18 cuda/nvidia packages pinned in `requirements-ci.txt`: no crash.
- `safety check -r requirements-ci.txt` against the **actual, full file** (400 packages, cuda-toolkit included): completes cleanly, produces a valid JSON report with the expected `vulnerabilities` key.

## Fix

Point Safety at `requirements-ci.txt` directly (`-r`) instead of scanning the ambient environment. This sidesteps the crash entirely and is also more precise — it no longer incidentally reports on CI-only tooling (safety/bandit/semgrep's own transitive deps) that happens to be installed in the same environment.

No change to the guard logic further down the step (missing-report / malformed-report checks) — the JSON shape is identical either way.

## Testing

- Validated the modified workflow YAML parses correctly.
- Reproduced the crash's absence against the real `requirements-ci.txt` locally (see root cause section above).
- No source code changes; CI-only.
