### PR TITLE
fix(context): deep-copy store results in ErasureReceipt.to_dict()

### DIFF
--- a/semantica/context/erasure.py
+++ b/semantica/context/erasure.py
@@ -34,6 +34,7 @@ Example:
     'unsupported'
 """
 
+import copy
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
@@ -122,7 +123,7 @@ class ErasureReceipt:
             "reason": self.reason,
             "erased_at": self.erased_at,
             "complete": self.complete,
-            "stores": {name: dict(result) for name, result in self.stores.items()},
+            "stores": copy.deepcopy(self.stores),
         }
 
 

--- a/tests/context/test_erasure_coordinator.py
+++ b/tests/context/test_erasure_coordinator.py
@@ -399,6 +399,27 @@ class TestReceipt(unittest.TestCase):
 
         self.assertEqual(receipt.stores["graph"]["status"], STATUS_ERASED)
 
+    def test_to_dict_copies_nested_backend_results(self):
+        """`dict(result)` was a shallow copy: `backend_result` (the raw dict a
+        backend like Qdrant returns) stayed shared, so sanitizing the payload
+        silently rewrote the live receipt it was audited from."""
+        receipt = ErasureReceipt(
+            entity_id="customer-4471",
+            stores={
+                "vectors": {
+                    "status": STATUS_ERASED,
+                    "backend_result": {"status": "completed"},
+                }
+            },
+        )
+
+        payload = receipt.to_dict()
+        payload["stores"]["vectors"]["backend_result"]["status"] = "redacted"
+
+        self.assertEqual(
+            receipt.stores["vectors"]["backend_result"]["status"], "completed"
+        )
+
     def test_receipt_and_tombstone_agree_on_when_the_erasure_happened(self):
         graph = _graph()
         receipt = ErasureCoordinator(graph=graph).erase_entity(


### PR DESCRIPTION
## Description

`ErasureReceipt.to_dict()` documents itself as deep-copying the per-store results, but `dict(result)` is a shallow copy. Nested dicts — `backend_result`, the raw dict a backend like Qdrant returns (`{"status": "completed"}`) — stay shared by reference between the serialized payload and the live receipt, so sanitizing the payload (e.g. redacting `backend_result` before a user-facing response) silently rewrites the audit receipt it was derived from.

The fix replaces the per-result shallow copy with `copy.deepcopy(self.stores)`, which makes the behavior match the existing docstring.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1376

## Changes Made

- `semantica/context/erasure.py`: `to_dict()` now returns `copy.deepcopy(self.stores)` instead of `{name: dict(result) ...}`
- `tests/context/test_erasure_coordinator.py`: added `test_to_dict_copies_nested_backend_results`, which mutates `payload["stores"]["vectors"]["backend_result"]["status"]` and asserts the live receipt is unaffected

## Testing

- [x] Tested locally
- [x] Added tests for new functionality

The new test fails on `main` (`receipt.stores["vectors"]["backend_result"]["status"]` comes back `"redacted"`) and passes with the fix. Full file: 49 passed, 3 subtests passed.

### Test Commands

```bash
pytest tests/context/test_erasure_coordinator.py
```

## Documentation

- [x] No documentation changes needed

The docstring already says "deep-copying the per-store results" — it is now accurate rather than aspirational.

## Breaking Changes

**Breaking Changes**: No

## Additional Notes

The existing `test_to_dict_copies_the_store_results` only mutates a top-level key, which `dict(result)` already isolated — that is why the shallow copy went uncaught.
