### PR TITLE
fix(ci): update actions/deploy-pages pin to current v5

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -65,4 +65,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5


### PR DESCRIPTION
verify-action-pins.sh is failing because actions/deploy-pages's v5 tag moved from v5.0.0 to v5.0.1 (backoff/jitter added to deployment polling, confirmed via the GitHub API, nothing suspicious). Updates the pinned SHA in docs.yml to match. Ran verify-action-pins.sh locally, all 49 references pass now.