### PR TITLE
docs: fix two broken cookbook notebook links

### DIFF
--- a/docs/learning-more.md
+++ b/docs/learning-more.md
@@ -46,7 +46,7 @@ Whether you're running your first pipeline or deploying Semantica in production,
         [Building Knowledge Graphs notebook](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/07_Building_Knowledge_Graphs.ipynb): multi-source, deduplication, conflict resolution.
       </Step>
       <Step title="Add semantic search">
-        [Embedding Generation notebook](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/12_Embedding_Generation.ipynb): providers, pooling strategies, vector stores.
+        [Embedding Generation notebook](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/12_Embedding_Generation.ipynb): generating embeddings, provider and model switching, dimensions. Then [Vector Store notebook](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/13_Vector_Store.ipynb): storing and searching vectors for retrieval.
       </Step>
       <Step title="Multi-source integration">
         [Multi-Source Data Integration notebook](https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/06_Multi_Source_Data_Integration.ipynb) for multi-source patterns.

--- a/docs/learning-more.md
+++ b/docs/learning-more.md
@@ -46,7 +46,7 @@ Whether you're running your first pipeline or deploying Semantica in production,
         [Building Knowledge Graphs notebook](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/07_Building_Knowledge_Graphs.ipynb): multi-source, deduplication, conflict resolution.
       </Step>
       <Step title="Add semantic search">
-        [Embeddings notebook](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/09_Embeddings.ipynb): providers, pooling strategies, vector stores.
+        [Embedding Generation notebook](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/12_Embedding_Generation.ipynb): providers, pooling strategies, vector stores.
       </Step>
       <Step title="Multi-source integration">
         [Multi-Source Data Integration notebook](https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/06_Multi_Source_Data_Integration.ipynb) for multi-source patterns.

--- a/docs/reference/distance.md
+++ b/docs/reference/distance.md
@@ -611,5 +611,3 @@ The Knowledge Explorer embeds Distance Intelligence directly in the browser dash
 - [Knowledge Graph Module](kg) — `NodeEmbedder`, `SimilarityCalculator`, and graph analytics.
 - [Visualization](visualization) — Programmatic distance heatmaps and ego-mode graph renders.
 - [Explorer](explorer) — Knowledge Explorer with built-in Distance Intelligence dashboard.
-
-- [Distance Intelligence](https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/12_Distance_Intelligence.ipynb) — Semantic neighborhoods and distance matrices · Advanced


### PR DESCRIPTION
I checked the `cookbook/**/*.ipynb` links in `docs/` and `README.md` against the notebooks currently in the repo and found two broken links.

* `docs/learning-more.md` pointed to `cookbook/introduction/09_Embeddings.ipynb`. Notebook 09 is actually `09_Graph_Store.ipynb`; the embeddings notebook is `12_Embedding_Generation.ipynb`. The link now points to the correct notebook.
* `docs/reference/distance.md` linked to `cookbook/advanced/12_Distance_Intelligence.ipynb`, which doesn't exist. There isn't a Distance Intelligence notebook elsewhere under `cookbook/` either, so the dead link has been removed. The section still links to the relevant Context, KG, Visualization, and Explorer reference pages.
