### PR TITLE
docs: convert relative page links to root paths to fix 404s on the live site

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -185,7 +185,7 @@ Centralized `ConfigManager` with environment variable overrides. No magic defaul
 | **Deduplication v2** | `blocking_v2`, `hybrid_v2`, `semantic_v2`: up to 7x faster than v1 |
 | **Indexed search** | Explorer search at 0.004ms on 118k nodes (v0.5.0) |
 
-- [Modules](modules) — Full module documentation with code examples.
-- [Learning More](learning-more) — Configuration reference, performance guide, and troubleshooting.
-- [Pipeline Reference](reference/pipeline) — Pipeline orchestration, workers, and retry policies.
-- [Core Reference](reference/core) — Framework lifecycle, plugin registry, and configuration.
+- [Modules](/modules) — Full module documentation with code examples.
+- [Learning More](/learning-more) — Configuration reference, performance guide, and troubleshooting.
+- [Pipeline Reference](/reference/pipeline) — Pipeline orchestration, workers, and retry policies.
+- [Core Reference](/reference/core) — Framework lifecycle, plugin registry, and configuration.

--- a/docs/choose-your-module.md
+++ b/docs/choose-your-module.md
@@ -5,7 +5,7 @@ icon: "compass"
 ---
 
 <Info>
-  Every module works independently — import only what you need. This page maps developer goals to starting points. The [Module Reference](modules) covers every module in depth.
+  Every module works independently — import only what you need. This page maps developer goals to starting points. The [Module Reference](/modules) covers every module in depth.
 </Info>
 
 ## Quick Reference
@@ -89,7 +89,7 @@ Pick your goal to see the minimum imports and a working skeleton.
       Pass `method="pattern"` to `NERExtractor` for zero-cost, zero-API-key extraction. Switch to `method="llm"` with any of the supported providers for higher recall.
     </Tip>
 
-    **Next:** [Quickstart →](quickstart) — full pipeline with visualization and export.
+    **Next:** [Quickstart →](/quickstart) — full pipeline with visualization and export.
   </Tab>
 
   <Tab title="Build GraphRAG">
@@ -122,7 +122,7 @@ Pick your goal to see the minimum imports and a working skeleton.
     print(result["reasoning_path"])  # multi-hop trace
     ```
 
-    **Next:** [Context module reference →](reference/context)
+    **Next:** [Context module reference →](/reference/context)
   </Tab>
 
   <Tab title="Add Agent Memory">
@@ -163,7 +163,7 @@ Pick your goal to see the minimum imports and a working skeleton.
       `decision_tracking=True` is required. Without it, `record_decision()` raises `RuntimeError`.
     </Note>
 
-    **Next:** [Context module reference →](reference/context)
+    **Next:** [Context module reference →](/reference/context)
   </Tab>
 
   <Tab title="Track Provenance">
@@ -195,7 +195,7 @@ Pick your goal to see the minimum imports and a working skeleton.
     diff     = manager.diff("v1.0", "v1.1")
     ```
 
-    **Next:** [Provenance reference →](reference/provenance) · [Change Management reference →](reference/change_management)
+    **Next:** [Provenance reference →](/reference/provenance) · [Change Management reference →](/reference/change_management)
   </Tab>
 
   <Tab title="Export">
@@ -222,7 +222,7 @@ Pick your goal to see the minimum imports and a working skeleton.
 
     **Formats:** Turtle · JSON-LD · N-Triples · RDF/XML · Parquet · Cypher · Arrow · OWL · CSV · ArangoDB AQL
 
-    **Next:** [Export module reference →](reference/export)
+    **Next:** [Export module reference →](/reference/export)
   </Tab>
 
   <Tab title="MCP — Claude / Cursor">
@@ -268,7 +268,7 @@ Pick your goal to see the minimum imports and a working skeleton.
       Set `SEMANTICA_KG_PATH` to persist your graph across restarts. Without it, all data is lost when the server process exits.
     </Warning>
 
-    **Next:** [MCP Server reference →](reference/mcp_server)
+    **Next:** [MCP Server reference →](/reference/mcp_server)
   </Tab>
 </Tabs>
 
@@ -283,11 +283,11 @@ Pick your goal to see the minimum imports and a working skeleton.
 
     Use **both together** via `AgentContext` (GraphRAG) to get grounded LLM responses where every claim traces back to a source node.
 
-    See also: [Core Concepts](concepts)
+    See also: [Core Concepts](/concepts)
   </Accordion>
 
   <Accordion title="I just want to run something quickly." icon="rocket">
-    Start with the [Quickstart](quickstart). It builds a complete pipeline (ingest → parse → extract → graph → visualize → export) with no API key required.
+    Start with the [Quickstart](/quickstart). It builds a complete pipeline (ingest → parse → extract → graph → visualize → export) with no API key required.
   </Accordion>
 
   <Accordion title="I'm adding Semantica to an existing agent — what's the minimum?" icon="plug">
@@ -304,7 +304,7 @@ Pick your goal to see the minimum imports and a working skeleton.
     )
     ```
 
-    [Context module reference →](reference/context)
+    [Context module reference →](/reference/context)
   </Accordion>
 
   <Accordion title="I need a compliance-ready pipeline — what's the minimum stack?" icon="shield-check">
@@ -322,6 +322,6 @@ Pick your goal to see the minimum imports and a working skeleton.
 
 ---
 
-- [Quickstart](quickstart) — Full pipeline in 5 minutes.
-- [Module Reference](modules) — Every module with examples and common chains.
-- [API Reference](reference/context) — Complete class and method documentation.
+- [Quickstart](/quickstart) — Full pipeline in 5 minutes.
+- [Module Reference](/modules) — Every module with examples and common chains.
+- [API Reference](/reference/context) — Complete class and method documentation.

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -48,5 +48,5 @@ Published research using Semantica? [Let us know](https://github.com/semantica-a
 
 ## See Also
 
-- [License](project-license) — MIT License details.
-- [Community](community) — Connect with the Semantica community.
+- [License](/project-license) — MIT License details.
+- [Community](/community) — Connect with the Semantica community.

--- a/docs/cli-setup.md
+++ b/docs/cli-setup.md
@@ -24,7 +24,7 @@ After installation the following commands are available:
 | `semantica-mcp` | `semantica.mcp_server:main` | MCP server (stdio) for Claude Desktop, Cursor, Windsurf, and other MCP clients |
 
 <Note>
-  `semantica-explorer` requires `pip install semantica[explorer]`. Running it without that extra will immediately print an error and exit. See [Explorer Setup](explorer-setup) for the full walkthrough.
+  `semantica-explorer` requires `pip install semantica[explorer]`. Running it without that extra will immediately print an error and exit. See [Explorer Setup](/explorer-setup) for the full walkthrough.
 </Note>
 
 
@@ -52,8 +52,8 @@ python -c "import semantica; print(semantica.__version__)"
 - **semantica** — The general-purpose CLI. Use it for one-off pipeline runs, entity extraction, and graph operations from a shell script or CI job.
 - **semantica-server** — Starts the REST API server. Binds to `0.0.0.0:8000`. Use this when another service or application needs programmatic access to Semantica over HTTP.
 - **semantica-worker** — Background task processor. Run alongside `semantica-server` when you need async pipeline execution outside the request cycle. Start the server first, then start one or more workers pointing at the same backend.
-- **semantica-explorer** — Launches the browser dashboard. Requires `pip install semantica[explorer]`. Use this to explore a saved knowledge graph interactively. See [Explorer Setup](explorer-setup).
-- **semantica-mcp** — Runs the MCP server over stdio. Configure it in your MCP client's settings file to expose all 15 tools and 3 resources to Claude Desktop, Cursor, Windsurf, or any MCP-aware client. See [MCP Server](reference/mcp_server).
+- **semantica-explorer** — Launches the browser dashboard. Requires `pip install semantica[explorer]`. Use this to explore a saved knowledge graph interactively. See [Explorer Setup](/explorer-setup).
+- **semantica-mcp** — Runs the MCP server over stdio. Configure it in your MCP client's settings file to expose all 15 tools and 3 resources to Claude Desktop, Cursor, Windsurf, or any MCP-aware client. See [MCP Server](/reference/mcp_server).
 
 
 ## Usage Examples
@@ -116,7 +116,7 @@ python -c "import semantica; print(semantica.__version__)"
     echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | semantica-mcp
     ```
 
-    You should receive a JSON-RPC response. See [MCP Server](reference/mcp_server) for the full list of tools and resources.
+    You should receive a JSON-RPC response. See [MCP Server](/reference/mcp_server) for the full list of tools and resources.
   </Tab>
   <Tab title="Explorer">
     ```bash
@@ -124,7 +124,7 @@ python -c "import semantica; print(semantica.__version__)"
     semantica-explorer --graph my_graph.json
     ```
 
-    See [Explorer Setup](explorer-setup) for the full walkthrough including how to build and save a graph file.
+    See [Explorer Setup](/explorer-setup) for the full walkthrough including how to build and save a graph file.
   </Tab>
   <Tab title="Python module form">
     Every command also runs as a Python module: useful when the script directory is not on `PATH`:
@@ -228,7 +228,7 @@ Install the [Microsoft Visual C++ Redistributable](https://aka.ms/vs/17/release/
 
 ## Next Steps
 
-- [Explorer Setup](explorer-setup) — Build a graph, save it, and launch the browser dashboard.
-- [MCP Server](reference/mcp_server) — All 15 tools and 3 resources exposed over the MCP protocol.
-- [Installation](installation) — Virtual environments, optional extras, and platform-specific notes.
-- [Quickstart](quickstart) — End-to-end pipeline walkthrough with working code.
+- [Explorer Setup](/explorer-setup) — Build a graph, save it, and launch the browser dashboard.
+- [MCP Server](/reference/mcp_server) — All 15 tools and 3 resources exposed over the MCP protocol.
+- [Installation](/installation) — Virtual environments, optional extras, and platform-specific notes.
+- [Quickstart](/quickstart) — End-to-end pipeline walkthrough with working code.

--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -114,7 +114,7 @@ See [Architecture](architecture#extension-points) for the full extension guide.
 
 ## How to Contribute
 
-- [Contributing Guide](contributing-guide) — Submit code, documentation, tests, or cookbook notebooks.
+- [Contributing Guide](/contributing-guide) — Submit code, documentation, tests, or cookbook notebooks.
 - [GitHub Issues](https://github.com/semantica-agi/semantica/issues) — Report bugs, request features, or propose integrations.
 - [Discord](https://discord.gg/sV34vps5hH) — Share what you're building with the community.
 - [GitHub Discussions](https://github.com/semantica-agi/semantica/discussions) — Long-form questions, design discussions, and ideas.

--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -109,7 +109,7 @@ def my_ingestor(source):
 method_registry.register("file", "my_format", my_ingestor)
 ```
 
-See [Architecture](architecture#extension-points) for the full extension guide.
+See [Architecture](/architecture#extension-points) for the full extension guide.
 
 
 ## How to Contribute

--- a/docs/community.md
+++ b/docs/community.md
@@ -55,7 +55,7 @@ There's no single right way to contribute. Pick the path that fits your skills a
 - Review open pull requests
 - Share your Semantica projects in GitHub Discussions
 
-See the [Contributing Guide](contributing-guide) for the full development workflow.
+See the [Contributing Guide](/contributing-guide) for the full development workflow.
 
 
 ## Stay Connected
@@ -68,7 +68,7 @@ See the [Contributing Guide](contributing-guide) for the full development workfl
 
 ## See Also
 
-- [Contributing Guide](contributing-guide) — Step-by-step guide for submitting PRs and setting up your dev environment.
-- [Community Projects](community-projects) — Projects and integrations built by the community.
-- [FAQ](faq) — Common questions answered.
-- [Governance](governance) — How the project is run and decisions are made.
+- [Contributing Guide](/contributing-guide) — Step-by-step guide for submitting PRs and setting up your dev environment.
+- [Community Projects](/community-projects) — Projects and integrations built by the community.
+- [FAQ](/faq) — Common questions answered.
+- [Governance](/governance) — How the project is run and decisions are made.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -5,7 +5,7 @@ icon: "book-open"
 ---
 
 <Info>
-  New here? Start with [Getting Started](getting-started) for hands-on examples, then return here for deeper understanding.
+  New here? Start with [Getting Started](/getting-started) for hands-on examples, then return here for deeper understanding.
 </Info>
 
 Semantica transforms unstructured data: documents, web pages, reports, databases: into **knowledge graphs**: structured representations that AI systems can query, reason about, and trace back to sources.
@@ -203,7 +203,7 @@ ontology = {
 }
 ```
 
-Semantica can auto-generate ontologies from your knowledge graph or import existing OWL/RDF/Turtle ontologies. The **Ontology Hub** (v0.5.0) adds a visual editor, SHACL Studio, alignment authoring, and a live health dashboard. See the [Ontology reference](reference/ontology) for the full 6-stage generation pipeline.
+Semantica can auto-generate ontologies from your knowledge graph or import existing OWL/RDF/Turtle ontologies. The **Ontology Hub** (v0.5.0) adds a visual editor, SHACL Studio, alignment authoring, and a live health dashboard. See the [Ontology reference](/reference/ontology) for the full 6-stage generation pipeline.
 
 
 ## Reasoning & Inference
@@ -319,7 +319,7 @@ scores = calc.calculate_similarity(entity_a, entity_b)
 
 **Features:** N×N semantic distance matrices, ego-mode visualization, distance band classification (`near` / `mid` / `far`), embedding cache optimization for large graphs.
 
-The [Visualization module](reference/visualization) renders distance matrices as interactive heatmaps and ego-mode neighborhood graphs. The [Explorer](reference/explorer) embeds distance intelligence directly in the browser dashboard.
+The [Visualization module](/reference/visualization) renders distance matrices as interactive heatmaps and ego-mode neighborhood graphs. The [Explorer](/reference/explorer) embeds distance intelligence directly in the browser dashboard.
 
 
 ## Deduplication & Entity Resolution
@@ -413,7 +413,7 @@ When multiple sources disagree on the same fact, Semantica flags and resolves th
 - **Majority vote**: aggregate across all sources with ≥ 2 agreeing
 - **Manual review**: flag for human arbitration; continue pipeline without blocking
 
-See the [Conflicts reference](reference/conflicts) for `ConflictResolver`, `SourceTracker`, and `InvestigationGuideGenerator`.
+See the [Conflicts reference](/reference/conflicts) for `ConflictResolver`, `SourceTracker`, and `InvestigationGuideGenerator`.
 
 
 ## Custom Plugin Development
@@ -482,6 +482,6 @@ Semantica is designed for extension. Any component: ingestor, extractor, graph b
   </Accordion>
 </AccordionGroup>
 
-- [Quickstart Tutorial](quickstart) — Build a full pipeline with code.
-- [Modules Guide](modules) — Every module explained with examples.
-- [API Reference](reference/context) — Complete technical reference.
+- [Quickstart Tutorial](/quickstart) — Build a full pipeline with code.
+- [Modules Guide](/modules) — Every module explained with examples.
+- [API Reference](/reference/context) — Complete technical reference.

--- a/docs/contributing-guide.md
+++ b/docs/contributing-guide.md
@@ -85,5 +85,5 @@ All contributors are expected to follow the [Contributor Covenant Code of Conduc
 - [GitHub Discussions](https://github.com/semantica-agi/semantica/discussions)
 - [Discord](https://discord.gg/sV34vps5hH)
 
-- [Community](community) — Community guidelines and values.
-- [Governance](governance) — How decisions are made and the project is run.
+- [Community](/community) — Community guidelines and values.
+- [Governance](/governance) — How decisions are made and the project is run.

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -8,7 +8,7 @@ icon: "flask"
   **Where to start:**
   - **New to Semantica**: begin with [Core Tutorials](#core-tutorials)
   - **Building an application**: see [Advanced Concepts](#advanced-concepts)
-  - **Need installation help**: see the [Installation Guide](installation)
+  - **Need installation help**: see the [Installation Guide](/installation)
 </Tip>
 
 <Note>

--- a/docs/explorer-setup.md
+++ b/docs/explorer-setup.md
@@ -6,7 +6,7 @@ icon: "map"
 
 **`semantica-explorer`** is an **interactive browser dashboard** for knowledge graph exploration. You give it a graph file, it starts a local server, and opens a browser tab where you can search nodes, find paths, inspect provenance, and run analytics: no code required after launch.
 
-This page covers everything needed to go from zero to a running Explorer. For the full REST API reference and endpoint catalogue, see [Explorer Reference](reference/explorer).
+This page covers everything needed to go from zero to a running Explorer. For the full REST API reference and endpoint catalogue, see [Explorer Reference](/reference/explorer).
 
 
 ## Prerequisites
@@ -264,7 +264,7 @@ Once running, Explorer exposes a REST API and dashboard for:
 
 The full endpoint catalogue is documented in the Swagger UI at `/docs` and in the reference page below.
 
-- [Explorer Reference](reference/explorer) — Every REST endpoint, WebSocket events, analytics, and all supported flags.
-- [CLI Setup](cli-setup) — All five Semantica executables and when to use each one.
-- [Context Module](reference/context) — Full documentation for ContextGraph: build, query, save, and load.
-- [Quickstart](quickstart) — End-to-end pipeline: ingest → extract → build graph → export.
+- [Explorer Reference](/reference/explorer) — Every REST endpoint, WebSocket events, analytics, and all supported flags.
+- [CLI Setup](/cli-setup) — All five Semantica executables and when to use each one.
+- [Context Module](/reference/context) — Full documentation for ContextGraph: build, query, save, and load.
+- [Quickstart](/quickstart) — End-to-end pipeline: ingest → extract → build graph → export.

--- a/docs/explorer-setup.md
+++ b/docs/explorer-setup.md
@@ -27,7 +27,7 @@ Verify:
 semantica-explorer --help
 ```
 
-You should see the usage message with the four available flags. If you see `command not found`, activate your virtual environment first. See [CLI Setup](cli-setup#troubleshooting) for PATH help.
+You should see the usage message with the four available flags. If you see `command not found`, activate your virtual environment first. See [CLI Setup](/cli-setup#troubleshooting) for PATH help.
 
 
 ## Minimal End-to-End Example

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -93,7 +93,7 @@ pip install --upgrade semantica
 pip install semantica
 ```
 
-See [Installation](installation) for virtual environment setup, optional extras (`[gpu]`, `[all]`, provider-specific), and platform-specific troubleshooting.
+See [Installation](/installation) for virtual environment setup, optional extras (`[gpu]`, `[all]`, provider-specific), and platform-specific troubleshooting.
 
 </Accordion>
 
@@ -173,7 +173,7 @@ This includes PyTorch with CUDA, FAISS GPU, and CuPy.
 <Accordion title="How does Semantica handle large datasets?" icon="layer-group">
 
 - **Batching**: process documents in configurable chunks to control memory usage
-- **Parallel processing**: the `semantica.pipeline` module can run independent, parallel-safe steps in the same dependency layer concurrently (see the [Pipeline guide](guides/pipeline))
+- **Parallel processing**: the `semantica.pipeline` module can run independent, parallel-safe steps in the same dependency layer concurrently (see the [Pipeline guide](/guides/pipeline))
 - **Delta processing**: update graphs incrementally without full recompute on new data
 - **Persistent backends**: swap in-memory NetworkX for Neo4j, FalkorDB, or Apache AGE for large-scale production graphs
 
@@ -350,4 +350,4 @@ set PYTHONIOENCODING=utf-8
 
 - [Discord](https://discord.gg/sV34vps5hH) — Community chat and live support.
 - [GitHub Issues](https://github.com/semantica-agi/semantica/issues) — Bug reports and feature requests.
-- [Contributing](contributing-guide) — Help improve Semantica.
+- [Contributing](/contributing-guide) — Help improve Semantica.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,7 +54,7 @@ icon: "rocket"
     | :----- | :-------------- | :--------- |
     | **Knowledge Graph** | Turn documents into structured, queryable graphs | [Quickstart → Step 1](/quickstart) |
     | **Agent Context** | Give your AI agent persistent memory and decision tracking | [Context reference](/reference/context) |
-    | **GraphRAG** | Ground LLM answers in structured knowledge | [Concepts → GraphRAG](concepts#graphrag) |
+    | **GraphRAG** | Ground LLM answers in structured knowledge | [Concepts → GraphRAG](/concepts#graphrag) |
     | **MCP Integration** | Use Semantica from Claude Desktop or VS Code | [MCP Server](/reference/mcp_server) |
 
   </Step>
@@ -161,7 +161,7 @@ icon: "rocket"
         print(f"{claim.text}  →  source: {claim.source_node}")
     ```
 
-    **Next:** [GraphRAG concepts →](concepts#graphrag)
+    **Next:** [GraphRAG concepts →](/concepts#graphrag)
   </Tab>
 
   <Tab title="MCP Integration">

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@ icon: "rocket"
 ---
 
 <Tip>
-  Already installed? Jump straight to [Quickstart](quickstart). Need setup help first? See [Installation](installation).
+  Already installed? Jump straight to [Quickstart](/quickstart). Need setup help first? See [Installation](/installation).
 </Tip>
 
 ## What You Can Build
@@ -52,15 +52,15 @@ icon: "rocket"
 
     | Track | You want to... | Start with |
     | :----- | :-------------- | :--------- |
-    | **Knowledge Graph** | Turn documents into structured, queryable graphs | [Quickstart → Step 1](quickstart) |
-    | **Agent Context** | Give your AI agent persistent memory and decision tracking | [Context reference](reference/context) |
+    | **Knowledge Graph** | Turn documents into structured, queryable graphs | [Quickstart → Step 1](/quickstart) |
+    | **Agent Context** | Give your AI agent persistent memory and decision tracking | [Context reference](/reference/context) |
     | **GraphRAG** | Ground LLM answers in structured knowledge | [Concepts → GraphRAG](concepts#graphrag) |
-    | **MCP Integration** | Use Semantica from Claude Desktop or VS Code | [MCP Server](reference/mcp_server) |
+    | **MCP Integration** | Use Semantica from Claude Desktop or VS Code | [MCP Server](/reference/mcp_server) |
 
   </Step>
 
   <Step title="Run the pipeline">
-    The full 6-step pipeline: ingest, parse, extract, build, visualize, export: is in the [Quickstart](quickstart). Takes under 5 minutes with pattern-based extraction (no API key required).
+    The full 6-step pipeline: ingest, parse, extract, build, visualize, export: is in the [Quickstart](/quickstart). Takes under 5 minutes with pattern-based extraction (no API key required).
 
     <Note>
       An LLM API key is **optional** for the quickstart. Pattern-based extraction works out of the box: upgrade to LLM extraction for higher accuracy when you're ready.
@@ -99,7 +99,7 @@ icon: "rocket"
     print(f"{len(graph['entities'])} nodes, {len(graph['relationships'])} edges")
     ```
 
-    **Next:** [Full pipeline walkthrough →](quickstart)
+    **Next:** [Full pipeline walkthrough →](/quickstart)
   </Tab>
 
   <Tab title="Agent Context">
@@ -131,7 +131,7 @@ icon: "rocket"
     precedents = context.find_precedents("model selection", limit=5)
     ```
 
-    **Next:** [Context module reference →](reference/context)
+    **Next:** [Context module reference →](/reference/context)
   </Tab>
 
   <Tab title="GraphRAG">
@@ -185,7 +185,7 @@ icon: "rocket"
 
     15 tools available instantly: extract entities, query graph, record decisions, run reasoning, export results.
 
-    **Next:** [MCP Server reference →](reference/mcp_server)
+    **Next:** [MCP Server reference →](/reference/mcp_server)
   </Tab>
 </Tabs>
 
@@ -194,29 +194,29 @@ icon: "rocket"
 
 Semantica uses a modular, layered architecture: import only what you need.
 
-- **[Input Layer](reference/ingest)** — Load and prepare data from any source. Modules: `ingest`, `parse`, `split`, `normalize`
-- **[Semantic Layer](reference/semantic_extract)** — Extract meaning from raw text. Modules: `semantic_extract`, `kg`, `ontology`, `reasoning`
-- **[Storage Layer](reference/vector_store)** — Persist knowledge for retrieval. Modules: `embeddings`, `vector_store`, `graph_store`, `triplet_store`
-- **[Quality Layer](reference/deduplication)** — Validate and deduplicate. Modules: `deduplication`, `conflicts`
-- **[Context Layer](reference/context)** — Track decisions and lineage. Modules: `context`, `provenance`, `change_management`
-- **[Output Layer](reference/export)** — Deliver results downstream. Modules: `export`, `visualization`, `pipeline`, `explorer`
+- **[Input Layer](/reference/ingest)** — Load and prepare data from any source. Modules: `ingest`, `parse`, `split`, `normalize`
+- **[Semantic Layer](/reference/semantic_extract)** — Extract meaning from raw text. Modules: `semantic_extract`, `kg`, `ontology`, `reasoning`
+- **[Storage Layer](/reference/vector_store)** — Persist knowledge for retrieval. Modules: `embeddings`, `vector_store`, `graph_store`, `triplet_store`
+- **[Quality Layer](/reference/deduplication)** — Validate and deduplicate. Modules: `deduplication`, `conflicts`
+- **[Context Layer](/reference/context)** — Track decisions and lineage. Modules: `context`, `provenance`, `change_management`
+- **[Output Layer](/reference/export)** — Deliver results downstream. Modules: `export`, `visualization`, `pipeline`, `explorer`
 
 
 ## Which Module Do I Need?
 
-See the [Choose the Right Module](choose-your-module) guide — it maps 35+ developer goals to the right starting point across all 27 modules, with working code for the most common paths.
+See the [Choose the Right Module](/choose-your-module) guide — it maps 35+ developer goals to the right starting point across all 27 modules, with working code for the most common paths.
 
 
 ## Next Steps
 
-- [Core Concepts](concepts) — Knowledge graphs, ontologies, and reasoning explained in depth.
-- [Quickstart Tutorial](quickstart) — Full 6-step pipeline walkthrough with working code.
-- [Module Reference](modules) — Every module, class, and common chain explained.
-- [API Reference](reference/context) — Complete module documentation for every class and method.
+- [Core Concepts](/concepts) — Knowledge graphs, ontologies, and reasoning explained in depth.
+- [Quickstart Tutorial](/quickstart) — Full 6-step pipeline walkthrough with working code.
+- [Module Reference](/modules) — Every module, class, and common chain explained.
+- [API Reference](/reference/context) — Complete module documentation for every class and method.
 
 
 ## Help
 
 - [Discord](https://discord.gg/sV34vps5hH) — Ask questions, share projects, get community support.
 - [GitHub Issues](https://github.com/semantica-agi/semantica/issues) — Report bugs or request features.
-- [FAQ](faq) — Common questions answered.
+- [FAQ](/faq) — Common questions answered.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -214,7 +214,7 @@ A vulnerability in XML parsers that allows attackers to read arbitrary files or 
 
 ## See Also
 
-- [Core Concepts](concepts) — Deeper explanation of key ideas with code examples.
-- [Getting Started](getting-started) — First working examples: no prior graph experience required.
-- [Modules Guide](modules) — All 27 modules explained with code and pipeline chains.
-- [API Reference](reference/context) — Complete technical reference for every class and method.
+- [Core Concepts](/concepts) — Deeper explanation of key ideas with code examples.
+- [Getting Started](/getting-started) — First working examples: no prior graph experience required.
+- [Modules Guide](/modules) — All 27 modules explained with code and pipeline chains.
+- [API Reference](/reference/context) — Complete technical reference for every class and method.

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -74,10 +74,10 @@ Semantica follows **Semantic Versioning** (`MAJOR.MINOR.PATCH`):
 
 ## License
 
-MIT License: see [LICENSE](https://github.com/semantica-agi/semantica/blob/main/LICENSE) and the [License page](project-license).
+MIT License: see [LICENSE](https://github.com/semantica-agi/semantica/blob/main/LICENSE) and the [License page](/project-license).
 
 
 ## See Also
 
-- [Contributing](contributing-guide) — How to submit changes.
-- [Community](community) — Community guidelines and channels.
+- [Contributing](/contributing-guide) — How to submit changes.
+- [Community](/community) — Community guidelines and channels.

--- a/docs/guides/agent-memory.md
+++ b/docs/guides/agent-memory.md
@@ -46,7 +46,7 @@ Agent Memory provides persistent storage and intelligent retrieval of informatio
 - Simple retrieval tasks where relationships between entities don't matter
 
 <Info>
-  This guide covers the memory layer. For graph-enriched traversal and entity linking, see [Context Graphs](context-graphs). For decision accountability — recording, auditing, and causally tracing what the agent chose — see [Decision Intelligence](decision-intelligence).
+  This guide covers the memory layer. For graph-enriched traversal and entity linking, see [Context Graphs](/guides/context-graphs). For decision accountability — recording, auditing, and causally tracing what the agent chose — see [Decision Intelligence](/guides/decision-intelligence).
 </Info>
 
 ## Setting Up a Persistent Memory Context
@@ -657,10 +657,10 @@ print("Total memories: {}".format(s.get("total_items", 0)))
 
 ## Related Guides
 
-- [Context Graphs](context-graphs) — How the underlying `ContextGraph` stores entity nodes and decision nodes; temporal interval reasoning; deduplication before node insertion; ontology from graph.
-- [Decision Intelligence](decision-intelligence) — Recording decisions as graph nodes with causal chains and policy gating.
-- [Multi-Agent Systems](multi-agent) — Coordinating multiple agents through a shared `AgentContext` and save/load handoffs.
-- [LLM Integrations](llm-integrations) — Configuring the LLM provider passed to `query_with_reasoning()`.
+- [Context Graphs](/guides/context-graphs) — How the underlying `ContextGraph` stores entity nodes and decision nodes; temporal interval reasoning; deduplication before node insertion; ontology from graph.
+- [Decision Intelligence](/guides/decision-intelligence) — Recording decisions as graph nodes with causal chains and policy gating.
+- [Multi-Agent Systems](/guides/multi-agent) — Coordinating multiple agents through a shared `AgentContext` and save/load handoffs.
+- [LLM Integrations](/guides/llm-integrations) — Configuring the LLM provider passed to `query_with_reasoning()`.
 - [Deduplication Guide](deduplication) — Full reference for `DuplicateDetector`, `EntityMerger`, similarity methods, and cluster strategies.
 - [Ontology Management](ontology) — Generate and validate OWL ontologies from the knowledge graph; export to Turtle, OWL/XML, JSON-LD.
 - [Context Module Reference](../reference/context) — Full API: `AgentContext`, `AgentMemory`, `MemoryItem`, `ContextRetriever`.

--- a/docs/guides/change-management.md
+++ b/docs/guides/change-management.md
@@ -496,8 +496,8 @@ print("Model v1.1 verified and approved for production.")
 
 ## Related Guides
 
-- [Context Graphs](context-graphs) — `ContextGraph.to_dict()` feeds `create_snapshot()`
+- [Context Graphs](/guides/context-graphs) — `ContextGraph.to_dict()` feeds `create_snapshot()`
 - [Ontology Management](ontology) — pair ontology versioning with graph versioning for a complete schema + data audit trail
-- [SHACL Validation](shacl-validation) — validate graph data at each version gate before snapshotting
+- [SHACL Validation](/guides/shacl-validation) — validate graph data at each version gate before snapshotting
 - [Provenance](provenance) — combine change management with W3C PROV-O lineage for a full audit trail
 - [Visualization](visualization) — `TemporalVisualizer.visualize_snapshot_comparison()` and `visualize_metrics_evolution()` render version diffs as interactive charts

--- a/docs/guides/conflict-resolution.md
+++ b/docs/guides/conflict-resolution.md
@@ -69,7 +69,7 @@ flowchart TD
 2. **Conflict Detection** — Call `detect_entity_conflicts()` to surface all property disagreements at once, or `detect_value_conflicts()` to target a specific property.
 3. **Resolution** — For each conflict, apply a strategy (`CREDIBILITY_WEIGHTED`, `MOST_RECENT`, `VOTING`, etc.) or route it for expert review (`EXPERT_REVIEW`).
 4. **Persist Canonical Values** — Write resolved values back to your canonical entities or graph store. See [Persisting resolved values](#persisting-resolved-values).
-5. **SHACL Validation** — Enforce structural constraints on the resolved graph to confirm it satisfies your ontology. See [SHACL Validation](shacl-validation).
+5. **SHACL Validation** — Enforce structural constraints on the resolved graph to confirm it satisfies your ontology. See [SHACL Validation](/guides/shacl-validation).
 
 ## Quick Start: A Beginner Example
 
@@ -698,6 +698,6 @@ Calling `set_resolution_rule()` for every entity-property pair just to apply the
 
 - [Deduplication](deduplication) — remove duplicate nodes before running conflict detection
 - [Provenance](provenance) — track which source each resolved value came from, and verify the audit trail cryptographically
-- [SHACL Validation](shacl-validation) — enforce structural constraints after conflicts are resolved
-- [Change Management](change-management) — snapshot the graph before and after conflict resolution runs
+- [SHACL Validation](/guides/shacl-validation) — enforce structural constraints after conflicts are resolved
+- [Change Management](/guides/change-management) — snapshot the graph before and after conflict resolution runs
 - [Ontology Management](ontology) — align entity types to a shared vocabulary to reduce type conflicts at the schema level

--- a/docs/guides/context-graphs.md
+++ b/docs/guides/context-graphs.md
@@ -50,7 +50,7 @@ A context graph is a property graph that stores entities as **nodes** and relati
 - Cases where setup complexity exceeds the relationship complexity
 
 <Info>
-  ContextGraph is an **in-memory data structure**. All nodes, edges, and metadata are stored in Python dictionaries and lists. For standalone graphs, persist state with `save_to_file()`. When using `AgentContext`, call `AgentContext.save()` instead — it saves the graph, the FAISS vector index, and memory in one step. For analytical operations on top of a populated graph — centrality rankings, community detection, node embeddings, link prediction — see the [Graph Analytics guide](graph-analytics). For recording and querying decisions stored as nodes, see the [Decision Intelligence guide](decision-intelligence).
+  ContextGraph is an **in-memory data structure**. All nodes, edges, and metadata are stored in Python dictionaries and lists. For standalone graphs, persist state with `save_to_file()`. When using `AgentContext`, call `AgentContext.save()` instead — it saves the graph, the FAISS vector index, and memory in one step. For analytical operations on top of a populated graph — centrality rankings, community detection, node embeddings, link prediction — see the [Graph Analytics guide](/guides/graph-analytics). For recording and querying decisions stored as nodes, see the [Decision Intelligence guide](/guides/decision-intelligence).
 </Info>
 
 ## Constructing the Graph
@@ -704,8 +704,8 @@ for n in stress_reach:
 
 ## Related Guides
 
-- [Graph Analytics](graph-analytics) — centrality rankings, community detection, node embeddings, and link prediction on a populated `ContextGraph`
-- [Decision Intelligence](decision-intelligence) — recording decisions as typed nodes, causal chain analysis, precedent search, and policy enforcement
+- [Graph Analytics](/guides/graph-analytics) — centrality rankings, community detection, node embeddings, and link prediction on a populated `ContextGraph`
+- [Decision Intelligence](/guides/decision-intelligence) — recording decisions as typed nodes, causal chain analysis, precedent search, and policy enforcement
 - [Ingest](ingest) — loading data from PDFs, APIs, databases, STIX bundles, and RSS feeds into the graph
 - [Deduplication](deduplication) — detecting and merging near-duplicate nodes before insertion to prevent graph fragmentation
 - [Reasoning](reasoning) — temporal interval algebra (Allen relations), forward/backward chaining, and SPARQL over the knowledge graph

--- a/docs/guides/decision-intelligence.md
+++ b/docs/guides/decision-intelligence.md
@@ -638,8 +638,8 @@ results = context.find_precedents("APT29 infrastructure attribution", limit=5)
 
 ## Related Guides
 
-- [Context Graphs](context-graphs) — how `ContextGraph` stores decision nodes and causal edges
-- [Distance Intelligence](distance-intelligence) — `trace_decision_causality()` annotates causal chains with confidence decay and distance bands
+- [Context Graphs](/guides/context-graphs) — how `ContextGraph` stores decision nodes and causal edges
+- [Distance Intelligence](/guides/distance-intelligence) — `trace_decision_causality()` annotates causal chains with confidence decay and distance bands
 - [Provenance](provenance) — W3C PROV-O audit trail that wraps decision records in standards-compliant provenance
-- [MCP Server](mcp-server) — expose decision recording and precedent search to LLM agents via the `record_decision` and `find_precedents` tools
-- [Change Management](change-management) — checkpoint decision state with `flush_checkpoint()` for versioned snapshots
+- [MCP Server](/guides/mcp-server) — expose decision recording and precedent search to LLM agents via the `record_decision` and `find_precedents` tools
+- [Change Management](/guides/change-management) — checkpoint decision state with `flush_checkpoint()` for versioned snapshots

--- a/docs/guides/deduplication.md
+++ b/docs/guides/deduplication.md
@@ -612,7 +612,7 @@ The similarity threshold controls sensitivity. Start at 0.7 and examine false po
 ## Related Guides
 
 - [Ingest Anything](ingest) — multi-source ingestion creates the duplicates this module resolves
-- [Context Graphs](context-graphs) — store deduplicated entities directly in the knowledge graph
-- [Conflict Resolution](conflict-resolution) — after merging, reconcile disagreeing property values on the canonical entity
+- [Context Graphs](/guides/context-graphs) — store deduplicated entities directly in the knowledge graph
+- [Conflict Resolution](/guides/conflict-resolution) — after merging, reconcile disagreeing property values on the canonical entity
 - [Provenance](provenance) — track merge lineage so every canonical entity traces back to its original sources
 - [Pipeline](pipeline) — chain ingest, deduplicate, and store as a `PipelineBuilder` workflow

--- a/docs/guides/distance-intelligence.md
+++ b/docs/guides/distance-intelligence.md
@@ -557,8 +557,8 @@ for chain in chains:
 
 ## Related Guides
 
-- [Context Graphs](context-graphs) — `ContextGraph` node and edge model; `add_edge(weight=...)` feeds confidence decay
-- [Graph Analytics](graph-analytics) — centrality, community detection, Node2Vec embeddings, link prediction
-- [Agent Memory](agent-memory) — proximity-blended retrieval (`proximity_weight`) integrates distance intelligence into memory search
-- [Decision Intelligence](decision-intelligence) — `trace_decision_causality()` for causal chains with distance annotations
+- [Context Graphs](/guides/context-graphs) — `ContextGraph` node and edge model; `add_edge(weight=...)` feeds confidence decay
+- [Graph Analytics](/guides/graph-analytics) — centrality, community detection, Node2Vec embeddings, link prediction
+- [Agent Memory](/guides/agent-memory) — proximity-blended retrieval (`proximity_weight`) integrates distance intelligence into memory search
+- [Decision Intelligence](/guides/decision-intelligence) — `trace_decision_causality()` for causal chains with distance annotations
 - [Reasoning & Rules](reasoning) — `TemporalReasoningEngine` for Allen interval algebra over time-bounded graph nodes

--- a/docs/guides/export.md
+++ b/docs/guides/export.md
@@ -443,8 +443,8 @@ For semantic reasoning and ontology work, OWL/XML is the format — it is the on
 
 ## Related Guides
 
-- [Context Graphs](context-graphs) — the `ContextGraph` object whose `to_dict()` feeds all exports
+- [Context Graphs](/guides/context-graphs) — the `ContextGraph` object whose `to_dict()` feeds all exports
 - [Ontology Management](ontology) — export OWL ontologies generated from your graph
 - [Reasoning & Rules](reasoning) — reasoning results can be exported as RDF triples
-- [Change Management](change-management) — snapshot a graph before exporting to prove the export was made from a verified state
+- [Change Management](/guides/change-management) — snapshot a graph before exporting to prove the export was made from a verified state
 - [Pipeline](pipeline) — chain ingest, extract, and export in a single `PipelineBuilder`

--- a/docs/guides/graph-analytics.md
+++ b/docs/guides/graph-analytics.md
@@ -310,7 +310,7 @@ for node1, node2, score in predictions:
 A score above 0.8 is worth analyst review — these aren't random; they're edges the topology of the existing graph strongly implies. Scores below 0.5 are noise. The sweet spot for human review is 0.6–0.8: plausible but not yet confirmed.
 
 <Info>
-  Link prediction is also available on `Decision` nodes through `DecisionQuery.predict_decision_relationships(decision_id, top_k)`. See the [Decision Intelligence guide](decision-intelligence) for how to surface causal relationships between past decisions.
+  Link prediction is also available on `Decision` nodes through `DecisionQuery.predict_decision_relationships(decision_id, top_k)`. See the [Decision Intelligence guide](/guides/decision-intelligence) for how to surface causal relationships between past decisions.
 </Info>
 
 ## Understanding Your Decision History
@@ -538,7 +538,7 @@ print(f"\n{len(result['communities'])} exposure clusters  "
 
 ## Related Guides
 
-- [Context Graphs](context-graphs) — building and querying the underlying `ContextGraph`
+- [Context Graphs](/guides/context-graphs) — building and querying the underlying `ContextGraph`
 - [Visualization](visualization) — render centrality rankings and community clusters as interactive dashboards
-- [Decision Intelligence](decision-intelligence) — link prediction and structural similarity applied to decision nodes
-- [GraphRAG](graphrag) — using analytics results to ground LLM generation in the most contextually relevant subgraph
+- [Decision Intelligence](/guides/decision-intelligence) — link prediction and structural similarity applied to decision nodes
+- [GraphRAG](/guides/graphrag) — using analytics results to ground LLM generation in the most contextually relevant subgraph

--- a/docs/guides/graphrag.md
+++ b/docs/guides/graphrag.md
@@ -576,9 +576,9 @@ The vector search and graph traversal run independently, then their scores are f
 
 ## Related Guides
 
-- [Semantic Extraction](semantic-extraction) — build the graph from raw unstructured text
-- [Agent Memory](agent-memory) — store, retrieve, and persist agent memories
-- [Context Graphs](context-graphs) — build and traverse the knowledge graph directly
+- [Semantic Extraction](/guides/semantic-extraction) — build the graph from raw unstructured text
+- [Agent Memory](/guides/agent-memory) — store, retrieve, and persist agent memories
+- [Context Graphs](/guides/context-graphs) — build and traverse the knowledge graph directly
 - [Reasoning](reasoning) — derive new facts and run inference rules over the graph
-- [Decision Intelligence](decision-intelligence) — causal chains, policy enforcement, decision tracking
-- [LLM Integrations](llm-integrations) — connect Groq, OpenAI, Anthropic, HuggingFace, and 100+ more
+- [Decision Intelligence](/guides/decision-intelligence) — causal chains, policy enforcement, decision tracking
+- [LLM Integrations](/guides/llm-integrations) — connect Groq, OpenAI, Anthropic, HuggingFace, and 100+ more

--- a/docs/guides/ingest.md
+++ b/docs/guides/ingest.md
@@ -951,8 +951,8 @@ print(f"Compliance graph: {graph.stats()['node_count']} nodes, "
 ## Related Guides
 
 - [Pipeline](pipeline) — chain ingest steps with `PipelineBuilder` for automated, retryable, parallelised workflows
-- [Context Graphs](context-graphs) — storing and querying the entities you ingest as a typed property graph
-- [Semantic Extraction](semantic-extraction) — NER, relation extraction, and triplet extraction from ingested text
+- [Context Graphs](/guides/context-graphs) — storing and querying the entities you ingest as a typed property graph
+- [Semantic Extraction](/guides/semantic-extraction) — NER, relation extraction, and triplet extraction from ingested text
 - [Provenance](provenance) — tracking the origin document, confidence score, and ingestion timestamp for every extracted entity
 - [Databricks Integration](../integrations/databricks) — Unity Catalog setup, PAT/OAuth M2M authentication, and lineage introspection
 - [Snowflake Integration](../integrations/snowflake) — warehouse setup and password/key-pair/OAuth authentication

--- a/docs/guides/llm-integrations.md
+++ b/docs/guides/llm-integrations.md
@@ -719,7 +719,7 @@ for src in best["sources"]:
 
 ## Related Guides
 
-- [Agent Memory](agent-memory) — using `query_with_reasoning()` with any LLM provider for graph-grounded retrieval
-- [Multi-Agent Systems](multi-agent) — wiring different LLM providers to different agent tiers in a shared-graph pipeline
-- [Semantic Extraction](semantic-extraction) — LLM-powered NER, relation extraction, event detection, and triplet extraction
-- [GraphRAG](graphrag) — multi-hop graph reasoning with `query_with_reasoning()`
+- [Agent Memory](/guides/agent-memory) — using `query_with_reasoning()` with any LLM provider for graph-grounded retrieval
+- [Multi-Agent Systems](/guides/multi-agent) — wiring different LLM providers to different agent tiers in a shared-graph pipeline
+- [Semantic Extraction](/guides/semantic-extraction) — LLM-powered NER, relation extraction, event detection, and triplet extraction
+- [GraphRAG](/guides/graphrag) — multi-hop graph reasoning with `query_with_reasoning()`

--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -343,7 +343,7 @@ The result is a fully auditable credit decision trail with precedent links, read
 ## Related Guides
 
 - [Reasoning & Rules](reasoning) — the engine behind the `run_reasoning` tool
-- [Decision Intelligence](decision-intelligence) — how decisions are stored as causal graph nodes
-- [Context Graphs](context-graphs) — the graph that `add_entity` and `add_relationship` write to
+- [Decision Intelligence](/guides/decision-intelligence) — how decisions are stored as causal graph nodes
+- [Context Graphs](/guides/context-graphs) — the graph that `add_entity` and `add_relationship` write to
 - [Export & Serialization](export) — all export formats available via `export_graph`
 - [Ontology Management](ontology) — generate OWL ontologies from the graph built via MCP

--- a/docs/guides/multi-agent.md
+++ b/docs/guides/multi-agent.md
@@ -55,7 +55,7 @@ Semantica coordinates agents through shared context (memory and knowledge graphs
 Semantica coordinates multiple agents through a shared `ContextGraph` — agents read and write to the same graph, or hand off serialized state via `save()` and `load()`, with no message broker required. Use this pattern when splitting work across ingestion, enrichment, reasoning, and reporting roles that must share a single evidence base.
 
 <Info>
-  This guide covers multi-agent coordination. For the memory layer each agent uses internally, see [Agent Memory](agent-memory). For graph traversal and entity linking, see [Context Graphs](context-graphs). For decision recording and precedent matching, see [Decision Intelligence](decision-intelligence).
+  This guide covers multi-agent coordination. For the memory layer each agent uses internally, see [Agent Memory](/guides/agent-memory). For graph traversal and entity linking, see [Context Graphs](/guides/context-graphs). For decision recording and precedent matching, see [Decision Intelligence](/guides/decision-intelligence).
 </Info>
 
 ## The Three Coordination Patterns
@@ -679,7 +679,7 @@ context.retrieve("...", user_id="analyst-jsmith")
 
 ## Related Guides
 
-- [Agent Memory](agent-memory) — memory storage, retrieval, persistence, and the working memory window each agent uses internally
-- [Context Graphs](context-graphs) — build and traverse the shared `ContextGraph` directly; temporal interval reasoning; entity deduplication before node insertion
-- [Decision Intelligence](decision-intelligence) — record and trace decisions across agent handoffs with causal chain analysis
-- [LLM Integrations](llm-integrations) — configure the LLM provider passed to `query_with_reasoning()` in each agent
+- [Agent Memory](/guides/agent-memory) — memory storage, retrieval, persistence, and the working memory window each agent uses internally
+- [Context Graphs](/guides/context-graphs) — build and traverse the shared `ContextGraph` directly; temporal interval reasoning; entity deduplication before node insertion
+- [Decision Intelligence](/guides/decision-intelligence) — record and trace decisions across agent handoffs with causal chain analysis
+- [LLM Integrations](/guides/llm-integrations) — configure the LLM provider passed to `query_with_reasoning()` in each agent

--- a/docs/guides/ontology.md
+++ b/docs/guides/ontology.md
@@ -297,7 +297,7 @@ export_rdf(ontology, "cyber_threat.jsonld", format="jsonld")
 export_rdf(ontology, "cyber_threat.nt", format="ntriples")
 ```
 
-The exported Turtle file is the input to Semantica's SHACL validation pipeline. See the [SHACL Validation](shacl-validation) guide for how to generate constraint shapes from this ontology and run them against live graph data.
+The exported Turtle file is the input to Semantica's SHACL validation pipeline. See the [SHACL Validation](/guides/shacl-validation) guide for how to generate constraint shapes from this ontology and run them against live graph data.
 
 ---
 
@@ -503,8 +503,8 @@ else:
 
 ## Related Guides
 
-- [SHACL Validation](shacl-validation) — generate W3C SHACL constraint shapes from your ontology and validate live graph data against them
+- [SHACL Validation](/guides/shacl-validation) — generate W3C SHACL constraint shapes from your ontology and validate live graph data against them
 - [Reasoning & Rules](reasoning) — apply forward/backward-chaining rules over your ontology to derive new facts
 - [Export & Serialization](export) — export graphs to RDF, GraphML, CSV, and Neo4j Cypher
-- [Semantic Extraction](semantic-extraction) — extract entities and relationships that feed ontology generation
-- [Context Graphs](context-graphs) — the knowledge graph that ontology generation reads from
+- [Semantic Extraction](/guides/semantic-extraction) — extract entities and relationships that feed ontology generation
+- [Context Graphs](/guides/context-graphs) — the knowledge graph that ontology generation reads from

--- a/docs/guides/pipeline.md
+++ b/docs/guides/pipeline.md
@@ -717,6 +717,6 @@ print(f"Compliance delta update: {result.output}")
 ## Related Guides
 
 - [Ingest](ingest) — all source types for the ingest step: PDFs, APIs, databases, RSS feeds, STIX directories, and streams
-- [Semantic Extraction](semantic-extraction) — NER, relation extraction, triplet extraction, and event detection for the extract step
-- [Context Graphs](context-graphs) — building and querying the `ContextGraph` that the store step populates
+- [Semantic Extraction](/guides/semantic-extraction) — NER, relation extraction, triplet extraction, and event detection for the extract step
+- [Context Graphs](/guides/context-graphs) — building and querying the `ContextGraph` that the store step populates
 - [Provenance](provenance) — tracking the origin document, confidence score, and pipeline run ID for every extracted entity

--- a/docs/guides/policy-engine.md
+++ b/docs/guides/policy-engine.md
@@ -662,9 +662,9 @@ print("Policy updated to v2.4.0")
 
 ## Related Guides
 
-- [Decision Intelligence](decision-intelligence) — `record_decision()`, causal chains, and precedent search — the decisions that `check_compliance()` evaluates
+- [Decision Intelligence](/guides/decision-intelligence) — `record_decision()`, causal chains, and precedent search — the decisions that `check_compliance()` evaluates
 - [Reasoning & Rules](reasoning) — complement policy rules with formal inference for logical conflict detection
-- [SHACL Validation](shacl-validation) — enforce structural constraints on policy nodes themselves
-- [Change Management](change-management) — version-snapshot the policy graph alongside the knowledge graph
+- [SHACL Validation](/guides/shacl-validation) — enforce structural constraints on policy nodes themselves
+- [Change Management](/guides/change-management) — version-snapshot the policy graph alongside the knowledge graph
 - [Provenance](provenance) — W3C PROV-O lineage for every policy decision and exception
-- [MCP Server](mcp-server) — expose `record_decision` and `find_precedents` as MCP tools for AI agents
+- [MCP Server](/guides/mcp-server) — expose `record_decision` and `find_precedents` as MCP tools for AI agents

--- a/docs/guides/provenance.md
+++ b/docs/guides/provenance.md
@@ -659,7 +659,7 @@ Note: the banking example above passes `agent_id="credit_data_service_v2"` to `t
 
 ## Related Guides
 
-- [Semantic Extraction](semantic-extraction) — the NER and relation extraction pipeline that auto-generates provenance entries for every extracted entity
-- [Conflict Resolution](conflict-resolution) — provenance property sources feed directly into conflict detection; every resolved value is traceable to its source
+- [Semantic Extraction](/guides/semantic-extraction) — the NER and relation extraction pipeline that auto-generates provenance entries for every extracted entity
+- [Conflict Resolution](/guides/conflict-resolution) — provenance property sources feed directly into conflict detection; every resolved value is traceable to its source
 - [Deduplication](deduplication) — merge operations are recorded in merge history; pair with provenance for a complete lineage from source to canonical entity
 - [Provenance Reference](../reference/provenance) — full storage backend API, `InMemoryStorage`, `SQLiteStorage`, and `ProvenanceEntry` schema

--- a/docs/guides/reasoning.md
+++ b/docs/guides/reasoning.md
@@ -838,9 +838,9 @@ if proof:
 
 ## Related Guides
 
-- [Semantic Extraction](semantic-extraction) — extract the entities and relationships that populate the graph facts you reason over
-- [GraphRAG](graphrag) — retrieve graph-grounded context for LLM responses
+- [Semantic Extraction](/guides/semantic-extraction) — extract the entities and relationships that populate the graph facts you reason over
+- [GraphRAG](/guides/graphrag) — retrieve graph-grounded context for LLM responses
 - [Ontology Management](ontology) — generate OWL ontologies to give your rules formal semantics
-- [Decision Intelligence](decision-intelligence) — record and trace inferred decisions through the full causal chain
-- [Context Graphs](context-graphs) — the knowledge graph that reasoning operates over
-- [MCP Server](mcp-server) — expose `run_reasoning` as a tool for Claude and other agents
+- [Decision Intelligence](/guides/decision-intelligence) — record and trace inferred decisions through the full causal chain
+- [Context Graphs](/guides/context-graphs) — the knowledge graph that reasoning operates over
+- [MCP Server](/guides/mcp-server) — expose `run_reasoning` as a tool for Claude and other agents

--- a/docs/guides/semantic-extraction.md
+++ b/docs/guides/semantic-extraction.md
@@ -71,7 +71,7 @@ This pipeline transforms documents like "APT29 deployed HAMMERTOSS malware targe
 `semantica.semantic_extract` turns unstructured text into structured graph-ready output: it identifies named entities, extracts relationships between them, detects time-anchored events, resolves coreferences, and serialises everything as RDF triplets. Use it to populate a `ContextGraph` from raw documents — intelligence reports, clinical notes, regulatory filings, or any free-text corpus.
 
 <Info>
-  Extracted entities and relationships feed into `ContextGraph` via `AgentContext.store()`. For how they are attributed back to source documents, see the [Provenance Guide](provenance). For how the populated graph is queried and traversed, see [Context Graphs](context-graphs).
+  Extracted entities and relationships feed into `ContextGraph` via `AgentContext.store()`. For how they are attributed back to source documents, see the [Provenance Guide](provenance). For how the populated graph is queried and traversed, see [Context Graphs](/guides/context-graphs).
 </Info>
 
 ## Step 1 — Named Entity Recognition: who and what is in the text
@@ -664,8 +664,8 @@ The fallback behaviour is automatic: if the primary method returns an empty list
 ## Related Guides
 
 - [Provenance Guide](provenance) — track every extracted entity and chunk back to its source document
-- [Agent Memory Guide](agent-memory) — store extracted knowledge as searchable agent memories with graph enrichment
-- [Context Graphs Guide](context-graphs) — how extracted entities populate `ContextGraph` nodes and edges
-- [GraphRAG Guide](graphrag) — retrieve facts from the populated graph to ground LLM responses
+- [Agent Memory Guide](/guides/agent-memory) — store extracted knowledge as searchable agent memories with graph enrichment
+- [Context Graphs Guide](/guides/context-graphs) — how extracted entities populate `ContextGraph` nodes and edges
+- [GraphRAG Guide](/guides/graphrag) — retrieve facts from the populated graph to ground LLM responses
 - [Reasoning Guide](reasoning) — derive new facts, run SPARQL queries, and apply inference rules over the extracted graph
 - [Semantic Extract Reference](../reference/semantic_extract) — full API for all extractor classes, providers, and validators

--- a/docs/guides/shacl-validation.md
+++ b/docs/guides/shacl-validation.md
@@ -740,5 +740,5 @@ def validate_before_publish(data_graph_str: str, ontology: dict) -> None:
 - [Ontology Management](ontology) — generate the OWL ontology that SHACL shapes are derived from
 - [Reasoning & Rules](reasoning) — complement SHACL structural constraints with logical inference rules
 - [Export & Serialization](export) — serialize graph data to Turtle/RDF/XML for `run_shacl_validation` input
-- [Conflict Resolution](conflict-resolution) — detect and resolve data conflicts before SHACL validation
-- [Change Management](change-management) — version-gate SHACL shapes alongside ontology versions
+- [Conflict Resolution](/guides/conflict-resolution) — detect and resolve data conflicts before SHACL validation
+- [Change Management](/guides/change-management) — version-gate SHACL shapes alongside ontology versions

--- a/docs/guides/visualization.md
+++ b/docs/guides/visualization.md
@@ -614,8 +614,8 @@ fig.write_html("out.html")   # manual export
 
 ## Related Guides
 
-- [Context Graphs](context-graphs) — `graph.to_dict()` is the primary input for `KGVisualizer`
+- [Context Graphs](/guides/context-graphs) — `graph.to_dict()` is the primary input for `KGVisualizer`
 - [Ontology Management](ontology) — `OntologyVisualizer` renders ontologies produced by `OntologyGenerator`
-- [Change Management](change-management) — `TemporalVersionManager` snapshots feed `visualize_metrics_evolution()` and `visualize_snapshot_comparison()`
-- [Graph Analytics](graph-analytics) — centrality scores, community dicts, and connectivity results that feed the `AnalyticsVisualizer`
+- [Change Management](/guides/change-management) — `TemporalVersionManager` snapshots feed `visualize_metrics_evolution()` and `visualize_snapshot_comparison()`
+- [Graph Analytics](/guides/graph-analytics) — centrality scores, community dicts, and connectivity results that feed the `AnalyticsVisualizer`
 - [Export & Serialization](export) — export the same graph to GraphML, GEXF, or DOT for Gephi and Graphviz

--- a/docs/index.md
+++ b/docs/index.md
@@ -185,8 +185,8 @@ decision_id = context.record_decision(
 
 </CodeGroup>
 
-- [Full Quickstart](quickstart) — Step-by-step pipeline walkthrough
-- [Cookbook](cookbook) — 40+ real-world Jupyter notebooks
+- [Full Quickstart](/quickstart) — Step-by-step pipeline walkthrough
+- [Cookbook](/cookbook) — 40+ real-world Jupyter notebooks
 - [Join Discord](https://discord.gg/sV34vps5hH) — Community chat and support
 
 
@@ -195,7 +195,7 @@ decision_id = context.record_decision(
 Semantica was designed for domains where every decision must be explainable and every fact must be traceable.
 
 <Warning>
-  **This is system-level explainability, not foundation-model explainability.** Semantica does not expose, reconstruct, or explain what happens *inside* the LLM/foundation model — its internal reasoning or chain-of-thought stays opaque, as it does for any external system. What Semantica explains is *outside* the model: the context and data fed in, the decision produced, its provenance, the relevant relationships, the policies applied, and the full execution trail. See [Core Concepts](concepts) for the full scope note.
+  **This is system-level explainability, not foundation-model explainability.** Semantica does not expose, reconstruct, or explain what happens *inside* the LLM/foundation model — its internal reasoning or chain-of-thought stays opaque, as it does for any external system. What Semantica explains is *outside* the model: the context and data fed in, the decision produced, its provenance, the relevant relationships, the policies applied, and the full execution trail. See [Core Concepts](/concepts) for the full scope note.
 </Warning>
 
 **Healthcare & Life Sciences**
@@ -242,35 +242,35 @@ Semantica was designed for domains where every decision must be explainable and 
     ```bash
     pip install semantica
     ```
-    See [Installation](installation) for optional extras (`[all]`, `[neo4j]`, `[pinecone]`) and environment setup.
+    See [Installation](/installation) for optional extras (`[all]`, `[neo4j]`, `[pinecone]`) and environment setup.
   </Step>
   <Step title="Run the Quickstart">
-    Build a complete knowledge graph pipeline in [5 minutes](quickstart):
+    Build a complete knowledge graph pipeline in [5 minutes](/quickstart):
     - Ingest documents from any source
     - Extract entities and relationships
     - Build and query the graph
     - Record and trace a decision
   </Step>
   <Step title="Learn the mental model">
-    [Core Concepts](concepts) covers:
+    [Core Concepts](/concepts) covers:
     - Knowledge graphs vs. vector stores: when to use each
     - What GraphRAG is and how Semantica implements it
     - How provenance and decision tracking work together
     - The accountability layer architecture
   </Step>
   <Step title="Go deep on any module">
-    Every module has a dedicated [reference page](reference/context) with:
+    Every module has a dedicated [reference page](/reference/context) with:
     - Full class and method documentation
     - Parameter tables with types and defaults
     - Runnable code examples for each feature
   </Step>
 </Steps>
 
-- [Installation](installation) — Get Semantica installed in under a minute
-- [Quickstart](quickstart) — Build a complete knowledge graph pipeline in 5 minutes
-- [Core Concepts](concepts) — The mental model behind the API
-- [API Reference](reference/context) — Exact module, class, and method details
-- [Cookbook](cookbook) — Domain notebooks for real-world use cases
+- [Installation](/installation) — Get Semantica installed in under a minute
+- [Quickstart](/quickstart) — Build a complete knowledge graph pipeline in 5 minutes
+- [Core Concepts](/concepts) — The mental model behind the API
+- [API Reference](/reference/context) — Exact module, class, and method details
+- [Cookbook](/cookbook) — Domain notebooks for real-world use cases
 - [Changelog](https://github.com/semantica-agi/semantica/releases) — Release history
 
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -183,6 +183,6 @@ Install the [Microsoft Visual C++ Redistributable](https://aka.ms/vs/17/release/
 
 ## Next Steps
 
-- [Getting Started](getting-started) — Understand what Semantica does before you build.
-- [Build the Pipeline](quickstart) — Follow the end-to-end workflow with code.
-- [Browse Examples](cookbook) — See notebook examples organized by use case.
+- [Getting Started](/getting-started) — Understand what Semantica does before you build.
+- [Build the Pipeline](/quickstart) — Follow the end-to-end workflow with code.
+- [Browse Examples](/cookbook) — See notebook examples organized by use case.

--- a/docs/integrations/databricks.md
+++ b/docs/integrations/databricks.md
@@ -193,7 +193,7 @@ if not connector.test_connection():
 ## See Also
 
 - [Ingest Module](../reference/ingest) — Full DatabricksIngestor and all other ingestors.
-- [Snowflake Integration](snowflake) — Companion connector for a Snowflake + Databricks hybrid estate.
+- [Snowflake Integration](/integrations/snowflake) — Companion connector for a Snowflake + Databricks hybrid estate.
 - [Pipeline](../reference/pipeline) — Use Databricks ingestion as a pipeline step.
 - [Installation](../installation) — All optional dependency extras.
 - [Knowledge Graph](../reference/kg) — Build a KG from ingested Databricks data.

--- a/docs/integrations/salesforce.md
+++ b/docs/integrations/salesforce.md
@@ -370,7 +370,7 @@ Common causes of authentication failures:
 ## See Also
 
 - [Ingest Module](../reference/ingest) — Full `SalesforceIngestor` API and all other ingestors.
-- [Snowflake Integration](snowflake) — Relational warehouse connector with a similar design.
-- [Databricks Integration](databricks) — Lakehouse connector.
+- [Snowflake Integration](/integrations/snowflake) — Relational warehouse connector with a similar design.
+- [Databricks Integration](/integrations/databricks) — Lakehouse connector.
 - [Installation](../installation) — All optional dependency extras.
 - [Knowledge Graph](../reference/kg) — Build a KG from ingested Salesforce data.

--- a/docs/integrations/snowflake.md
+++ b/docs/integrations/snowflake.md
@@ -172,7 +172,7 @@ if not connector.test_connection():
 ## See Also
 
 - [Ingest Module](../reference/ingest) — Full SnowflakeIngestor and all other ingestors.
-- [Databricks Integration](databricks) — Companion connector for a Snowflake + Databricks hybrid estate.
+- [Databricks Integration](/integrations/databricks) — Companion connector for a Snowflake + Databricks hybrid estate.
 - [Pipeline](../reference/pipeline) — Use Snowflake ingestion as a pipeline step.
 - [Installation](../installation) — All optional dependency extras.
 - [Knowledge Graph](../reference/kg) — Build a KG from ingested Snowflake data.

--- a/docs/learning-more.md
+++ b/docs/learning-more.md
@@ -9,9 +9,9 @@ Whether you're running your first pipeline or deploying Semantica in production,
 
 ## Learning Paths
 
-- **Beginner (1–2 hrs)** — New to Semantica and knowledge graphs. [Start with Installation →](installation)
-- **Intermediate (4–6 hrs)** — Comfortable with basics, building real applications. [Start with Modules →](modules)
-- **Advanced (8+ hrs)** — Enterprise deployments, customization, and extension. [Start with Architecture →](architecture)
+- **Beginner (1–2 hrs)** — New to Semantica and knowledge graphs. [Start with Installation →](/installation)
+- **Intermediate (4–6 hrs)** — Comfortable with basics, building real applications. [Start with Modules →](/modules)
+- **Advanced (8+ hrs)** — Enterprise deployments, customization, and extension. [Start with Architecture →](/architecture)
 
 <Tabs>
   <Tab title="Beginner (1–2 hrs)">
@@ -19,16 +19,16 @@ Whether you're running your first pipeline or deploying Semantica in production,
 
     <Steps>
       <Step title="Set up your environment">
-        [Installation Guide](installation): virtual environments, optional extras, platform-specific fixes.
+        [Installation Guide](/installation): virtual environments, optional extras, platform-specific fixes.
       </Step>
       <Step title="Understand the core ideas">
-        [Core Concepts](concepts): what knowledge graphs are, how embeddings work, what extraction does.
+        [Core Concepts](/concepts): what knowledge graphs are, how embeddings work, what extraction does.
       </Step>
       <Step title="Run your first example">
-        [Getting Started](getting-started): 5-minute code walkthrough with pattern-based extraction (no API key needed).
+        [Getting Started](/getting-started): 5-minute code walkthrough with pattern-based extraction (no API key needed).
       </Step>
       <Step title="Build your first knowledge graph">
-        [Quickstart Tutorial](quickstart): full 6-step pipeline from ingestion to visualization.
+        [Quickstart Tutorial](/quickstart): full 6-step pipeline from ingestion to visualization.
       </Step>
       <Step title="Explore interactively">
         [Welcome to Semantica notebook](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/01_Welcome_to_Semantica.ipynb): Jupyter walkthrough of every module.
@@ -40,7 +40,7 @@ Whether you're running your first pipeline or deploying Semantica in production,
 
     <Steps>
       <Step title="Learn every module">
-        [Modules Guide](modules): all 27 modules with code examples and common pipeline chains.
+        [Modules Guide](/modules): all 27 modules with code examples and common pipeline chains.
       </Step>
       <Step title="Build production knowledge graphs">
         [Building Knowledge Graphs notebook](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/07_Building_Knowledge_Graphs.ipynb): multi-source, deduplication, conflict resolution.
@@ -58,7 +58,7 @@ Whether you're running your first pipeline or deploying Semantica in production,
 
     <Steps>
       <Step title="Understand the architecture">
-        [Architecture Guide](architecture): four-layer design, extension points, and design decisions.
+        [Architecture Guide](/architecture): four-layer design, extension points, and design decisions.
       </Step>
       <Step title="Temporal intelligence">
         [Temporal Graphs notebook](https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/10_Temporal_Knowledge_Graphs.ipynb): `valid_from`/`valid_until`, Allen interval algebra, point-in-time queries.
@@ -236,6 +236,6 @@ The `blocking_v2`, `hybrid_v2`, and `semantic_v2` strategies reduce O(n²) compa
 - **Graph exports**: encrypt sensitive exports at rest; use the v0.5.0 SSRF-safe `base_url` validation when configuring custom LLM gateways
 - **XML ingestion**: always use `XMLIngestor` (v0.5.0), which uses the XXE-safe lxml backend; never parse untrusted XML with the standard library parser
 
-- [Cookbook](cookbook) — Interactive Jupyter notebooks from beginner to advanced.
-- [FAQ](faq) — Common questions answered.
-- [API Reference](reference/core) — Complete technical documentation.
+- [Cookbook](/cookbook) — Interactive Jupyter notebooks from beginner to advanced.
+- [FAQ](/faq) — Common questions answered.
+- [API Reference](/reference/core) — Complete technical documentation.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -9,7 +9,7 @@ icon: "puzzle-piece"
 </Info>
 
 <Tip>
-  Not sure which module to use? The [Choose the Right Module](choose-your-module) guide maps 35+ developer goals to modules with code examples — start there if you're orienting for the first time.
+  Not sure which module to use? The [Choose the Right Module](/choose-your-module) guide maps 35+ developer goals to modules with code examples — start there if you're orienting for the first time.
 </Tip>
 
 Semantica is organized into **27 modules** across six logical layers. Each module is independently importable: you never pay for what you don't use.
@@ -680,34 +680,34 @@ versioner.create_snapshot(kg, "2024-Q1", author="user@example.com", description=
 
 | Module | Purpose | Key Classes |
 | :------ | :------- | :----------- |
-| [ingest](reference/ingest) | Data ingestion | `FileIngestor`, `WebIngestor`, `ParquetIngestor`, `XMLIngestor` |
-| [parse](reference/parse) | Document parsing | `DocumentParser`, `DoclingParser` |
-| [split](reference/split) | Text chunking | `TextSplitter` |
-| [normalize](reference/normalize) | Data cleaning | `TextNormalizer`, `EntityNormalizer`, `LanguageDetector` |
-| [semantic_extract](reference/semantic_extract) | NER & relation extraction | `NERExtractor`, `RelationExtractor`, `TripletExtractor`, `SemanticAnalyzer`, `SemanticNetworkExtractor`, `ExtractionValidator` |
-| [kg](reference/kg) | Graph construction | `GraphBuilder`, `TemporalGraphQuery`, `SimilarityCalculator` |
-| [ontology](reference/ontology) | Schema management | `OntologyGenerator`, `SHACLGenerator` |
-| [reasoning](reference/reasoning) | Logical inference | `Reasoner`, `DatalogReasoner` |
-| [embeddings](reference/embeddings) | Vector embeddings | `EmbeddingGenerator` |
-| [vector_store](reference/vector_store) | Vector database | `VectorStore` |
-| [graph_store](reference/graph_store) | Graph database | `GraphStore` |
-| [triplet_store](reference/triplet_store) | RDF triple store | `TripletStore` |
-| [deduplication](reference/deduplication) | Entity resolution | `EntityResolver`, `DuplicateDetector`, `ClusterBuilder`, `MergeStrategyManager` |
-| [conflicts](reference/conflicts) | Conflict resolution | `ConflictDetector` |
-| [context](reference/context) | Agent context & decisions | `AgentContext`, `ContextGraph` |
-| [provenance](reference/provenance) | W3C PROV-O lineage | `ProvenanceManager` |
-| [change_management](reference/change_management) | Version control | `TemporalVersionManager` |
-| [export](reference/export) | Data export | `RDFExporter`, `ParquetExporter` |
-| [visualization](reference/visualization) | Graph visualization | `KGVisualizer` |
-| [pipeline](reference/pipeline) | Workflow orchestration | `Pipeline`, `PipelineBuilder` |
-| [explorer](reference/explorer) | Knowledge Explorer UI | `semantica-explorer --graph <file>` |
-| [llms](reference/llms) | LLM providers | `Groq`, `OpenAI`, `create_provider` |
-| [mcp_server](reference/mcp_server) | MCP stdio server | `python -m semantica.mcp_server` |
-| [seed](reference/seed) | KG bootstrapping from structured sources | `SeedManager` |
-| [evals](reference/evals) | Quality evaluation | `KGEvaluator`, `ExtractionEvaluator`, `PipelineEvaluator`, `RegressionTracker` |
-| [core](reference/core) | Base classes & registry | `Semantica`, `ConfigManager`, `PluginRegistry`, `LifecycleManager` |
-| [utils](reference/utils) | Shared utilities | `helpers`, `validators` |
+| [ingest](/reference/ingest) | Data ingestion | `FileIngestor`, `WebIngestor`, `ParquetIngestor`, `XMLIngestor` |
+| [parse](/reference/parse) | Document parsing | `DocumentParser`, `DoclingParser` |
+| [split](/reference/split) | Text chunking | `TextSplitter` |
+| [normalize](/reference/normalize) | Data cleaning | `TextNormalizer`, `EntityNormalizer`, `LanguageDetector` |
+| [semantic_extract](/reference/semantic_extract) | NER & relation extraction | `NERExtractor`, `RelationExtractor`, `TripletExtractor`, `SemanticAnalyzer`, `SemanticNetworkExtractor`, `ExtractionValidator` |
+| [kg](/reference/kg) | Graph construction | `GraphBuilder`, `TemporalGraphQuery`, `SimilarityCalculator` |
+| [ontology](/reference/ontology) | Schema management | `OntologyGenerator`, `SHACLGenerator` |
+| [reasoning](/reference/reasoning) | Logical inference | `Reasoner`, `DatalogReasoner` |
+| [embeddings](/reference/embeddings) | Vector embeddings | `EmbeddingGenerator` |
+| [vector_store](/reference/vector_store) | Vector database | `VectorStore` |
+| [graph_store](/reference/graph_store) | Graph database | `GraphStore` |
+| [triplet_store](/reference/triplet_store) | RDF triple store | `TripletStore` |
+| [deduplication](/reference/deduplication) | Entity resolution | `EntityResolver`, `DuplicateDetector`, `ClusterBuilder`, `MergeStrategyManager` |
+| [conflicts](/reference/conflicts) | Conflict resolution | `ConflictDetector` |
+| [context](/reference/context) | Agent context & decisions | `AgentContext`, `ContextGraph` |
+| [provenance](/reference/provenance) | W3C PROV-O lineage | `ProvenanceManager` |
+| [change_management](/reference/change_management) | Version control | `TemporalVersionManager` |
+| [export](/reference/export) | Data export | `RDFExporter`, `ParquetExporter` |
+| [visualization](/reference/visualization) | Graph visualization | `KGVisualizer` |
+| [pipeline](/reference/pipeline) | Workflow orchestration | `Pipeline`, `PipelineBuilder` |
+| [explorer](/reference/explorer) | Knowledge Explorer UI | `semantica-explorer --graph <file>` |
+| [llms](/reference/llms) | LLM providers | `Groq`, `OpenAI`, `create_provider` |
+| [mcp_server](/reference/mcp_server) | MCP stdio server | `python -m semantica.mcp_server` |
+| [seed](/reference/seed) | KG bootstrapping from structured sources | `SeedManager` |
+| [evals](/reference/evals) | Quality evaluation | `KGEvaluator`, `ExtractionEvaluator`, `PipelineEvaluator`, `RegressionTracker` |
+| [core](/reference/core) | Base classes & registry | `Semantica`, `ConfigManager`, `PluginRegistry`, `LifecycleManager` |
+| [utils](/reference/utils) | Shared utilities | `helpers`, `validators` |
 
-- [Getting Started](getting-started) — Your first knowledge graph in 5 minutes.
-- [Cookbook](cookbook) — 40+ domain notebooks with real-world examples.
-- [API Reference](reference/context) — Full technical documentation.
+- [Getting Started](/getting-started) — Your first knowledge graph in 5 minutes.
+- [Cookbook](/cookbook) — 40+ domain notebooks with real-world examples.
+- [API Reference](/reference/context) — Full technical documentation.

--- a/docs/project-license.md
+++ b/docs/project-license.md
@@ -76,5 +76,5 @@ By contributing to Semantica, you agree that your contributions will be licensed
 
 ## See Also
 
-- [Contributing](contributing-guide) — How to contribute to the project.
-- [Citation](citation) — How to cite Semantica in research.
+- [Contributing](/contributing-guide) — How to contribute to the project.
+- [Citation](/citation) — How to cite Semantica in research.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -420,7 +420,7 @@ for info in ingestor.scan_directory("data/reports/", recursive=True):
 ```
 
 For multi-step orchestration with configurable parallelism, see the
-[Pipeline guide](guides/pipeline).
+[Pipeline guide](/guides/pipeline).
 
 </Accordion>
 
@@ -452,7 +452,7 @@ pip install --upgrade semantica
 
 ## Next Steps
 
-- [Core Concepts](concepts) — Knowledge graphs, ontologies, reasoning engines: the mental model behind Semantica.
-- [Module Reference](modules) — Every module explained with key classes and common chains.
-- [API Reference](reference/context) — Complete documentation for every module, class, and parameter.
-- [Cookbook](cookbook) — 40+ interactive Jupyter notebooks with real-world datasets.
+- [Core Concepts](/concepts) — Knowledge graphs, ontologies, reasoning engines: the mental model behind Semantica.
+- [Module Reference](/modules) — Every module explained with key classes and common chains.
+- [API Reference](/reference/context) — Complete documentation for every module, class, and parameter.
+- [Cookbook](/cookbook) — 40+ interactive Jupyter notebooks with real-world datasets.

--- a/docs/reference/change_management.md
+++ b/docs/reference/change_management.md
@@ -351,6 +351,6 @@ for record in history:
 </AccordionGroup>
 
 - [Provenance](provenance) — W3C PROV-O lineage tracking.
-- [Knowledge Graph](kg) — The graph being versioned.
+- [Knowledge Graph](/reference/kg) — The graph being versioned.
 - [Export](export) — Export versioned snapshots.
-- [Conflicts](conflicts) — Detect conflicts introduced between versions.
+- [Conflicts](/reference/conflicts) — Detect conflicts introduced between versions.

--- a/docs/reference/conflicts.md
+++ b/docs/reference/conflicts.md
@@ -453,4 +453,4 @@ class InvestigationStep:
 - [Deduplication](deduplication) — Resolve duplicate entities before conflict detection.
 - [Ontology](ontology) — Logical conflicts use SHACL shapes and ontology axioms.
 - [Provenance](provenance) — Track which source each conflicting fact came from.
-- [Knowledge Graph](kg) — The graph being checked for conflicts.
+- [Knowledge Graph](/reference/kg) — The graph being checked for conflicts.

--- a/docs/reference/context.md
+++ b/docs/reference/context.md
@@ -449,7 +449,7 @@ print("Nodes: {}, Edges: {}".format(stats["node_count"], stats["edge_count"]))
 `ContextGraph` exposes a full Distance Intelligence API for exploring semantic neighborhoods and blending proximity into retrieval.
 
 <Info>
-  Full Distance Intelligence reference — distance matrices, API endpoints, embedding cache, Explorer UI — is covered in the dedicated [Distance Intelligence](distance) page. This section documents the context-layer API.
+  Full Distance Intelligence reference — distance matrices, API endpoints, embedding cache, Explorer UI — is covered in the dedicated [Distance Intelligence](/reference/distance) page. This section documents the context-layer API.
 </Info>
 
 ### Neighbors with Distance Metadata
@@ -1087,8 +1087,8 @@ class EntityLink:
   </Tab>
 </Tabs>
 
-- [Vector Store](vector_store) — Embedding storage backend for memory retrieval.
-- [Knowledge Graph](kg) — Graph algorithms and analytics used inside ContextGraph.
+- [Vector Store](/reference/vector_store) — Embedding storage backend for memory retrieval.
+- [Knowledge Graph](/reference/kg) — Graph algorithms and analytics used inside ContextGraph.
 - [Reasoning](reasoning) — Logical inference layered on top of context.
 - [Provenance](provenance) — W3C PROV-O lineage for every stored fact.
 

--- a/docs/reference/core.md
+++ b/docs/reference/core.md
@@ -227,6 +227,6 @@ result = build_knowledge_base(sources=["doc.pdf"], method="fast")
 </Tip>
 
 - [Pipeline](pipeline) — Pipeline execution and step orchestration.
-- [Utils](utils) — Shared utilities used by Core internally.
+- [Utils](/reference/utils) — Shared utilities used by Core internally.
 - [Getting Started](../getting-started) — Learn the basics before using Core.
-- [LLMs](llms) — Configure LLM providers via ConfigManager.
+- [LLMs](/reference/llms) — Configure LLM providers via ConfigManager.

--- a/docs/reference/deduplication.md
+++ b/docs/reference/deduplication.md
@@ -437,7 +437,7 @@ result = calculate_similarity(entity_a, entity_b, method="drug_name")
   </Tab>
 </Tabs>
 
-- [Conflicts](conflicts) — Detect value conflicts between non-duplicate entities.
-- [Knowledge Graph](kg) — GraphBuilder uses deduplication during construction.
-- [Normalize](normalize) — Normalize entity names before deduplication.
+- [Conflicts](/reference/conflicts) — Detect value conflicts between non-duplicate entities.
+- [Knowledge Graph](/reference/kg) — GraphBuilder uses deduplication during construction.
+- [Normalize](/reference/normalize) — Normalize entity names before deduplication.
 - [Provenance](provenance) — Track merged entity lineage.

--- a/docs/reference/distance.md
+++ b/docs/reference/distance.md
@@ -607,7 +607,7 @@ The Knowledge Explorer embeds Distance Intelligence directly in the browser dash
   The 10× cache improvement applies when the graph is unchanged between requests. In write-heavy pipelines where nodes are added continuously, cache hit rates will be lower. Use `force_refresh=False` (default) for read-heavy Explorer usage and `force_refresh=True` for batch pipeline contexts.
 </Note>
 
-- [Context Module](context) — `ContextGraph.get_neighbors()` and proximity-blended retrieval.
-- [Knowledge Graph Module](kg) — `NodeEmbedder`, `SimilarityCalculator`, and graph analytics.
+- [Context Module](/reference/context) — `ContextGraph.get_neighbors()` and proximity-blended retrieval.
+- [Knowledge Graph Module](/reference/kg) — `NodeEmbedder`, `SimilarityCalculator`, and graph analytics.
 - [Visualization](visualization) — Programmatic distance heatmaps and ego-mode graph renders.
-- [Explorer](explorer) — Knowledge Explorer with built-in Distance Intelligence dashboard.
+- [Explorer](/reference/explorer) — Knowledge Explorer with built-in Distance Intelligence dashboard.

--- a/docs/reference/embeddings.md
+++ b/docs/reference/embeddings.md
@@ -619,7 +619,7 @@ providers = check_available_providers()
 # → {"sentence_transformers": True, "fastembed": True, "openai": False}
 ```
 
-- [Vector Store](vector_store) — Store and search the generated embeddings.
-- [Split](split) — Chunk text before embedding for better retrieval quality.
-- [KG Module](kg) — Distance Intelligence uses graph embeddings for semantic neighbourhoods.
+- [Vector Store](/reference/vector_store) — Store and search the generated embeddings.
+- [Split](/reference/split) — Chunk text before embedding for better retrieval quality.
+- [KG Module](/reference/kg) — Distance Intelligence uses graph embeddings for semantic neighbourhoods.
 - [Deduplication](deduplication) — Semantic deduplication uses embedding distance for entity resolution.

--- a/docs/reference/evals.md
+++ b/docs/reference/evals.md
@@ -58,7 +58,7 @@ print("Relation coverage: ", report["relation_completeness"]["relation_coverage"
 | `suggestions` | `List[str]` | Improvement suggestions |
 | `metrics` | `dict` | Detailed sub-metrics |
 
-- [Semantic Extract](semantic_extract) — Extraction module.
-- [Knowledge Graph](kg) — Graph quality assessment.
+- [Semantic Extract](/reference/semantic_extract) — Extraction module.
+- [Knowledge Graph](/reference/kg) — Graph quality assessment.
 - [Pipeline](pipeline) — Pipeline performance metrics.
 - [Ontology Evaluator](ontology) — Available now for ontology quality metrics.

--- a/docs/reference/explorer.md
+++ b/docs/reference/explorer.md
@@ -403,7 +403,7 @@ Semantic neighborhood requires node embeddings stored in node properties (keys `
 **Session state lost after restart**
 Session state is in-memory only. Use `POST /api/export` to save a JSON snapshot before shutting down.
 
-- [Context](context) — Build and save the ContextGraph that Explorer loads.
+- [Context](/reference/context) — Build and save the ContextGraph that Explorer loads.
 - [Ontology](ontology) — Programmatic ontology management and SHACL generation.
 - [Visualization](visualization) — Programmatic graph rendering without the Explorer server.
 - [Export](export) — Export to RDF, Parquet, and other formats without launching a server.

--- a/docs/reference/export.md
+++ b/docs/reference/export.md
@@ -394,7 +394,7 @@ The `export_csv` convenience function delegates to `CSVExporter.export()`. For p
   **Match your export format to your consumer.** Neo4j → `cypher`; ArangoDB → `aql`; Gephi/yEd → `graphml` or `gexf`; semantic web tools → `turtle` or `json-ld`; analytics pipelines → `parquet`; zero-copy IPC → `arrow`.
 </Tip>
 
-- [Triplet Store](triplet_store) — Store RDF exports in a SPARQL-queryable backend.
+- [Triplet Store](/reference/triplet_store) — Store RDF exports in a SPARQL-queryable backend.
 - [Ontology](ontology) — Export OWL ontologies.
 - [Provenance](provenance) — Include provenance metadata in RDF exports.
 - [Pipeline](pipeline) — Add export as a final pipeline step.

--- a/docs/reference/graph_store.md
+++ b/docs/reference/graph_store.md
@@ -503,7 +503,7 @@ stats = store.get_stats()
   </Tab>
 </Tabs>
 
-- [KG Module](kg) — Build the graph before persisting it.
-- [Triplet Store](triplet_store) — RDF triple store for semantic web and SPARQL queries.
+- [KG Module](/reference/kg) — Build the graph before persisting it.
+- [Triplet Store](/reference/triplet_store) — RDF triple store for semantic web and SPARQL queries.
 - [Visualization](visualization) — Visualize graphs stored in any backend.
-- [Context](context) — AgentContext uses GraphStore for memory retrieval.
+- [Context](/reference/context) — AgentContext uses GraphStore for memory retrieval.

--- a/docs/reference/ingest.md
+++ b/docs/reference/ingest.md
@@ -646,7 +646,7 @@ from semantica.ingest import ingest_file
 result = ingest_file("source_path", method="my_format")
 ```
 
-- [Parse](parse) — Parse raw sources into structured text and tables.
+- [Parse](/reference/parse) — Parse raw sources into structured text and tables.
 - [Pipeline](pipeline) — Orchestrate ingest as the first pipeline step.
 - [Snowflake Integration](../integrations/snowflake) — Snowflake-specific setup and authentication guide.
 - [Databricks Integration](../integrations/databricks) — Databricks Unity Catalog setup, authentication, and lineage guide.

--- a/docs/reference/kg.md
+++ b/docs/reference/kg.md
@@ -75,10 +75,10 @@ kg = builder.build({"entities": entities, "relationships": relationships})
 ## Temporal Knowledge Graphs (v0.4.0+)
 
 <Info>
-  Full temporal reference including `BiTemporalFact`, `TemporalReasoningEngine`, Allen interval algebra, and `TemporalNormalizer` is covered in the dedicated [Temporal Intelligence](temporal) page. This section documents the KG-layer temporal API.
+  Full temporal reference including `BiTemporalFact`, `TemporalReasoningEngine`, Allen interval algebra, and `TemporalNormalizer` is covered in the dedicated [Temporal Intelligence](/reference/temporal) page. This section documents the KG-layer temporal API.
 </Info>
 
-The temporal stack — see the [Temporal Intelligence](temporal) page for the full reference.
+The temporal stack — see the [Temporal Intelligence](/reference/temporal) page for the full reference.
 
 ### Building a Temporal Graph
 
@@ -264,7 +264,7 @@ versioner.verify_checksum(past_kg)
 ```
 
 <Tip>
-  See the [Temporal Intelligence](temporal) reference for the full class API, domain examples (personnel changes, policy evolution, financial timelines), and configuration options.
+  See the [Temporal Intelligence](/reference/temporal) reference for the full class API, domain examples (personnel changes, policy evolution, financial timelines), and configuration options.
 </Tip>
 
 
@@ -475,10 +475,10 @@ kg:
     default_validity: infinite
 ```
 
-- [Graph Store](graph_store) — Persist graphs in Neo4j, FalkorDB, or Apache AGE.
-- [Semantic Extract](semantic_extract) — Source of entities and relationships fed to GraphBuilder.
+- [Graph Store](/reference/graph_store) — Persist graphs in Neo4j, FalkorDB, or Apache AGE.
+- [Semantic Extract](/reference/semantic_extract) — Source of entities and relationships fed to GraphBuilder.
 - [Visualization](visualization) — Visualize knowledge graphs interactively.
-- [Conflicts](conflicts) — Conflict detection and resolution.
+- [Conflicts](/reference/conflicts) — Conflict detection and resolution.
 
 ### Cookbooks
 

--- a/docs/reference/llms.md
+++ b/docs/reference/llms.md
@@ -439,7 +439,7 @@ extractor = NERExtractor(
 )
 ```
 
-- [Semantic Extract](semantic_extract) — Use LLMs for NER and relation extraction.
+- [Semantic Extract](/reference/semantic_extract) — Use LLMs for NER and relation extraction.
 - [Agno Integration](../integrations/agno) — LLM providers in Agno multi-agent teams.
 - [Reasoning](reasoning) — LLM-backed deductive and abductive reasoning.
-- [Context](context) — GraphRAG uses LLMs for reasoning over knowledge graphs.
+- [Context](/reference/context) — GraphRAG uses LLMs for reasoning over knowledge graphs.

--- a/docs/reference/mcp_server.md
+++ b/docs/reference/mcp_server.md
@@ -45,7 +45,7 @@ python -m semantica.mcp_server
 - **Zero Infrastructure** — Runs over stdio: no server, no port, no Docker required. One config block to activate in any MCP client.
 - **Persistent Graphs** — Point `SEMANTICA_KG_PATH` at a saved graph file to reload it automatically on every server startup.
 - **Decision Intelligence** — Record decisions, find precedents via hybrid similarity search, and trace causal chains across agent runs.
-- **REST Alternative** — The [Explorer](explorer) module offers a full HTTP API and browser dashboard if you prefer programmatic access.
+- **REST Alternative** — The [Explorer](/reference/explorer) module offers a full HTTP API and browser dashboard if you prefer programmatic access.
 
 ## Installation
 
@@ -493,7 +493,7 @@ The MCP server exposes three readable resources:
 | `semantica://decisions/list` | All recorded decisions (up to 50) |
 | `semantica://schema/info` | Server version and available tools |
 
-- [Context](context) — The ContextGraph that the MCP server operates on.
-- [Semantic Extract](semantic_extract) — NER and relation extraction powering the MCP tools.
+- [Context](/reference/context) — The ContextGraph that the MCP server operates on.
+- [Semantic Extract](/reference/semantic_extract) — NER and relation extraction powering the MCP tools.
 - [Reasoning](reasoning) — Forward-chaining engine behind run_reasoning.
 - [Agno Integration](../integrations/agno) — Use Semantica inside Agno multi-agent teams.

--- a/docs/reference/normalize.md
+++ b/docs/reference/normalize.md
@@ -584,7 +584,7 @@ normalized = normalize_text("Apple Inc.", method="expand_suffixes")
 # → "Apple Incorporated"
 ```
 
-- [Parse](parse) — Parse documents before normalization.
-- [Split](split) — Chunk normalized text for embedding.
+- [Parse](/reference/parse) — Parse documents before normalization.
+- [Split](/reference/split) — Chunk normalized text for embedding.
 - [Deduplication](deduplication) — Resolve duplicate entities after normalization.
 - [Pipeline](pipeline) — Include normalization as a named pipeline step.

--- a/docs/reference/ontology.md
+++ b/docs/reference/ontology.md
@@ -287,6 +287,6 @@ ontology_data = ingest_ontology("schema.jsonld")  # JSON-LD
 </Note>
 
 - [Reasoning](reasoning) — Apply inference rules over ontology axioms.
-- [Knowledge Graph](kg) — The graph being modeled by the ontology.
+- [Knowledge Graph](/reference/kg) — The graph being modeled by the ontology.
 - [Export](export) — Export ontologies as RDF, OWL, or JSON-LD.
-- [Conflicts](conflicts) — Detect ontology constraint violations.
+- [Conflicts](/reference/conflicts) — Detect ontology constraint violations.

--- a/docs/reference/parse.md
+++ b/docs/reference/parse.md
@@ -298,6 +298,6 @@ for source in sources:
 </Note>
 
 - [Ingest](ingest) — Load files before parsing.
-- [Split](split) — Chunk parsed text for embedding and extraction.
+- [Split](/reference/split) — Chunk parsed text for embedding and extraction.
 - [Docling Integration](../integrations/docling) — Full Docling integration setup guide.
-- [Semantic Extract](semantic_extract) — Extract entities and relations from parsed text.
+- [Semantic Extract](/reference/semantic_extract) — Extract entities and relations from parsed text.

--- a/docs/reference/pipeline.md
+++ b/docs/reference/pipeline.md
@@ -589,6 +589,6 @@ StepStatus.SKIPPED    # Skipped due to FailureHandler "skip" strategy
 </AccordionGroup>
 
 - [Ingest](ingest) — First step in most pipelines.
-- [Semantic Extract](semantic_extract) — Core extraction step.
-- [Knowledge Graph](kg) — Graph construction step.
+- [Semantic Extract](/reference/semantic_extract) — Core extraction step.
+- [Knowledge Graph](/reference/kg) — Graph construction step.
 - [Export](export) — Final output step.

--- a/docs/reference/pipeline.md
+++ b/docs/reference/pipeline.md
@@ -497,7 +497,7 @@ result   = engine.execute_pipeline(
 
 ## SPARQL CONSTRUCT Template Steps
 
-Use the `"construct_template"` step type to render and execute a [SPARQL CONSTRUCT template](triplet_store#sparql-construct-templates) as part of a pipeline. `store_backend` and `construct_template_registry` are execution-time resources, not step config — pass them to `execute_pipeline()`, the same way `delta_mode` steps receive `version_manager` and `triplet_store`:
+Use the `"construct_template"` step type to render and execute a [SPARQL CONSTRUCT template](/reference/triplet_store#sparql-construct-templates) as part of a pipeline. `store_backend` and `construct_template_registry` are execution-time resources, not step config — pass them to `execute_pipeline()`, the same way `delta_mode` steps receive `version_manager` and `triplet_store`:
 
 ```python
 from semantica.pipeline import PipelineBuilder, ExecutionEngine

--- a/docs/reference/provenance.md
+++ b/docs/reference/provenance.md
@@ -522,7 +522,7 @@ Provenance tracking in Semantica produces the following audit artifacts:
   `ProvenanceManager` does not include built-in Turtle or JSON-LD serialization. Use `entry.to_dict()` and `get_lineage()` to retrieve provenance data, then serialize with your preferred RDF library if W3C PROV-O RDF output is required.
 </Note>
 
-- [Change Management](change_management) — Version control and snapshot audit trails.
+- [Change Management](/reference/change_management) — Version control and snapshot audit trails.
 - [Ingest](ingest) — Provenance begins at the ingestion stage.
 - [Export](export) — Include provenance metadata in RDF exports.
-- [Context](context) — Decision provenance via AgentContext.
+- [Context](/reference/context) — Decision provenance via AgentContext.

--- a/docs/reference/reasoning.md
+++ b/docs/reference/reasoning.md
@@ -482,7 +482,7 @@ step.confidence     # float
   `GraphReasoner` requires a configured LLM provider. If the provider fails to initialize, `reason()` returns an error string instead of raising. Check `reasoner.provider is not None` before calling if you need to surface failures explicitly.
 </Warning>
 
-- [Knowledge Graph](kg) — The knowledge graph being reasoned over.
+- [Knowledge Graph](/reference/kg) — The knowledge graph being reasoned over.
 - [Ontology](ontology) — Ontology axioms and SHACL constraints for logical reasoning.
-- [Triplet Store](triplet_store) — RDF backend for SPARQL-based reasoning.
-- [Context](context) — Reasoning integrated into agent decision intelligence.
+- [Triplet Store](/reference/triplet_store) — RDF backend for SPARQL-based reasoning.
+- [Context](/reference/context) — Reasoning integrated into agent decision intelligence.

--- a/docs/reference/seed.md
+++ b/docs/reference/seed.md
@@ -322,6 +322,6 @@ export SEMANTICA_SEED_MERGE_STRATEGY=seed_first
 </Tip>
 
 - [Ingest](ingest) — Load unstructured data alongside seed data.
-- [Knowledge Graph](kg) — The target graph that seed data populates.
+- [Knowledge Graph](/reference/kg) — The target graph that seed data populates.
 - [Deduplication](deduplication) — Handle duplicates during seed-extracted merge.
 - [Pipeline](pipeline) — Incorporate seed loading as a named pipeline step.

--- a/docs/reference/semantic_extract.md
+++ b/docs/reference/semantic_extract.md
@@ -410,7 +410,7 @@ triplets      = trip.extract(text)
 | `ml` | Fast | Free | High | Limited |
 | `llm` | Medium | API cost | Highest | Yes (schema) |
 
-- [LLM Providers](llms) — Configure which LLM is used for extraction.
-- [Knowledge Graph](kg) — Build graphs from extracted entities and relationships.
-- [Parse Module](parse) — Parse documents before extraction.
+- [LLM Providers](/reference/llms) — Configure which LLM is used for extraction.
+- [Knowledge Graph](/reference/kg) — Build graphs from extracted entities and relationships.
+- [Parse Module](/reference/parse) — Parse documents before extraction.
 - [Deduplication](deduplication) — Resolve duplicate entities after extraction.

--- a/docs/reference/split.md
+++ b/docs/reference/split.md
@@ -373,7 +373,7 @@ for chunk in chunks:
 
 For the full pipeline orchestration API, see the [Pipeline reference](pipeline).
 
-- [Parse](parse) — Parse documents before chunking: produces sections and metadata.
-- [Embeddings](embeddings) — Embed chunks for vector search and semantic chunking.
-- [Semantic Extract](semantic_extract) — Extract entities and relations from individual chunks.
+- [Parse](/reference/parse) — Parse documents before chunking: produces sections and metadata.
+- [Embeddings](/reference/embeddings) — Embed chunks for vector search and semantic chunking.
+- [Semantic Extract](/reference/semantic_extract) — Extract entities and relations from individual chunks.
 - [Pipeline](pipeline) — Integrate splitting as a named pipeline step.

--- a/docs/reference/temporal.md
+++ b/docs/reference/temporal.md
@@ -874,8 +874,8 @@ kg:
       engine: allen                   # allen | point_in_time_only
 ```
 
-- [Knowledge Graph Module](kg) — Core graph construction, `GraphBuilder`, analytics.
-- [Context Module](context) — Decision temporal windows and `find_active_nodes()`.
+- [Knowledge Graph Module](/reference/kg) — Core graph construction, `GraphBuilder`, analytics.
+- [Context Module](/reference/context) — Decision temporal windows and `find_active_nodes()`.
 - [Provenance](provenance) — W3C PROV-O lineage stamped alongside temporal metadata.
 - [Export](export) — OWL, Turtle, JSON-LD, and Parquet export with temporal annotations.
 

--- a/docs/reference/triplet_store.md
+++ b/docs/reference/triplet_store.md
@@ -564,4 +564,4 @@ for row in result.bindings:
 - [Export](export) — Export knowledge graphs to RDF formats.
 - [Ontology](ontology) — Load OWL ontologies and store as RDF triples.
 - [Reasoning](reasoning) — SPARQL-based property chain inference.
-- [Graph Store](graph_store) — Property graph alternative for Cypher queries.
+- [Graph Store](/reference/graph_store) — Property graph alternative for Cypher queries.

--- a/docs/reference/utils.md
+++ b/docs/reference/utils.md
@@ -222,5 +222,5 @@ from semantica.utils import read_json_file
 config = read_json_file("config.json")
 ```
 
-- [Core](core) — Framework orchestration that uses Utils internally.
+- [Core](/reference/core) — Framework orchestration that uses Utils internally.
 - [Pipeline](pipeline) — Uses ProgressTracker for per-step tracking.

--- a/docs/reference/vector_store.md
+++ b/docs/reference/vector_store.md
@@ -588,7 +588,7 @@ store.create_index(index_type="pq", metric="L2", m=8)
   </Tab>
 </Tabs>
 
-- [Embeddings](embeddings) — Generate the vectors stored here.
-- [Context](context) — AgentContext uses VectorStore for memory retrieval.
-- [Split](split) — Chunk documents before embedding and storing.
+- [Embeddings](/reference/embeddings) — Generate the vectors stored here.
+- [Context](/reference/context) — AgentContext uses VectorStore for memory retrieval.
+- [Split](/reference/split) — Chunk documents before embedding and storing.
 - [Ingest](ingest) — Ingest documents before embedding and storing.

--- a/docs/reference/visualization.md
+++ b/docs/reference/visualization.md
@@ -288,9 +288,9 @@ For a full browser-based UI with search, path finding, and the Ontology Hub, lau
 semantica-explorer --graph my_graph.json
 ```
 
-See the [Explorer reference](explorer) for the full feature set and REST API.
+See the [Explorer reference](/reference/explorer) for the full feature set and REST API.
 
-- [Knowledge Graph](kg) — The graph being visualized.
+- [Knowledge Graph](/reference/kg) — The graph being visualized.
 - [Ontology](ontology) — Visualize ontology class structure.
-- [Embeddings](embeddings) — Generate the embeddings visualized here.
-- [Explorer](explorer) — Full interactive Knowledge Explorer UI.
+- [Embeddings](/reference/embeddings) — Generate the embeddings visualized here.
+- [Explorer](/reference/explorer) — Full interactive Knowledge Explorer UI.


### PR DESCRIPTION
## Description

Nearly every "Next Steps" / "Related" link in the docs body 404s on the live site.

The docs are built with `mintlify export` and deployed as static files to GitHub Pages (`.github/workflows/docs.yml`). GitHub Pages 301-redirects every page to a trailing-slash URL (`/installation` → `/installation/`). Body links written as relative paths, such as `[Getting Started](getting-started)`, are emitted unchanged, so the browser resolves them against the trailing-slash URL and opens `/installation/getting-started`, which is GitHub Pages' 404 page. Sidebar and pagination links generated from `docs.json` use root paths and work; only hand-written Markdown links are affected.

This PR rewrites relative body links as root paths, resolving each against its source file's directory. Link text is untouched.

| Written as | In | Becomes |
|---|---|---|
| `getting-started` | `installation.md` | `/getting-started` |
| `kg` | `reference/embeddings.md` | `/reference/kg` |
| `context-graphs` | `guides/agent-memory.md` | `/guides/context-graphs` |
| `concepts#graphrag` | `getting-started.md` | `/concepts#graphrag` |

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues

Closes #1405

## Changes Made

- Rewrite 300 relative links across 74 pages under `docs/` to root paths (295 plain links plus 5 links with `#anchor` fragments)
- Each converted target basename exists in exactly one place in `docs/`, so the intended page is unambiguous
- Links written as `../x` are not touched: `mintlify export` already rewrites those to root paths, and they work on the live site

## Testing

- [x] Tested locally
- [ ] Added tests for new functionality
- [ ] Package builds successfully (`python -m build`) — docs-only change, no package impact

### Test Commands

```bash
# Docs integrity checks: all static checks pass, mintlify export builds 81 pages
python docs_check.py


# Reproduce the production behaviour locally: static export + a server that
# redirects directories to trailing-slash URLs, exactly like GitHub Pages
cd docs && npx mintlify@4.2.632 export --output /tmp/site.zip
unzip -q /tmp/site.zip -d /tmp/site && cd /tmp/site && python3 -m http.server 8766
# open http://127.0.0.1:8766/installation/#next-steps and click "Getting Started"

Full-site crawl of the exported HTML, resolving every internal <a href> with browser
semantics against the page's trailing-slash URL:

┌─────────────┬─────────────────────────────────────────────┐
│    Build    │            Broken internal links            │
├─────────────┼─────────────────────────────────────────────┤
│ main        │ 341                                         │
├─────────────┼─────────────────────────────────────────────┤
│ this branch │ 90 (all in the 95 deferred same-name links) │
└─────────────┴─────────────────────────────────────────────┘

No new broken links introduced. Against https://docs.getsemantica.ai, all 64 distinct new target URLs return 200 and all 339 URLs the current links resolve to return 404.
```
## Documentation

- [x] Updated relevant documentation
- [ ] Added code examples if applicable
- [ ] Updated API reference if adding new APIs
- [ ] Updated cookbook if adding new examples
- [ ] No documentation changes needed

## Breaking Changes: No

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (n/a, Markdown only)
- [x] My changes generate no new warnings
- [ ] Package builds successfully (n/a, docs only)

## Additional Notes

docs_check.py did not catch this because its href check resolves against the source directory, where the target file exists. A follow-up could add a check that rejects body links without a leading /, or crawl the export output the way described above, so the problem cannot come back.