### PR TITLE
docs(getting-started): fix broken APIs in the Knowledge Graph and GraphRAG tabs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,8 +84,8 @@ icon: "rocket"
     # 1. Ingest
     sources = FileIngestor().ingest("data/report.pdf")
 
-    # 2. Parse (parse() takes a path and returns a dict)
-    text = DocumentParser().parse(sources[0].path)["text"]
+    # 2. Parse (extract_text returns a plain string for any supported format)
+    text = DocumentParser().extract_text(sources[0].path)
 
     # 3. Extract (extractors take text, return Entity / Relation objects)
     ner           = NERExtractor(method="pattern")  # no API key needed

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,13 +84,13 @@ icon: "rocket"
     # 1. Ingest
     sources = FileIngestor().ingest("data/report.pdf")
 
-    # 2. Parse
-    parsed = DocumentParser().parse(sources[0])
+    # 2. Parse (parse() takes a path and returns a dict)
+    text = DocumentParser().parse(sources[0].path)["text"]
 
-    # 3. Extract
+    # 3. Extract (extractors take text, return Entity / Relation objects)
     ner           = NERExtractor(method="pattern")  # no API key needed
-    entities      = ner.extract(parsed)
-    relationships = RelationExtractor().extract(parsed, entities=entities)
+    entities      = ner.extract(text)
+    relationships = RelationExtractor(method="pattern").extract(text, entities=entities)
 
     # 4. Build
     graph = GraphBuilder(merge_entities=True).build(
@@ -144,22 +144,29 @@ icon: "rocket"
     context = AgentContext(
         vector_store=VectorStore(backend="faiss", dimension=768),
         knowledge_graph=ContextGraph(advanced_analytics=True),
+        graph_expansion=True,   # multi-hop traversal from seed nodes
     )
 
-    # Load your knowledge graph
-    context.load_graph("company_kg.json")
+    # store() runs extraction and populates both the vector index and the graph
+    context.store([
+        {"content": "Steve Wozniak co-founded Apple with Steve Jobs in 1976."},
+        {"content": "Tony Fadell led the iPod team at Apple, then founded Nest."},
+    ])
 
-    # Multi-hop GraphRAG query
-    result = context.query(
+    # GraphRAG retrieval: seed from vector matches, expand along graph edges
+    results = context.retrieve(
         "What companies were founded by people who worked at Apple?",
-        mode="graphrag",
-        reasoning=True,
+        use_graph=True,
+        expand_graph=True,
+        max_hops=3,
     )
-
-    # Every claim links back to a source node
-    for claim in result.claims:
-        print(f"{claim.text}  →  source: {claim.source_node}")
+    for r in results:
+        print(f"[{r['score']:.3f}]  {r['content'][:80]}")
     ```
+
+    For a grounded natural-language answer with an auditable traversal, use
+    `context.query_with_reasoning(query, llm_provider=...)` — it returns
+    `response`, `reasoning_path`, `sources`, and `confidence`.
 
     **Next:** [GraphRAG concepts →](/concepts#graphrag)
   </Tab>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -144,7 +144,8 @@ icon: "rocket"
     context = AgentContext(
         vector_store=VectorStore(backend="faiss", dimension=768),
         knowledge_graph=ContextGraph(advanced_analytics=True),
-        graph_expansion=True,   # multi-hop traversal from seed nodes
+        graph_expansion=True,       # blend graph traversal into retrieval
+        max_expansion_hops=3,       # how far to walk from the seed nodes
     )
 
     # store() runs extraction and populates both the vector index and the graph
@@ -158,13 +159,13 @@ icon: "rocket"
         "What companies were founded by people who worked at Apple?",
         use_graph=True,
         expand_graph=True,
-        max_hops=3,
     )
     for r in results:
-        print(f"[{r['score']:.3f}]  {r['content'][:80]}")
+        print(f"[{r['score']:.3f}]  {r['content'][:70]}  (source: {r['source']})")
     ```
 
-    For a grounded natural-language answer with an auditable traversal, use
+    Each result carries `content`, `score`, `source`, and `metadata`. For a
+    grounded natural-language answer plus an auditable traversal, use
     `context.query_with_reasoning(query, llm_provider=...)` — it returns
     `response`, `reasoning_path`, `sources`, and `confidence`.
 


### PR DESCRIPTION
`getting-started.md` is the 5-minute walkthrough linked from `learning-more.md`, and two of the four "Choose Your Path" tabs currently contain examples that fail as written.

**Knowledge Graph**

This had the same issue fixed in #1401 for the quickstart:

* `DocumentParser().parse(sources[0])` passes a `FileObject`, but `parse()` expects a path string. It also returns a `dict`, not an object.
* `ner.extract(parsed)` and `RelationExtractor().extract(parsed, ...)` pass the full parse result, while both extractors expect text.

Updated the example to use `parse(sources[0].path)["text"]` and pass that text into the extractors.

Smoke-tested the ingest → build flow.

**GraphRAG**

The existing example uses APIs that don't exist on `AgentContext`:

* There's no `load_graph()` method. `load()` is for loading a context-state directory.
* There's no `query()` method with `mode=` or `reasoning=` arguments.
* `result.claims` and `claim.source_node` aren't part of the API.

Reworked the example to match `docs/guides/graphrag.md`: use `context.store([...])` to populate the graph and vector index, then call:

`context.retrieve(query, use_graph=True, expand_graph=True, max_hops=3)`

The example reads `r["score"]` and `r["content"]` from the results.

Also added a note about `query_with_reasoning(query, llm_provider=...)` for grounded answers, including its `response`, `reasoning_path`, `sources`, and `confidence` fields.

Verified the updated examples against `semantica/context/agent_context.py` and the GraphRAG guide.
