### PR TITLE
docs: simplify custom.css to a static, professional style

### DIFF
--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -1,13 +1,8 @@
 /* ============================================================
-   SEMANTICA DOCS — PREMIUM DESIGN SYSTEM
+   SEMANTICA DOCS — DESIGN SYSTEM
    Dark-first (#080C10 bg, #10B981 emerald accent)
+   Minimal, static styling — no decorative motion.
    ============================================================ */
-
-/* ── Keyframes ─────────────────────────────────────────────── */
-@keyframes pageFadeIn {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0);   }
-}
 
 /* ── Global ─────────────────────────────────────────────────── */
 html {
@@ -29,16 +24,7 @@ html {
 }
 ::-webkit-scrollbar-thumb:hover { background: rgba(16, 185, 129, 0.4); }
 
-/* ── Page entrance ──────────────────────────────────────────── */
-main,
-article,
-[class*="content-area"],
-[class*="ContentArea"],
-[class*="prose"] {
-  animation: pageFadeIn 0.35s ease both;
-}
-
-/* ── Focus rings ─────────────────────────────────────────────── */
+/* ── Focus rings (accessibility — kept) ─────────────────────── */
 *:focus-visible {
   outline: 2px solid rgba(16, 185, 129, 0.55) !important;
   outline-offset: 3px !important;
@@ -59,7 +45,7 @@ h1::after {
   left: 0;
   width: 44px;
   height: 2px;
-  background: linear-gradient(90deg, #10B981 0%, transparent 100%);
+  background: #10B981;
   border-radius: 1px;
 }
 
@@ -71,9 +57,6 @@ article a,
 [class*="prose"] a {
   text-decoration-color: rgba(16, 185, 129, 0.35);
   text-underline-offset: 3px;
-  transition:
-    text-decoration-color 0.15s ease,
-    color                 0.15s ease;
 }
 
 article a:hover,
@@ -89,14 +72,6 @@ blockquote {
   padding: 0.9rem 1.2rem !important;
   font-style: italic;
   color: rgba(255, 255, 255, 0.68) !important;
-  transition:
-    border-color     0.2s ease,
-    background-color 0.2s ease !important;
-}
-
-blockquote:hover {
-  border-left-color: rgba(16, 185, 129, 0.65) !important;
-  background: rgba(16, 185, 129, 0.07) !important;
 }
 
 /* ── HR / Divider ────────────────────────────────────────────── */
@@ -123,165 +98,11 @@ table thead th {
   border-bottom: 1px solid rgba(16, 185, 129, 0.18) !important;
 }
 
-table tbody tr {
-  transition: background-color 0.15s ease;
-  cursor: default;
-}
-
-table tbody tr:hover {
-  background-color: rgba(16, 185, 129, 0.06) !important;
-}
-
-table tbody tr:hover td {
-  background-color: transparent !important;
-}
-
-table td,
-table th {
-  transition: background-color 0.15s ease;
-}
-
-/* ── CODE BLOCKS ─────────────────────────────────────────────── */
-pre,
-[class*="codeblock"],
-[class*="code-group"],
-[class*="CodeBlock"],
-[data-rehype-pretty-code-fragment] {
-  transition:
-    box-shadow   0.25s cubic-bezier(0.4, 0, 0.2, 1),
-    border-color 0.25s cubic-bezier(0.4, 0, 0.2, 1),
-    transform    0.25s cubic-bezier(0.4, 0, 0.2, 1) !important;
-}
-
-pre:hover,
-[class*="codeblock"]:hover,
-[class*="CodeBlock"]:hover,
-[data-rehype-pretty-code-fragment]:hover {
-  transform: translateY(-1px) !important;
-  box-shadow:
-    0 0 0 1px rgba(16, 185, 129, 0.18),
-    0 2px 12px rgba(16, 185, 129, 0.06),
-    0 8px 32px rgba(0, 0, 0, 0.2) !important;
-  border-color: rgba(16, 185, 129, 0.2) !important;
-}
-
-/* ── CARDS ───────────────────────────────────────────────────── */
-[class*="card"],
-[class*="Card"],
-[data-card],
-.group\/card {
-  transition:
-    transform    0.22s ease,
-    box-shadow   0.22s ease,
-    border-color 0.22s ease !important;
-}
-
-[class*="card"]:hover,
-[class*="Card"]:hover,
-[data-card]:hover,
-.group\/card:hover {
-  transform: translateY(-3px) !important;
-  box-shadow:
-    0 8px 28px rgba(0, 0, 0, 0.18),
-    0 0 0 1px rgba(16, 185, 129, 0.22) !important;
-  border-color: rgba(16, 185, 129, 0.28) !important;
-}
-
-/* ── CALLOUTS / ADMONITIONS ──────────────────────────────────── */
-[class*="callout"],
-[class*="Callout"],
-[class*="admonition"] {
-  transition:
-    box-shadow   0.2s ease,
-    border-color 0.2s ease !important;
-}
-
-[class*="callout"]:hover,
-[class*="Callout"]:hover,
-[class*="admonition"]:hover {
-  box-shadow: 0 2px 16px rgba(16, 185, 129, 0.08) !important;
-  border-color: rgba(16, 185, 129, 0.35) !important;
-}
-
-/* ── STEPS ───────────────────────────────────────────────────── */
-[class*="step"],
-[class*="Step"] {
-  transition: background-color 0.15s ease !important;
-}
-
-[class*="step"]:hover,
-[class*="Step"]:hover {
-  background-color: rgba(16, 185, 129, 0.04) !important;
-}
-
-/* ── INLINE CODE ─────────────────────────────────────────────── */
-:not(pre) > code {
-  transition:
-    background-color 0.15s ease,
-    color            0.15s ease !important;
-  cursor: text;
-}
-
-:not(pre) > code:hover {
-  background-color: rgba(16, 185, 129, 0.16) !important;
-}
-
 /* ── NAVIGATION / SIDEBAR ────────────────────────────────────── */
 nav a,
 [class*="sidebar"] a,
 [class*="Sidebar"] a {
-  transition: color 0.15s ease !important;
   text-decoration: none;
-  position: relative;
-}
-
-nav a::after,
-[class*="sidebar"] a::after,
-[class*="Sidebar"] a::after {
-  content: "";
-  position: absolute;
-  bottom: -1px;
-  left: 0;
-  width: 0;
-  height: 1px;
-  background: #10B981;
-  transition: width 0.2s ease;
-}
-
-nav a:hover::after,
-[class*="sidebar"] a:hover::after,
-[class*="Sidebar"] a:hover::after {
-  width: 100%;
-}
-
-/* ── TEXT / LIST ITEMS ───────────────────────────────────────── */
-ul > li,
-ol > li {
-  border-radius: 3px;
-  transition: background-color 0.12s ease;
-}
-
-ul > li:hover,
-ol > li:hover {
-  background-color: rgba(16, 185, 129, 0.04);
-}
-
-/* ── PRIMARY BUTTON / CTA ────────────────────────────────────── */
-button[class*="primary"],
-a[class*="primary"],
-[class*="btn-primary"],
-[class*="ButtonPrimary"] {
-  transition:
-    box-shadow 0.2s ease,
-    transform  0.2s ease !important;
-}
-
-button[class*="primary"]:hover,
-a[class*="primary"]:hover,
-[class*="btn-primary"]:hover,
-[class*="ButtonPrimary"]:hover {
-  box-shadow: 0 0 22px rgba(16, 185, 129, 0.28) !important;
-  transform: translateY(-1px) !important;
 }
 
 /* ── HIDE THEME TOGGLE ───────────────────────────────────────── */


### PR DESCRIPTION
## Description

The docs' shared `docs/assets/custom.css` ("PREMIUM DESIGN SYSTEM") added a decorative hover animation to nearly every element type: code blocks and cards lifted (`translateY`) and glowed (`box-shadow`) on hover, table rows and list items highlighted on hover, the sidebar nav underline animated in on hover, buttons lifted and glowed, and every page faded/slid in on navigation. That reads as flashy rather than professional for technical documentation, and the code-block hover effect in particular is distracting while reading code.

This PR strips the CSS back to static, professional styling: same color palette, typography, and accessibility focus rings, but no transform/box-shadow hover effects and no page-load animation. Since `custom.css` is loaded site-wide (`docs.json` → `"css": "/assets/custom.css"`), this affects every page under `docs/` without needing per-page edits.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

- Removed the `pageFadeIn` keyframe animation applied to every page on load/navigation
- Removed hover `transform`/`box-shadow` lift+glow effects from code blocks, cards, callouts, and buttons
- Removed hover background highlighting on table rows and list items
- Removed the animated underline slide-in on sidebar/nav links (back to plain static links)
- Removed hover-only color/shadow transitions on blockquotes and inline code
- Kept: color palette, heading/typography styling, the `h1` accent underline (now static, no gradient sweep), the HR divider, table header styling, custom scrollbar, text selection color, `scroll-behavior: smooth`, accessibility `:focus-visible` rings, and the theme-toggle hiding rule

## Testing

- [x] Tested locally
- [ ] Added tests for new functionality (CSS-only change, not applicable)
- [x] Package builds successfully

### Test Commands

```
python docs_check.py
# pass  docs.json is valid JSON
# pass  All nav pages exist on disk
# pass  All internal Card hrefs resolve
# pass  No stale repo URLs
# pass  All reference pages have frontmatter
# pass  No known-wrong class names in reference pages
# pass  No Python 3.9+ type syntax in code blocks (3.8 compat)
# pass  All 27 modules present in index.md
# pass  All Mintlify JSX component tags are balanced
# pass  Mintlify export builds without errors
# All checks passed
```

## Breaking Changes: No

## Additional Notes

Scoped to `docs/assets/custom.css` only — no per-page Markdown content changes needed, since the animations were all sourced from this one shared stylesheet.
