### PR TITLE
docs: restructure nav — drop FAQ/Changelog tabs, add API Reference tab

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -121,6 +121,23 @@
             "pages": [
               "vector_stores/pgvector"
             ]
+          },
+          {
+            "group": "FAQ",
+            "pages": [
+              "faq"
+            ]
+          },
+          {
+            "group": "Community",
+            "pages": [
+              "community",
+              "community-projects",
+              "contributing-guide",
+              "governance",
+              "citation",
+              "project-license"
+            ]
           }
         ]
       },
@@ -167,7 +184,17 @@
               "guides/policy-engine",
               "guides/visualization",
               "guides/distance-intelligence",
-              "guides/graph-analytics",
+              "guides/graph-analytics"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "API Reference",
+        "groups": [
+          {
+            "group": "Context & Intelligence",
+            "pages": [
               "reference/context",
               "reference/kg",
               "reference/temporal",
@@ -236,32 +263,6 @@
             ]
           }
         ]
-      },
-      {
-        "tab": "FAQ",
-        "groups": [
-          {
-            "group": "FAQ",
-            "pages": [
-              "faq"
-            ]
-          },
-          {
-            "group": "Community",
-            "pages": [
-              "community",
-              "community-projects",
-              "contributing-guide",
-              "governance",
-              "citation",
-              "project-license"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "Changelog",
-        "href": "https://github.com/semantica-agi/semantica/releases"
       }
     ]
   },


### PR DESCRIPTION
## Description

Restructures the top-level docs navigation in `docs/docs.json`:

- Removed the standalone **FAQ** and **Changelog** tabs.
- Added a dedicated **API Reference** tab holding every module's class/function reference docs, split out of the **Modules** tab.

## Changes Made

- **FAQ tab removed.** Its two groups (`FAQ` — the `faq` page, and `Community` — `community`, `community-projects`, `contributing-guide`, `governance`, `citation`, `project-license`) are relocated into the **Overview** tab as their own groups. Nothing was deleted from `docs/`; these pages are still fully linked from the nav, just under Overview instead of a dedicated tab.
- **Changelog tab removed.** It only ever pointed to the external GitHub releases page (`href`, no pages of its own), so there's nothing to relocate.
- **New API Reference tab added**, containing the `reference/*` pages that were previously mixed into the Modules tab: `Context & Intelligence`, `Storage`, `Data Pipeline`, `Quality & Provenance`, `Output`, and `Utilities` groups — i.e. every module's actual class/function API docs, all in one place.
- **Modules tab trimmed** to just its `Context & Intelligence` group of conceptual guides (`guides/*`); the `reference/*` entries that used to also live in that same group, plus the four groups that were 100% reference pages, moved wholesale to the new API Reference tab. No duplication between the two tabs.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

```
python docs_check.py
# pass  docs.json is valid JSON
# pass  All nav pages exist on disk
# pass  All internal Card hrefs resolve
# pass  No stale repo URLs
# pass  All reference pages have frontmatter
# pass  No known-wrong class names in reference pages
# pass  No Python 3.9+ type syntax in code blocks (3.8 compat)
# pass  All 27 modules present in index.md
# pass  All Mintlify JSX component tags are balanced
# pass  Mintlify export builds without errors
# All checks passed
```

## Breaking Changes: No

Page URLs are unchanged (this only touches `navigation.tabs` in `docs.json`, not file paths or frontmatter), so no existing links break.
