### PR TITLE
docs: tighten prose in concepts.md, guides/graphrag.md, reference/context.md

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -8,16 +8,16 @@ icon: "book-open"
   New here? Start with [Getting Started](/getting-started) for hands-on examples, then return here for deeper understanding.
 </Info>
 
-Semantica transforms unstructured data: documents, web pages, reports, databases: into **knowledge graphs**: structured representations that AI systems can query, reason about, and trace back to sources.
+Semantica transforms unstructured data (documents, web pages, reports, databases) into **knowledge graphs**: structured representations that AI systems can query, reason about, and trace back to sources.
 
-At its core, Semantica adds a **context and accountability layer** on top of your existing AI stack. It doesn't replace LangChain, LlamaIndex, or your LLM provider: it makes their outputs **grounded**, **traceable**, and **auditable**.
+At its core, Semantica adds a context and semantic layer on top of your existing AI stack. It doesn't replace LangChain, LlamaIndex, or your LLM provider. It makes their outputs grounded, traceable, and auditable.
 
-- **Context Layer** — Knowledge graphs, GraphRAG retrieval, semantic embeddings, and temporal intelligence ground every LLM response in structured, queryable facts.
-- **Accountability Layer** — Provenance tracking, decision intelligence, conflict detection, and W3C PROV-O compliance make every claim in your AI stack auditable and explainable.
-- **Extension Layer** — `PluginRegistry` and `MethodRegistry` let you replace or augment any component: ingestors, extractors, reasoning engines, backends: without changing framework code.
+- **Context Layer.** Knowledge graphs, GraphRAG retrieval, semantic embeddings, and temporal intelligence ground every LLM response in structured, queryable facts.
+- **Accountability Layer.** Provenance tracking, decision intelligence, conflict detection, and W3C PROV-O compliance make every claim in your AI stack auditable and explainable.
+- **Extension Layer.** `PluginRegistry` and `MethodRegistry` let you replace or augment any component (ingestors, extractors, reasoning engines, backends) without changing framework code.
 
 <Warning>
-  **This is system-level explainability, not foundation-model explainability.** Semantica does not expose, reconstruct, or explain what happens *inside* the LLM/foundation model — its internal reasoning or chain-of-thought stays opaque, as it does for any external system. What Semantica explains is *outside* the model: the context and data fed in, the decision produced, its provenance, the relevant relationships, the policies applied, and the full execution trail. In short, Semantica explains and audits *what the AI system did*, not the foundation model's private internal reasoning.
+  **This is system-level explainability, not foundation-model explainability.** Semantica does not expose, reconstruct, or explain what happens *inside* the LLM/foundation model. Its internal reasoning or chain-of-thought stays opaque, as it does for any external system. What Semantica explains is *outside* the model: the context and data fed in, the decision produced, its provenance, the relevant relationships, the policies applied, and the full execution trail. In short, Semantica explains and audits *what the AI system did*, not the foundation model's private internal reasoning.
 </Warning>
 
 ## Knowledge Graphs
@@ -30,7 +30,7 @@ The foundation of everything in Semantica. A knowledge graph stores information 
 - **Edges (relationships)**: `works_for`, `located_in`, `founded_by`
 - **Properties**: name, date, confidence score, source URL
 
-This structure makes knowledge **searchable**, **connectable**, **queryable**, and: critically: **explainable**: every answer can be traced back to the facts and relationships that produced it.
+This structure makes knowledge searchable, connectable, and queryable. Critically, it's explainable: every answer can be traced back to the facts and relationships that produced it.
 
 
 ## Entity Extraction (NER)
@@ -513,6 +513,6 @@ Semantica is designed for extension. Any component: ingestor, extractor, graph b
   </Accordion>
 </AccordionGroup>
 
-- [Quickstart Tutorial](/quickstart) — Build a full pipeline with code.
-- [Modules Guide](/modules) — Every module explained with examples.
-- [API Reference](/reference/context) — Complete technical reference.
+- [Quickstart Tutorial](/quickstart): build a full pipeline with code.
+- [Modules Guide](/modules): every module explained with examples.
+- [API Reference](/reference/context): complete technical reference.

--- a/docs/guides/graphrag.md
+++ b/docs/guides/graphrag.md
@@ -1,9 +1,9 @@
 ---
-title: "GraphRAG — Graph-Augmented Retrieval"
+title: "GraphRAG: Graph-Augmented Retrieval"
 description: "Go beyond vector search: retrieve facts, trace reasoning paths, and ground LLM responses in your knowledge graph."
 ---
 
-GraphRAG combines vector similarity with knowledge graph traversal so retrieval finds structurally connected facts, not just text that sounds related. When a `ContextGraph` is attached to `AgentContext`, every retrieval call automatically blends semantic search with multi-hop graph expansion — and `query_with_reasoning()` returns an auditable reasoning path alongside the LLM answer.
+GraphRAG combines vector similarity with knowledge graph traversal so retrieval finds structurally connected facts, not just text that sounds related. When a `ContextGraph` is attached to `AgentContext`, every retrieval call automatically blends semantic search with multi-hop graph expansion, and `query_with_reasoning()` returns an auditable reasoning path alongside the LLM answer.
 
 ## What Is GraphRAG?
 
@@ -11,7 +11,7 @@ GraphRAG (Graph-Augmented Retrieval-Augmented Generation) enhances traditional R
 
 **GraphRAG vs. traditional vector-only RAG:** Vector RAG finds documents similar to your query text. GraphRAG finds documents similar to your query AND documents connected to those through entity relationships, even if they don't mention your query terms directly.
 
-**The role of graph traversal:** Starting from entities found in vector-similar documents, GraphRAG expands outward through relationship edges to discover related facts. This reveals connections that pure text similarity would miss — like finding that a threat actor targets healthcare by following the path: Actor → Tool → Victim Organization → Industry Sector.
+**The role of graph traversal:** Starting from entities found in vector-similar documents, GraphRAG expands outward through relationship edges to discover related facts. This reveals connections that pure text similarity would miss, like finding that a threat actor targets healthcare by following the path: Actor → Tool → Victim Organization → Industry Sector.
 
 ## Why Use GraphRAG?
 
@@ -96,7 +96,7 @@ context = AgentContext(
 )
 ```
 
-Now ingest your documents. `store()` with `extract_entities=True` runs the full extraction pipeline internally — Named Entity Recognition (NER), relation extraction, and entity linking — and populates both the vector index and the graph simultaneously:
+Now ingest your documents. `store()` with `extract_entities=True` runs the full extraction pipeline internally (Named Entity Recognition, relation extraction, and entity linking) and populates both the vector index and the graph simultaneously:
 
 ```python
 intel_documents = [
@@ -137,7 +137,7 @@ print("Graph built: {} nodes, {} edges".format(
 # Edges: deployed, observed_on, classified_as, targets, operates_in, ...
 ```
 
-The graph now contains a connected subgraph linking APT29 to healthcare infrastructure across four document boundaries — something that would be invisible to a pure vector search.
+The graph now contains a connected subgraph linking APT29 to healthcare infrastructure across four document boundaries, something that would be invisible to a pure vector search.
 
 ## Retrieving the relevant subgraph
 
@@ -169,7 +169,7 @@ Notice the top results: while pure vector search might rank connected facts lowe
 When you know specifically which entity you want to anchor the traversal to, pass `anchor_node`:
 
 ```python
-# Anchor on APT29 explicitly — proximity scores are calculated from this node
+# Anchor on APT29 explicitly: proximity scores are calculated from this node
 apt29_intel = context.retrieve(
     "C2 infrastructure beaconing patterns",
     use_graph=True,
@@ -197,7 +197,7 @@ result = context.query_with_reasoning(
     max_hops=3,
 )
 
-# The LLM answer — grounded in graph-retrieved context, not training memory
+# The LLM answer, grounded in graph-retrieved context, not training memory
 print(result["response"])
 
 # The multi-hop trace: APT29 → deployed → HAMMERTOSS → observed_on → LifeCare → ...
@@ -213,7 +213,7 @@ for src in result["sources"]:
     print("  [{:.3f}] {}".format(src["score"], src["content"][:80]))
 ```
 
-The `reasoning_path` field is what separates GraphRAG from a black-box LLM call. When an analyst asks "how do you know APT29 targeted healthcare?", you can show them the exact traversal the system made across your own documents — not a claim the model generated from training data.
+The `reasoning_path` field is what separates GraphRAG from a black-box LLM call. When an analyst asks "how do you know APT29 targeted healthcare?", you can show them the exact traversal the system made across your own documents, not a claim the model generated from training data.
 
 The full return structure from `query_with_reasoning()`:
 
@@ -232,11 +232,11 @@ The full return structure from `query_with_reasoning()`:
 
 <Tabs>
 
-<Tab title="Defense — CTI/Threat">
+<Tab title="Defense: CTI/Threat">
 
 Multi-INT intelligence fusion: OSINT threat feeds, NVD CVE data, and HUMINT summaries ingested into a single graph, then queried with multi-hop reasoning to trace C2 infrastructure chains and attribute campaigns to specific actors.
 
-In classified environments the graph can be partitioned by data handling caveat — each `AgentContext` operates over the subset of documents cleared for the querying user. The `reasoning_path` output doubles as a sanitisable audit trail for downgraded reporting.
+In classified environments the graph can be partitioned by data handling caveat: each `AgentContext` operates over the subset of documents cleared for the querying user. The `reasoning_path` output doubles as a sanitisable audit trail for downgraded reporting.
 
 ```python
 from semantica.context import AgentContext, ContextGraph
@@ -300,11 +300,11 @@ proximate = context.retrieve(
 
 </Tab>
 
-<Tab title="Security — SOC/Incident">
+<Tab title="Security: SOC/Incident">
 
 Security operations: real-time alert triage against a graph containing hosts, CVEs, user accounts, runbooks, and historical incidents. GraphRAG retrieves the relevant runbook and similar past incidents in a single call, reducing mean-time-to-respond.
 
-The `decision_tracking=True` flag records every triage query as an auditable decision, with the full context that was provided to the LLM — essential for post-incident review and SOC metrics.
+The `decision_tracking=True` flag records every triage query as an auditable decision, with the full context that was provided to the LLM. That's essential for post-incident review and SOC metrics.
 
 ```python
 from semantica.context import AgentContext, ContextGraph
@@ -369,7 +369,7 @@ for inc in similar:
 
 </Tab>
 
-<Tab title="Life Science — Clinical/Pharma">
+<Tab title="Life Science: Clinical/Pharma">
 
 Clinical decision support: FDA drug labels, clinical guidelines, and trial summaries ingested into a graph where drug-enzyme-metabolite-interaction chains become traversable paths. A three-hop query (drug → enzyme → metabolite → contraindication) surfaces interaction risks that no single document would make explicit.
 
@@ -443,7 +443,7 @@ contra_chain = clinical_context.retrieve(
 
 </Tab>
 
-<Tab title="Banking — Risk/Compliance">
+<Tab title="Banking: Risk/Compliance">
 
 Regulatory compliance: Basel III (CRE20), BCBS 239, SR 11-7, and EBA IRRBB guidelines ingested as a graph where regulation articles cross-reference each other as edges. Multi-hop queries traverse those cross-references automatically, so a question about commercial real estate RWA pulls the relevant CRE20 paragraphs and the BCBS 239 data quality requirements that govern their calculation in a single call.
 
@@ -466,7 +466,7 @@ compliance_context = AgentContext(
     retention_days=2555,   # 7-year regulatory retention
 )
 
-# In production these come from ingest_file() — shown as strings here for brevity
+# In production these come from ingest_file(); shown as strings here for brevity
 basel_cre20_text  = "CRE20.32: For income-producing real estate where repayment depends on "
                     "property cash flows, RWA = exposure × risk weight, where risk weight "
                     "is determined by LTV bucket per Table CRE20.3..."
@@ -496,7 +496,7 @@ print(answer["response"])
 print("Regulatory sources cited: {}".format(answer["num_sources"]))
 print("Confidence: {:.1%}".format(answer["confidence"]))
 
-# The reasoning path is the audit log — show it to the regulator
+# The reasoning path is the audit log: show it to the regulator
 print("\n--- Reasoning Path (audit log) ---")
 print(answer["reasoning_path"])
 ```
@@ -524,12 +524,12 @@ The `hybrid_alpha` parameter set in the `AgentContext` constructor establishes a
 When targeting a specific `anchor_node`, you can apply `proximity_weight` in `retrieve()` to dynamically blend structural distance from the anchor into the final score:
 
 ```python
-# Anchor node provided — let vector semantics lead, graph proximity only slightly boosts
+# Anchor node provided: let vector semantics lead, graph proximity only slightly boosts
 results = context.retrieve(
     query, use_graph=True, anchor_node="APT29", proximity_weight=0.2
 )
 
-# Known-entity tracing — topology drives the retrieval
+# Known-entity tracing: topology drives the retrieval
 results = context.retrieve(
     query, use_graph=True, anchor_node="APT29", proximity_weight=0.8
 )
@@ -576,9 +576,9 @@ The vector search and graph traversal run independently, then their scores are f
 
 ## Related Guides
 
-- [Semantic Extraction](/guides/semantic-extraction) — build the graph from raw unstructured text
-- [Agent Memory](/guides/agent-memory) — store, retrieve, and persist agent memories
-- [Context Graphs](/guides/context-graphs) — build and traverse the knowledge graph directly
-- [Reasoning](reasoning) — derive new facts and run inference rules over the graph
-- [Decision Intelligence](/guides/decision-intelligence) — causal chains, policy enforcement, decision tracking
-- [LLM Integrations](/guides/llm-integrations) — connect Groq, OpenAI, Anthropic, HuggingFace, and 100+ more
+- [Semantic Extraction](/guides/semantic-extraction): build the graph from raw unstructured text
+- [Agent Memory](/guides/agent-memory): store, retrieve, and persist agent memories
+- [Context Graphs](/guides/context-graphs): build and traverse the knowledge graph directly
+- [Reasoning](/guides/reasoning): derive new facts and run inference rules over the graph
+- [Decision Intelligence](/guides/decision-intelligence): causal chains, policy enforcement, decision tracking
+- [LLM Integrations](/guides/llm-integrations): connect Groq, OpenAI, Anthropic, HuggingFace, and 100+ more

--- a/docs/reference/context.md
+++ b/docs/reference/context.md
@@ -30,28 +30,28 @@ icon: "brain"
 
 ## What You Get
 
-- **AgentContext** — Memory, decision tracking, and graph-backed retrieval behind one API
+- **AgentContext**: memory, decision tracking, and graph-backed retrieval behind one API
   - Conversation history and checkpoint diffing
   - Persist and restore full context state to disk
-- **ContextGraph** — Thread-safe in-memory knowledge graph
+- **ContextGraph**: thread-safe in-memory knowledge graph
   - PageRank, centrality, community detection, temporal validity
   - Cross-graph navigation and link traversal
-- **AgentMemory** — Embedding-backed memory with retention policy
+- **AgentMemory**: embedding-backed memory with retention policy
   - LRU eviction at configurable `max_memory_size`
   - Per-conversation history isolation
-- **DecisionRecorder** — Records decisions with causal chains and confidence scores
+- **DecisionRecorder**: records decisions with causal chains and confidence scores
   - Temporal validity windows (`valid_from` / `valid_until`)
   - Cross-system context capture on every decision
-- **PolicyEngine** — Versioned policy storage in the knowledge graph
+- **PolicyEngine**: versioned policy storage in the knowledge graph
   - Compliance checking against recorded decisions
   - Policy exception tracking with approver audit trail
-- **EntityLinker** — Maps entity text to stable URIs
+- **EntityLinker**: maps entity text to stable URIs
   - Creates typed links between entity IDs
   - Prevents "Apple", "Apple Inc.", "AAPL" becoming separate nodes
-- **ContextRetriever** — Fuses vector similarity, graph traversal, and agent memory
+- **ContextRetriever**: fuses vector similarity, graph traversal, and agent memory
   - Richer context than pure vector search
   - Configurable `hybrid_alpha` and expansion hops
-- **CausalChainAnalyzer** — Traces upstream causes and downstream effects of any decision
+- **CausalChainAnalyzer**: traces upstream causes and downstream effects of any decision
   - Explainability paths with relationship types
   - Configurable depth and direction
 
@@ -273,7 +273,7 @@ icon: "brain"
 </Tip>
 
 <Tip>
-  **Persist your context between runs.** `VectorStore` does not auto-persist — passing `index_path=` to its constructor is a no-op. Call `context.save("agent_state/")` to write memory, the vector index, and the graph to disk, and `context.load("agent_state/")` on the next process to restore them. See the "Persist & Restore" tab under [Real-World Patterns](#real-world-patterns) below.
+  **Persist your context between runs.** `VectorStore` does not auto-persist; passing `index_path=` to its constructor is a no-op. Call `context.save("agent_state/")` to write memory, the vector index, and the graph to disk, and `context.load("agent_state/")` on the next process to restore them. See the "Persist & Restore" tab under [Real-World Patterns](#real-world-patterns) below.
 </Tip>
 
 ### Memory Methods
@@ -449,7 +449,7 @@ print("Nodes: {}, Edges: {}".format(stats["node_count"], stats["edge_count"]))
 `ContextGraph` exposes a full Distance Intelligence API for exploring semantic neighborhoods and blending proximity into retrieval.
 
 <Info>
-  Full Distance Intelligence reference — distance matrices, API endpoints, embedding cache, Explorer UI — is covered in the dedicated [Distance Intelligence](/reference/distance) page. This section documents the context-layer API.
+  Full Distance Intelligence reference (distance matrices, API endpoints, embedding cache, Explorer UI) is covered in the dedicated [Distance Intelligence](/reference/distance) page. This section documents the context-layer API.
 </Info>
 
 ### Neighbors with Distance Metadata
@@ -480,7 +480,7 @@ for n in neighbors:
 | Added field | Type | Description |
 | :---------- | :---- | :----------- |
 | `distance_band` | `str` | `"direct"` (1 hop) / `"near"` (2) / `"mid-range"` (3–4) / `"distant"` (5+) |
-| `confidence_decay` | `float` | `edge_weight ^ hop_count` — decays with each hop |
+| `confidence_decay` | `float` | `edge_weight ^ hop_count`; decays with each hop |
 | `path_to_anchor` | `List[str]` | Shortest path from anchor node to this neighbor |
 | `hop_count` | `int` | BFS depth from anchor |
 
@@ -659,7 +659,7 @@ if not receipt.complete:
 ```
 
 <Warning>
-Check the receipt — the call returning is not proof the data is gone. FAISS,
+Check the receipt. The call returning is not proof the data is gone. FAISS,
 Milvus, and Weaviate expose no delete method, so erasure cannot be completed on
 those backends today; the receipt reports `unsupported` rather than a success it
 did not achieve.
@@ -687,9 +687,9 @@ At least one store is required; a store that is not supplied reports
 
 | Status | Meaning |
 | :--- | :--- |
-| `erased` | Reached, data removed. On the vectors leg this means the store accepted the delete for the ids given — backends offer no portable existence check, so it is not a count of embeddings that were really there |
+| `erased` | Reached, data removed. On the vectors leg this means the store accepted the delete for the ids given; backends offer no portable existence check, so it is not a count of embeddings that were really there |
 | `not_found` | Reached, held nothing for this entity |
-| `not_configured` | No such store was bound — normal, not a failure |
+| `not_configured` | No such store was bound: normal, not a failure |
 | `unsupported` | The store cannot delete at all; retrying will not help |
 | `failed` | The store was reached and the deletion did not succeed |
 
@@ -721,7 +721,7 @@ receipt.to_dict()
 # }
 ```
 
-Erasure runs outward-in — vectors, then memory, then the graph. The tombstone is
+Erasure runs outward-in: vectors, then memory, then the graph. The tombstone is
 the durable attestation that an erasure happened, so it is written last: a crash
 mid-cascade leaves the node present and the receipt incomplete, rather than a
 tombstone claiming more than actually happened. A store that raises is recorded
@@ -1087,10 +1087,10 @@ class EntityLink:
   </Tab>
 </Tabs>
 
-- [Vector Store](/reference/vector_store) — Embedding storage backend for memory retrieval.
-- [Knowledge Graph](/reference/kg) — Graph algorithms and analytics used inside ContextGraph.
-- [Reasoning](reasoning) — Logical inference layered on top of context.
-- [Provenance](provenance) — W3C PROV-O lineage for every stored fact.
+- [Vector Store](/reference/vector_store): embedding storage backend for memory retrieval.
+- [Knowledge Graph](/reference/kg): graph algorithms and analytics used inside ContextGraph.
+- [Reasoning](/guides/reasoning): logical inference layered on top of context.
+- [Provenance](/guides/provenance): W3C PROV-O lineage for every stored fact.
 
-- [Context Module](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/19_Context_Module.ipynb) — Memory and decision tracking · Intermediate
-- [Advanced Context Engineering](https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/11_Advanced_Context_Engineering.ipynb) — Production FAISS + Neo4j setup · Advanced
+- [Context Module](https://github.com/semantica-agi/semantica/blob/main/cookbook/introduction/19_Context_Module.ipynb): memory and decision tracking · Intermediate
+- [Advanced Context Engineering](https://github.com/semantica-agi/semantica/blob/main/cookbook/advanced/11_Advanced_Context_Engineering.ipynb): production FAISS + Neo4j setup · Advanced


### PR DESCRIPTION
## Description

Second wave of the docs prose cleanup started in #1421 (index.md). This PR does three representative pages, one per content type, to establish the pattern before opening it up to contributors for the remaining ~80 pages:

- `docs/concepts.md`: the "Core Concepts" overview page
- `docs/guides/graphrag.md`: a representative `guides/*` page
- `docs/reference/context.md`: a representative `reference/*` API page

## Changes Made

- **Em dashes removed** from explanatory prose, headings, tab titles, and link lists across all three files, replaced with plain sentence structure or a colon depending on context.
- **Em dashes intentionally left** inside simulated document/alert string literals in `guides/graphrag.md` (fictional SOC runbook and SIEM alert text used as example data) since those represent someone else's writing style, not ours.
- **Two broken relative links fixed** in `reference/context.md`: `[Reasoning](reasoning)` and `[Provenance](provenance)` were missing their leading slash and would 404 on the live site (the trailing-slash redirect issue #1407 fixed sitewide). Corrected to `/guides/reasoning` and `/guides/provenance`.
- `concepts.md`'s intro picks up the "context and semantic layer" tagline from #1421, replacing the old "context and accountability layer" phrasing (the `**Accountability Layer**` sub-bullet name is unchanged, since that's a legitimate architectural term, not the headline tagline).
- No code examples, tables, parameter docs, or other technical content changed. `guides/graphrag.md` and `reference/context.md` were already close to the target style (dense, code-first, no narrative bloat); this pass only touched punctuation and a couple of dashes-as-list-separators.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

```
python docs_check.py
# pass  docs.json is valid JSON
# pass  All nav pages exist on disk
# pass  All internal Card hrefs resolve
# pass  No stale repo URLs
# pass  All reference pages have frontmatter
# pass  No known-wrong class names in reference pages
# pass  No Python 3.9+ type syntax in code blocks (3.8 compat)
# pass  All 27 modules present in index.md
# pass  All Mintlify JSX component tags are balanced
# pass  Mintlify export builds without errors
# All checks passed
```

## Breaking Changes: No

## Additional Notes

This establishes the reference style for a follow-up batch of contributor-facing issues covering the remaining `guides/*`, `reference/*`, `integrations/*`, and top-level pages.
