### PR TITLE
fix(explorer): serve entity_type from the ontology graph endpoint

### DIFF
--- a/explorer/src/workspaces/OntologyWorkspace/OntologyEditor.tsx
+++ b/explorer/src/workspaces/OntologyWorkspace/OntologyEditor.tsx
@@ -27,7 +27,6 @@ import {
 import { loadOntologyEntityOwner, loadOntologyGraph } from "./api";
 import type { OntologyGraphEdge, OntologyGraphNode } from "./api";
 import {
-  classifyNodeType,
   inferOntologyUri,
   isEditableEntityType,
   ONTOLOGY_MINIMAP_THEME,
@@ -153,8 +152,17 @@ function nodeLabel(node: OntologyGraphNode): string {
   return trimmed.split("#").pop() || trimmed.split("/").pop() || node.id;
 }
 
+// The backend's remaining kinds (concept, scheme, individual) have no editor
+// affordances, so they collapse into the read-only "external" kind.
 function classifyEditorNode(node: OntologyGraphNode): OntologyNodeData["entityType"] {
-  return classifyNodeType(node.type);
+  switch (node.entity_type) {
+    case "ontology":
+    case "class":
+    case "property":
+      return node.entity_type;
+    default:
+      return "external";
+  }
 }
 
 function layoutEditorNodes(inputNodes: OntologyNode[]): OntologyNode[] {

--- a/explorer/src/workspaces/OntologyWorkspace/OntologyEditor.tsx
+++ b/explorer/src/workspaces/OntologyWorkspace/OntologyEditor.tsx
@@ -152,8 +152,10 @@ function nodeLabel(node: OntologyGraphNode): string {
   return trimmed.split("#").pop() || trimmed.split("/").pop() || node.id;
 }
 
-// The backend's remaining kinds (concept, scheme, individual) have no editor
-// affordances, so they collapse into the read-only "external" kind.
+// The backend's remaining kinds (concept, scheme, individual, unknown) have no
+// editor affordances, so they collapse into the read-only "external" kind. That
+// reading belongs here rather than on the wire: "external reference material"
+// is what the editor does about an unnameable type, not what the type is.
 function classifyEditorNode(node: OntologyGraphNode): OntologyNodeData["entityType"] {
   switch (node.entity_type) {
     case "ontology":

--- a/explorer/src/workspaces/OntologyWorkspace/api.ts
+++ b/explorer/src/workspaces/OntologyWorkspace/api.ts
@@ -12,7 +12,9 @@ import type {
 export type OntologyGraphNode = {
   id: string;
   type: string;
-  entity_type?: string;
+  // Required: /graph always classifies. Optional here would make a producer
+  // that forgets read as a graph of read-only nodes rather than a type error.
+  entity_type: string;
   content?: string;
   properties?: Record<string, unknown>;
 };

--- a/explorer/src/workspaces/OntologyWorkspace/api.ts
+++ b/explorer/src/workspaces/OntologyWorkspace/api.ts
@@ -12,6 +12,7 @@ import type {
 export type OntologyGraphNode = {
   id: string;
   type: string;
+  entity_type?: string;
   content?: string;
   properties?: Record<string, unknown>;
 };

--- a/explorer/src/workspaces/OntologyWorkspace/ontologyEditorModel.ts
+++ b/explorer/src/workspaces/OntologyWorkspace/ontologyEditorModel.ts
@@ -20,31 +20,6 @@ export const ONTOLOGY_MINIMAP_THEME = {
   },
 } as const;
 
-// The backend emits node types in compact (owl:Class) or full IRI
-// (http://www.w3.org/2002/07/owl#Class) form; classification must accept both.
-const FULL_IRI_PREFIXES: Array<[string, string]> = [
-  ["http://www.w3.org/2002/07/owl#", "owl:"],
-  ["http://www.w3.org/2000/01/rdf-schema#", "rdfs:"],
-  ["http://www.w3.org/2004/02/skos/core#", "skos:"],
-];
-
-export function compactNodeType(type: string): string {
-  for (const [iri, prefix] of FULL_IRI_PREFIXES) {
-    if (type.startsWith(iri)) {
-      return `${prefix}${type.slice(iri.length)}`;
-    }
-  }
-  return type;
-}
-
-export function classifyNodeType(rawType: string): EditorEntityType {
-  const type = compactNodeType(rawType);
-  if (type === "owl:Ontology") return "ontology";
-  if (type === "owl:Class" || type === "rdfs:Class") return "class";
-  if (type.includes("Property")) return "property";
-  return "external";
-}
-
 function ownsByNamespace(entityUri: string, ontologyUri: string): boolean {
   const stem = ontologyUri.replace(/[/#]+$/, "");
   return entityUri === ontologyUri

--- a/explorer/tests/ontologyEditorModel.test.ts
+++ b/explorer/tests/ontologyEditorModel.test.ts
@@ -2,8 +2,6 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  classifyNodeType,
-  compactNodeType,
   inferOntologyUri,
   isEditableEntityType,
   ONTOLOGY_MINIMAP_THEME,
@@ -41,26 +39,4 @@ test("the ontology minimap has an explicit dark, high-contrast theme", () => {
   assert.equal(ONTOLOGY_MINIMAP_THEME.maskStrokeColor, "#5faeff");
   assert.equal(ONTOLOGY_MINIMAP_THEME.nodeStrokeColor, "#9acbff");
   assert.match(ONTOLOGY_MINIMAP_THEME.style.border, /#29435c/);
-});
-
-test("node types classify identically in compact and full IRI form", () => {
-  const cases: Array<[string, string, string]> = [
-    ["owl:Ontology", "http://www.w3.org/2002/07/owl#Ontology", "ontology"],
-    ["owl:Class", "http://www.w3.org/2002/07/owl#Class", "class"],
-    ["rdfs:Class", "http://www.w3.org/2000/01/rdf-schema#Class", "class"],
-    ["owl:ObjectProperty", "http://www.w3.org/2002/07/owl#ObjectProperty", "property"],
-    ["owl:DatatypeProperty", "http://www.w3.org/2002/07/owl#DatatypeProperty", "property"],
-    ["owl:AnnotationProperty", "http://www.w3.org/2002/07/owl#AnnotationProperty", "property"],
-  ];
-  for (const [compact, fullIri, expected] of cases) {
-    assert.equal(classifyNodeType(compact), expected, compact);
-    assert.equal(classifyNodeType(fullIri), expected, fullIri);
-  }
-  assert.equal(classifyNodeType("owl:NamedIndividual"), "external");
-  assert.equal(classifyNodeType("http://www.w3.org/2004/02/skos/core#Concept"), "external");
-});
-
-test("compactNodeType leaves unknown namespaces untouched", () => {
-  assert.equal(compactNodeType("https://example.org/custom#Thing"), "https://example.org/custom#Thing");
-  assert.equal(compactNodeType("owl:Class"), "owl:Class");
 });

--- a/semantica/explorer/routes/ontology.py
+++ b/semantica/explorer/routes/ontology.py
@@ -1946,7 +1946,15 @@ async def get_ontology_graph(
             str(edge.get("id", "")),
         )
     )
-    return OntologyGraphResponse(uri=uri, nodes=selected_nodes, edges=selected_edges)
+    # Annotate copies: session node dicts may be cached and shared with other callers.
+    return OntologyGraphResponse(
+        uri=uri,
+        nodes=[
+            {**node, "entity_type": _classify_node_type(node.get("type", ""))}
+            for node in selected_nodes
+        ],
+        edges=selected_edges,
+    )
 
 
 @router.get("/entity/{entity_uri:path}", response_model=EntityDetailResponse)

--- a/tests/explorer/test_ontology_subissue3.py
+++ b/tests/explorer/test_ontology_subissue3.py
@@ -219,7 +219,9 @@ def test_graph_and_entity_endpoints_agree_on_entity_type(client):
     }
 
     for uri in ("http://example.org/onto-a#Person", unrecognized_external):
-        detail = client.get(f"/api/ontology/entity/{uri}")
+        # The fragment has to survive the request or the path resolves to the
+        # parent ontology and the comparison silently passes on the wrong node.
+        detail = client.get(f"/api/ontology/entity/{quote(uri, safe='')}")
         assert detail.status_code == 200
         assert from_graph[uri] == detail.json()["entity_type"]
 

--- a/tests/explorer/test_ontology_subissue3.py
+++ b/tests/explorer/test_ontology_subissue3.py
@@ -159,12 +159,32 @@ def test_ontology_graph_returns_editable_schema_nodes_and_edges(client):
 def test_ontology_graph_nodes_carry_entity_type_for_compact_and_full_iri_types(client):
     graph = client.app.state.session.graph
     full_iri_class = "http://example.org/onto-a#Organization"
+    full_iri_property = "http://example.org/onto-a#employs"
+    full_iri_ontology = "http://example.org/full-iri-onto"
+    unrecognized_external = "http://vocab.example/Widget"
     graph.add_node(
         full_iri_class,
         node_type="http://www.w3.org/2002/07/owl#Class",
         content="Organization",
         scheme_uri="http://example.org/onto-a",
     )
+    graph.add_node(
+        full_iri_property,
+        node_type="http://www.w3.org/2002/07/owl#ObjectProperty",
+        content="employs",
+        scheme_uri="http://example.org/onto-a",
+    )
+    graph.add_node(
+        full_iri_ontology,
+        node_type="http://www.w3.org/2002/07/owl#Ontology",
+        content="Full IRI Ontology",
+        scheme_uri="http://example.org/onto-a",
+    )
+    # An outward reference to a node whose type is outside the schema
+    # vocabulary. /graph reports the classifier's verdict verbatim; reading it
+    # as "external reference material" is the editor's job, not the wire's.
+    graph.add_node(unrecognized_external, node_type="ex:Widget", content="Widget")
+    graph.add_edge(full_iri_property, unrecognized_external, edge_type="rdfs:range")
 
     response = client.get(
         "/api/ontology/graph",
@@ -177,6 +197,31 @@ def test_ontology_graph_nodes_carry_entity_type_for_compact_and_full_iri_types(c
     assert entity_types["http://example.org/onto-a#Person"] == "class"
     assert entity_types[full_iri_class] == "class"
     assert entity_types["http://example.org/onto-a#name"] == "property"
+    assert entity_types[full_iri_property] == "property"
+    assert entity_types[full_iri_ontology] == "ontology"
+    assert entity_types[unrecognized_external] == "unknown"
+
+
+def test_graph_and_entity_endpoints_agree_on_entity_type(client):
+    graph = client.app.state.session.graph
+    unrecognized_external = "http://vocab.example/Widget"
+    graph.add_node(unrecognized_external, node_type="ex:Widget", content="Widget")
+    graph.add_edge(
+        "http://example.org/onto-a#name", unrecognized_external, edge_type="rdfs:range"
+    )
+
+    graph_response = client.get(
+        "/api/ontology/graph", params={"uri": "http://example.org/onto-a"}
+    )
+    assert graph_response.status_code == 200
+    from_graph = {
+        node["id"]: node["entity_type"] for node in graph_response.json()["nodes"]
+    }
+
+    for uri in ("http://example.org/onto-a#Person", unrecognized_external):
+        detail = client.get(f"/api/ontology/entity/{uri}")
+        assert detail.status_code == 200
+        assert from_graph[uri] == detail.json()["entity_type"]
 
 
 def test_ontology_graph_rejects_unregistered_namespace(client):

--- a/tests/explorer/test_ontology_subissue3.py
+++ b/tests/explorer/test_ontology_subissue3.py
@@ -156,6 +156,29 @@ def test_ontology_graph_returns_editable_schema_nodes_and_edges(client):
     )
 
 
+def test_ontology_graph_nodes_carry_entity_type_for_compact_and_full_iri_types(client):
+    graph = client.app.state.session.graph
+    full_iri_class = "http://example.org/onto-a#Organization"
+    graph.add_node(
+        full_iri_class,
+        node_type="http://www.w3.org/2002/07/owl#Class",
+        content="Organization",
+        scheme_uri="http://example.org/onto-a",
+    )
+
+    response = client.get(
+        "/api/ontology/graph",
+        params={"uri": "http://example.org/onto-a"},
+    )
+
+    assert response.status_code == 200
+    entity_types = {node["id"]: node["entity_type"] for node in response.json()["nodes"]}
+    assert entity_types["http://example.org/onto-a"] == "ontology"
+    assert entity_types["http://example.org/onto-a#Person"] == "class"
+    assert entity_types[full_iri_class] == "class"
+    assert entity_types["http://example.org/onto-a#name"] == "property"
+
+
 def test_ontology_graph_rejects_unregistered_namespace(client):
     response = client.get(
         "/api/ontology/graph",


### PR DESCRIPTION
## Summary

Implements #1433. The node-type vocabulary existed twice — backend `_CLASS_TYPES`/`_URI_PREFIX_MAP`/`_classify_node_type()` and a frontend copy (`classifyNodeType`/`compactNodeType`/`FULL_IRI_PREFIXES`) added as a hotfix during #1278 review — and had already drifted once (the compact vs full-IRI misclassification).

- `/api/ontology/graph` nodes now carry a server-computed `entity_type`, emitted from `_classify_node_type()` verbatim so it is the same classifier **and the same wire vocabulary** as `/entity/{uri}`; the response builds copies so session-cached dicts are never mutated
- `classifyEditorNode` switches on `node.entity_type`, mapping `ontology`/`class`/`property` through and collapsing the remaining kinds (`concept`/`scheme`/`individual`/`unknown`) into read-only `"external"`. "External reference material" is what the editor *does* about a type it has no affordances for, so that reading stays in the editor rather than being baked into the wire
- `entity_type` is **required** on `OntologyGraphNode`. Optional would make a producer that forgets the field render as a graph of silently read-only nodes instead of failing `tsc`
- Frontend classification logic and its IRI-prefix table are deleted; the compact/full-IRI classification matrix test moves to the backend response (`test_ontology_graph_nodes_carry_entity_type_for_compact_and_full_iri_types`), and a new `test_graph_and_entity_endpoints_agree_on_entity_type` pins the two endpoints to the same answer for the same node

## Behavior change

Not quite "behavior unchanged", contrary to an earlier revision of this description — thanks to @zeekay for catching it.

The deleted `classifyNodeType` returned `property` for **any** type whose string contained `"Property"`, so an external node typed e.g. `ex:HasProperty` was rendered editable. The backend classifier recognizes only the exact OWL/RDFS property types, so such a node is now read-only. That is the better answer — an external term should not be editable — but it is a change, not a no-op.

Everything the editor renders for in-vocabulary nodes is identical, and nothing locally created can reach the new `default:` branch: `classifyEditorNode` is only ever fed API nodes, while the Add Class / Add Individual paths set `entityType` directly.

## Verification

- `pytest tests/explorer -m "not integration"` — 326 passed, 1 skipped (DNS-pinning case, unbindable in this environment)
- `pytest tests/explorer/test_ontology_subissue3.py` — 48 passed
- `npm run test:graph-workspace` 105/105 (108 on `main`, minus the two frontend classification tests this moves to the backend), `tsc -b` clean, `eslint` 75 problems — identical to the `main` baseline

Rebased onto `main` (`ec55385b`). #1441 landed the `_known_ontology_uris`/`_collect_core_nodes`/`_select_structure_edges` helpers where the removed `_graph_entity_type` sat; that was a placement collision only. #1439 is also in flight against `OntologyEditor.tsx`/`ontologyEditorModel.ts`.

Closes #1433

🤖 Generated with [Claude Code](https://claude.com/claude-code)
