### PR TITLE
docs(reasoning): clarify Datalog query result ordering

### DIFF
--- a/docs/reference/reasoning.md
+++ b/docs/reference/reasoning.md
@@ -323,7 +323,7 @@ all_facts = datalog.derive_all()
 
 # Query with variable pattern: variables start with uppercase or ?
 results = datalog.query("ancestor(alice, ?Z)")
-# → [{"Z": "bob"}, {"Z": "charlie"}, {"Z": "dave"}]
+# → {"Z": "bob"}, {"Z": "charlie"}, {"Z": "dave"} (order not guaranteed)
 
 # Clear and start over
 datalog.clear()

--- a/docs/reference/reasoning.md
+++ b/docs/reference/reasoning.md
@@ -323,7 +323,7 @@ all_facts = datalog.derive_all()
 
 # Query with variable pattern: variables start with uppercase or ?
 results = datalog.query("ancestor(alice, ?Z)")
-# → {"Z": "bob"}, {"Z": "charlie"}, {"Z": "dave"} (order not guaranteed)
+# → a list of binding dicts: [{"Z": "bob"}, {"Z": "charlie"}, {"Z": "dave"}] (order not guaranteed)
 
 # Clear and start over
 datalog.clear()


### PR DESCRIPTION
Audited `docs/reference/reasoning.md` against the current `semantica.reasoning` implementation.

The only issue was the `datalog.query("ancestor(alice, ?Z)")` example. It showed the results in a fixed order but Datalog query results are set-backed, so their order isn't guaranteed.

Updated the example comment so it doesn't imply a deterministic result order.
