### PR TITLE
docs(ontology): document quality gate thresholds

### DIFF
--- a/docs/reference/ontology.md
+++ b/docs/reference/ontology.md
@@ -105,6 +105,15 @@ if not report.passed:
         print(issue.code, issue.message)
 ```
 
+The available gate controls are:
+
+| Threshold | Default | Meaning |
+| :-------- | :------ | :------ |
+| `min_coverage` | `0.0` | Minimum required `coverage` value (the average of class and property coverage, from 0.0 to 1.0). |
+| `max_errors` | `0.0` | Maximum number of `error` or `critical` issues allowed. |
+| `max_warnings` | `None` (unlimited) | Maximum number of `warning` issues allowed. Warnings alone do not fail the gate when unset. |
+| `fail_on_warnings` | `False` | Separate gate flag; when enabled, any warning fails the gate. It is not a `thresholds` key. |
+
 The report checks class/property coverage, orphan schema elements, domain and
 range references, and unresolved KG relationship endpoints. It includes
 machine-readable issue codes, severity, counts, metrics, and threshold

--- a/docs/reference/ontology.md
+++ b/docs/reference/ontology.md
@@ -109,10 +109,10 @@ The available gate controls are:
 
 | Threshold | Default | Meaning |
 | :-------- | :------ | :------ |
-| `min_coverage` | `0.0` | Minimum required `coverage` value (the average of class and property coverage, from 0.0 to 1.0). |
-| `max_errors` | `0.0` | Maximum number of `error` or `critical` issues allowed. |
+| `min_coverage` | `0.0` | Minimum required `coverage` value (the average of class and property coverage, from 0.0 to 1.0). The report fails when actual coverage is lower. |
+| `max_errors` | `0.0` | Maximum number of `error` or `critical` issues allowed. The report fails when the count exceeds this value. |
 | `max_warnings` | `None` (unlimited) | Maximum number of `warning` issues allowed. Warnings alone do not fail the gate when unset. |
-| `fail_on_warnings` | `False` | Separate gate flag; when enabled, any warning fails the gate. It is not a `thresholds` key. |
+| `fail_on_warnings` | `False` | Separate constructor/call flag; when enabled, any warning fails the gate. It is not a `thresholds` key. |
 
 The report checks class/property coverage, orphan schema elements, domain and
 range references, and unresolved KG relationship endpoints. It includes


### PR DESCRIPTION
## Description

Adds the quality gate threshold table requested in the follow-up to #1397, including the supported controls, defaults, and pass/fail behavior.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Related Issues

Related PR: #1397

Closes #
Fixes #

## Changes Made

- Documents the defaults and meaning of min_coverage, max_errors, and max_warnings.
- Clarifies that fail_on_warnings is a separate flag.
- Explains the warning behavior when max_warnings is unset.

## Testing

- [x] Tested locally
- [x] Updated relevant documentation
- [x] Package builds successfully (python -m build)
- [ ] Added tests for new functionality

### Test Commands

    python docs_check.py
    python -m build

## Breaking Changes

No.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the relevant documentation
- [x] My changes generate no new warnings
- [x] Package builds successfully

## Additional Notes

This is a documentation-only follow-up to the threshold clarification requested on #1397. The repository docs checker passed its content checks; its Mintlify export check is blocked by the local Node.js 26 runtime, which Mintlify does not support.
