### PR TITLE
docs(contributing): tighten prose and use developer-first guidance

### DIFF
--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -66,12 +66,12 @@ Production deployments span regulated and high-stakes industries where AI accoun
     | :-------- | :---- |
     | **OpenAI** | GPT-4o, GPT-4, GPT-3.5 |
     | **Anthropic** | Claude Opus, Sonnet, Haiku |
-    | **Google Gemini** |: |
+    | **Google Gemini** | Gemini Pro and other Gemini models |
     | **Groq** | LLaMA, Mixtral (fast inference) |
     | **Ollama** | Fully local, air-gapped |
-    | **HuggingFace** |: |
-    | **DeepSeek** |: |
-    | **Novita AI** |: |
+    | **HuggingFace** | Transformers-based local LLM models |
+    | **DeepSeek** | deepseek-chat and reasoning models |
+    | **Novita AI** | OpenAI-compatible gateway, DeepSeek-V3.2 default |
     | **LiteLLM** | 100+ model gateway |
   </Tab>
   <Tab title="NLP Libraries">

--- a/docs/community-projects.md
+++ b/docs/community-projects.md
@@ -67,7 +67,7 @@ Production deployments span regulated and high-stakes industries where AI accoun
     | **OpenAI** | GPT-4o, GPT-4, GPT-3.5 |
     | **Anthropic** | Claude Opus, Sonnet, Haiku |
     | **Google Gemini** |: |
-    | **Groq** | LLaMA, Mixtral: fast inference |
+    | **Groq** | LLaMA, Mixtral (fast inference) |
     | **Ollama** | Fully local, air-gapped |
     | **HuggingFace** |: |
     | **DeepSeek** |: |
@@ -114,7 +114,7 @@ See [Architecture](/architecture#extension-points) for the full extension guide.
 
 ## How to Contribute
 
-- [Contributing Guide](/contributing-guide) — Submit code, documentation, tests, or cookbook notebooks.
-- [GitHub Issues](https://github.com/semantica-agi/semantica/issues) — Report bugs, request features, or propose integrations.
-- [Discord](https://discord.gg/sV34vps5hH) — Share what you're building with the community.
-- [GitHub Discussions](https://github.com/semantica-agi/semantica/discussions) — Long-form questions, design discussions, and ideas.
+- [Contributing Guide](/contributing-guide): submit code, documentation, tests, or cookbook notebooks.
+- [GitHub Issues](https://github.com/semantica-agi/semantica/issues): report bugs, request features, or propose integrations.
+- [Discord](https://discord.gg/sV34vps5hH): share what you're building with the community.
+- [GitHub Discussions](https://github.com/semantica-agi/semantica/discussions): long-form questions, design discussions, and ideas.

--- a/docs/contributing-guide.md
+++ b/docs/contributing-guide.md
@@ -4,7 +4,7 @@ description: "How to contribute code, documentation, tests, and community suppor
 icon: "code-pull-request"
 ---
 
-Contributions of all kinds are welcome: code, documentation, tests, and community support. Every contribution is recognized in release notes and the GitHub contributors list.
+Contributions of all kinds are welcome (code, documentation, tests, and community support). Every contribution is recognized in release notes and the GitHub contributors list.
 
 
 ## Quick Start
@@ -17,15 +17,15 @@ pip install -e ".[dev]"
 pytest
 ```
 
-New to the project? Start with [`good-first-issue`](https://github.com/semantica-agi/semantica/labels/good-first-issue) labeled tickets: they're scoped to be completable in a few hours without deep codebase knowledge.
+First-time contributors can start with [`good-first-issue`](https://github.com/semantica-agi/semantica/labels/good-first-issue) labeled tickets, which are scoped to be completable in a few hours without deep codebase knowledge.
 
 
 ## Ways to Contribute
 
-- **Code** — Fix bugs, implement features, optimize performance, or add new ingestors, parsers, and exporters using the plugin registry.
-- **Documentation** — Fix typos, improve clarity, add missing examples, write tutorials, or keep the API reference accurate as modules evolve.
-- **Testing** — Add test coverage for untested modules or edge cases, reproduce reported bugs with minimal repros, or improve cross-platform reliability.
-- **Community** — Answer questions in GitHub Issues and Discussions, review pull requests with constructive feedback, or share Semantica in blog posts and talks.
+- **Code**: fix bugs, implement features, optimize performance, or add new ingestors, parsers, and exporters using the plugin registry.
+- **Documentation**: fix typos, improve clarity, add missing examples, write tutorials, or keep the API reference accurate as modules evolve.
+- **Testing**: add test coverage for untested modules or edge cases, reproduce reported bugs with minimal repros, or improve cross-platform reliability.
+- **Community**: answer questions in GitHub Issues and Discussions, review pull requests with constructive feedback, or share Semantica in blog posts and talks.
 
 
 ## Development Setup
@@ -76,7 +76,7 @@ Before submitting a PR, confirm:
 
 ## Code of Conduct
 
-All contributors are expected to follow the [Contributor Covenant Code of Conduct](https://github.com/semantica-agi/semantica/blob/main/CODE_OF_CONDUCT.md). Be respectful, patient, and constructive: especially toward newcomers. Report violations by opening an issue with the `[CoC]` prefix.
+All contributors are expected to follow the [Contributor Covenant Code of Conduct](https://github.com/semantica-agi/semantica/blob/main/CODE_OF_CONDUCT.md). Be respectful, patient, and constructive, especially toward newcomers. Report violations by opening an issue with the `[CoC]` prefix.
 
 
 ## Help
@@ -85,5 +85,5 @@ All contributors are expected to follow the [Contributor Covenant Code of Conduc
 - [GitHub Discussions](https://github.com/semantica-agi/semantica/discussions)
 - [Discord](https://discord.gg/sV34vps5hH)
 
-- [Community](/community) — Community guidelines and values.
-- [Governance](/governance) — How decisions are made and the project is run.
+- [Community](/community): community guidelines and values.
+- [Governance](/governance): how decisions are made and the project is run.


### PR DESCRIPTION
## Description

This PR tightens the prose in contributing-guide and community-projects to improve clarity, readability, and conciseness for users and contributors. 

## Changes Made

We have reviewed and refined the text in the following documentation files:
*   `docs/community-projects.md`
*   `docs/contributing-guide.md`


## Testing

*   Verified documentation formatting and verified locally via the `agy` CLI. All checks completed successfully.

Closes #1426

## Documentation

- [X] Updated relevant documentation
- [ ] Added code examples if applicable
- [ ] Updated API reference if adding new APIs
- [ ] Updated cookbook if adding new examples
- [ ] No documentation changes needed

## Breaking Changes

**Breaking Changes**: No
<!-- If yes, describe the impact and migration path -->

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] Package builds successfully

## Additional Notes

<!-- Any additional information for reviewers -->
