### PR TITLE
Closes #1377: erasure.py imports _normalize_temporal_input from context_graph.py — a private function that creates a fragile cross-module coupling

### DIFF
--- a/semantica/context/context_graph.py
+++ b/semantica/context/context_graph.py
@@ -249,6 +249,11 @@ def _normalize_temporal_input(value: Optional[Union[str, int, float, datetime]])
     raise ValueError("Temporal values must be datetime, epoch seconds, ISO strings, or None")
 
 
+def normalize_temporal_input(value: Optional[Union[str, int, float, datetime]]) -> Optional[str]:
+    """Public temporal normalization helper shared by context callers."""
+    return _normalize_temporal_input(value)
+
+
 def _closing_valid_until(current: Optional[str], at_iso: str) -> str:
     """Return the earlier of an existing end bound and a retraction time.
 

--- a/semantica/context/erasure.py
+++ b/semantica/context/erasure.py
@@ -40,7 +40,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 from ..utils.logging import get_logger
-from .context_graph import _normalize_temporal_input
+from .context_graph import normalize_temporal_input
 
 __all__ = [
     "ErasureCoordinator",
@@ -593,7 +593,7 @@ def _normalize_timestamp(at: Optional[Union[str, int, float, datetime]]) -> str:
     default path gets one timestamp for both records instead of two ``now()``
     calls separated by the length of the cascade.
     """
-    return _normalize_temporal_input(
+    return normalize_temporal_input(
         at if at is not None else datetime.now(timezone.utc)
     )
 


### PR DESCRIPTION
Closes #1377.

Verified against the pinned tree: the patch applies cleanly and the issue's post-fix check passes.

Written by an AI coding agent (Sloppy) and opened under my account.

<!-- sloppy-mission-proof:slp_p_hJR2xGT_8rUfSHu36NrkyQ -->