### PR TITLE
Closes #1376: Title: ErasureReceipt.to_dict() performs a shallow copy — nested dicts in backend_result are shared by reference with the live receipt

### DIFF
--- a/semantica/context/erasure.py
+++ b/semantica/context/erasure.py
@@ -34,6 +34,7 @@ Example:
     'unsupported'
 """
 
+import copy
 import inspect
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -123,7 +124,9 @@ class ErasureReceipt:
             "reason": self.reason,
             "erased_at": self.erased_at,
             "complete": self.complete,
-            "stores": {name: dict(result) for name, result in self.stores.items()},
+            "stores": {
+                name: copy.deepcopy(result) for name, result in self.stores.items()
+            },
         }
 
 

--- a/tests/context/test_erasure_coordinator.py
+++ b/tests/context/test_erasure_coordinator.py
@@ -399,6 +399,24 @@ class TestReceipt(unittest.TestCase):
 
         self.assertEqual(receipt.stores["graph"]["status"], STATUS_ERASED)
 
+    def test_to_dict_copies_nested_store_results(self):
+        receipt = ErasureReceipt(
+            entity_id="customer-4471",
+            stores={
+                "vectors": {
+                    "status": STATUS_ERASED,
+                    "backend_result": {"status": "completed"},
+                }
+            },
+        )
+
+        payload = receipt.to_dict()
+        payload["stores"]["vectors"]["backend_result"]["status"] = "redacted"
+
+        self.assertEqual(
+            receipt.stores["vectors"]["backend_result"]["status"], "completed"
+        )
+
     def test_receipt_and_tombstone_agree_on_when_the_erasure_happened(self):
         graph = _graph()
         receipt = ErasureCoordinator(graph=graph).erase_entity(


### PR DESCRIPTION
Closes #1376.

Verified against the pinned tree: the patch applies cleanly and the issue's post-fix check passes.
**Scope:** this repository does not build as a whole in the sandbox that produced this, so the check ran over the packages this patch touches and their dependencies. The rest of the repository was not built or tested here - please treat CI as the first check over the whole tree.

Written by an AI coding agent (Sloppy) and opened under my account.

<!-- sloppy-mission-proof:slp_p_3CEv_jpbOX2Vn1nv3nHG1g -->