### PR TITLE
Closes #1423: docs: tighten prose in guides/* pages

### DIFF
--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -8,7 +8,7 @@ icon: "plug"
 
 MCP stands for the Model Context Protocol. It is an open standard that allows external AI assistants (like Claude Desktop, Cursor, or Windsurf) to securely access local tools and data sources. 
 
-The Semantica MCP server exposes your knowledge graph as 12 callable tools. By connecting it, any compatible AI client can traverse the graph live, record decisions, run analytics, and export results during a conversation — without you having to write custom tool wrappers.
+The Semantica MCP server exposes your knowledge graph as 12 callable tools. By connecting it, any compatible AI client can traverse the graph live, record decisions, run analytics, and export results during a conversation without custom tool wrappers.
 
 <Info>
   The Semantica MCP server exposes 15 tools and 3 read-only resources. All tools accept and return JSON. No configuration beyond an optional environment variable for graph persistence is required.
@@ -22,14 +22,14 @@ Instead, the AI client launches `semantica-mcp` locally as a subprocess. All com
 
 ## Why Use MCP With Semantica?
 
-- **Zero-Code Integration**: Instantly connect Semantica's graph capabilities to your favorite AI IDE or desktop chat app without writing any glue code.
-- **Real-Time Graph Updates**: Chat with an AI to extract entities from documents and watch them populate your live knowledge graph instantly.
-- **Auditable AI**: Use the AI to make decisions and have it automatically record the reasoning and causal chain directly into the graph via Semantica's decision intelligence tools.
+- **Zero-code integration.** Connect Semantica's graph capabilities to your AI IDE or desktop chat app without writing glue code.
+- **Real-time graph updates.** Chat with an AI to extract entities from documents and populate your live knowledge graph.
+- **Auditable AI.** Use the AI to make decisions and automatically record the reasoning and causal chain directly into the graph via Semantica's decision intelligence tools.
 
 ## When To Use / When Not To Use
 
-- **When to Use**: You want to use a third-party AI interface (like Claude Desktop or Windsurf) to manipulate, query, and reason over a Semantica knowledge graph on your local machine.
-- **When NOT to Use**: You are building an autonomous Python script or backend service. If you are writing Python code to build an agent, use `semantica.context.AgentContext` natively instead of spinning up an MCP server. The MCP server does not support remote hosting over HTTP/SSE.
+- **Use MCP when** you want a third-party AI interface, such as Claude Desktop or Windsurf, to manipulate, query, and reason over a Semantica knowledge graph on your local machine.
+- **Use `AgentContext` when** you are building an autonomous Python script or backend service. If you are writing Python code to build an agent, use `semantica.context.AgentContext` natively instead of spinning up an MCP server. The MCP server does not support remote hosting over HTTP/SSE.
 
 ---
 
@@ -61,7 +61,7 @@ semantica-mcp
 python -m semantica.mcp_server
 ```
 
-By default, the server logs at `WARNING` level and produces no startup output. Set `SEMANTICA_LOG_LEVEL=INFO` (or `DEBUG`) to see startup messages on stderr. Without `SEMANTICA_KG_PATH` the server initialises an empty in-memory graph — sufficient for testing. For a persistent graph that survives restarts, set the path:
+By default, the server logs at `WARNING` level and produces no startup output. Set `SEMANTICA_LOG_LEVEL=INFO` (or `DEBUG`) to see startup messages on stderr. Without `SEMANTICA_KG_PATH` the server initialises an empty in-memory graph. That is sufficient for testing. For a persistent graph that survives restarts, set the path:
 
 ```bash
 SEMANTICA_KG_PATH=/data/threat_graph.json semantica-mcp
@@ -73,7 +73,7 @@ SEMANTICA_KG_PATH=/data/threat_graph.json semantica-mcp
 
 ## Connecting to Claude Desktop
 
-Edit the Claude Desktop config file — on macOS at `~/Library/Application Support/Claude/claude_desktop_config.json`, on Windows at `%APPDATA%\Claude\claude_desktop_config.json`:
+Edit the Claude Desktop config file. On macOS it is at `~/Library/Application Support/Claude/claude_desktop_config.json`. On Windows it is at `%APPDATA%\Claude\claude_desktop_config.json`:
 
 ```json
 {
@@ -89,13 +89,13 @@ Edit the Claude Desktop config file — on macOS at `~/Library/Application Suppo
 }
 ```
 
-Restart Claude Desktop after saving. The Semantica tools appear in the tool palette automatically — Claude can now call them during any conversation.
+Restart Claude Desktop after saving. The Semantica tools appear in the tool palette automatically, and Claude can call them during any conversation.
 
 If `semantica-mcp` is not on your system PATH (for example, if it is installed in a virtualenv), use the full absolute binary path in `"command"`: `"/path/to/venv/bin/semantica-mcp"`.
 
 ## Connecting to Other Clients
 
-**Windsurf** — in Settings → MCP Servers → Add Server, or edit `~/.windsurf/mcp_servers.json`:
+**Windsurf.** In Settings → MCP Servers → Add Server, or edit `~/.windsurf/mcp_servers.json`:
 
 ```json
 {
@@ -106,7 +106,7 @@ If `semantica-mcp` is not on your system PATH (for example, if it is installed i
 }
 ```
 
-**VS Code (Cline / Roo Code / Continue)** — add to `.mcp.json` in your project root:
+**VS Code (Cline / Roo Code / Continue).** Add to `.mcp.json` in your project root:
 
 ```json
 {
@@ -134,19 +134,19 @@ docker run --rm -i \
 
 ## What the Agent Can Do: The 15 Tools
 
-Once connected, the LLM can call any of these tools during a conversation. The agent chains them automatically — you do not orchestrate the sequence, you just describe what you want.
+Once connected, the LLM can call any of these tools during a conversation. The agent chains them automatically. You describe what you want instead of orchestrating the sequence.
 
-**Entity and relation extraction** — `extract_entities` pulls named entities from free text; `extract_relations` extracts semantic relationships and RDF triplets. These two tools turn a raw OSINT report into structured graph inputs without any preprocessing.
+**Entity and relation extraction.** `extract_entities` pulls named entities from free text; `extract_relations` extracts semantic relationships and RDF triplets. These two tools turn a raw OSINT report into structured graph inputs without any preprocessing.
 
-**Knowledge graph manipulation** — `add_entity` adds a node, `add_relationship` adds a directed edge. After extraction, the agent calls these to persist what it found into the live graph.
+**Knowledge graph manipulation.** `add_entity` adds a node, `add_relationship` adds a directed edge. After extraction, the agent calls these to persist what it found into the live graph.
 
-**Live graph queries and edits** — `query_graph` reads the graph without exporting it: fetch one node, walk its neighbours up to five hops, or keyword-search nodes. `update_node` merges properties onto an existing node (for example marking a task node `done`), and `delete_node` archives a node it no longer tracks. When `SEMANTICA_KG_PATH` is set, `update_node` and `delete_node` write their changes back to that file so they survive a restart.
+**Live graph queries and edits.** `query_graph` reads the graph without exporting it: fetch one node, walk its neighbours up to five hops, or keyword-search nodes. `update_node` merges properties onto an existing node (for example marking a task node `done`), and `delete_node` archives a node it no longer tracks. When `SEMANTICA_KG_PATH` is set, `update_node` and `delete_node` write their changes back to that file so they survive a restart.
 
-**Decision intelligence** — `record_decision` writes a decision as a provenance node with confidence score, reasoning, and decision maker identity. `query_decisions` retrieves past decisions by query or category. `find_precedents` finds the most similar past decisions by semantic similarity. `get_causal_chain` traces decision causality upstream or downstream.
+**Decision intelligence.** `record_decision` writes a decision as a provenance node with confidence score, reasoning, and decision maker identity. `query_decisions` retrieves past decisions by query or category. `find_precedents` finds the most similar past decisions by semantic similarity. `get_causal_chain` traces decision causality upstream or downstream.
 
-**Reasoning** — `run_reasoning` applies forward-chaining IF/THEN rules over a set of facts and returns derived conclusions.
+**Reasoning.** `run_reasoning` applies forward-chaining IF/THEN rules over a set of facts and returns derived conclusions.
 
-**Analytics and export** — `get_graph_analytics` computes PageRank centrality and community detection. `get_graph_summary` returns node count, decision count, and server status. `export_graph` serializes the current graph to Turtle (`"turtle"` / `"ttl"`), RDF/XML (`"xml"`), N-Triples (`"nt"`), JSON-LD (`"json-ld"`), or plain JSON (`"json"`).
+**Analytics and export.** `get_graph_analytics` computes PageRank centrality and community detection. `get_graph_summary` returns node count, decision count, and server status. `export_graph` serializes the current graph to Turtle (`"turtle"` / `"ttl"`), RDF/XML (`"xml"`), N-Triples (`"nt"`), JSON-LD (`"json-ld"`), or plain JSON (`"json"`).
 
 ## Universal Example: Employee Directory
 
@@ -213,11 +213,11 @@ Claude chains six tool calls automatically:
    → { "format": "turtle", "data": "@prefix ... <apt29> a :ThreatActor ..." }
 ```
 
-The analyst asked one question in natural language. Six structured tool calls happened against live graph data. The result is a populated graph, a recorded attribution decision with full provenance, and a Turtle export ready for the SPARQL endpoint — all in a single conversation turn.
+The analyst asked one question in natural language. Six structured tool calls happened against live graph data. The result is a populated graph, a recorded attribution decision with full provenance, and a Turtle export ready for the SPARQL endpoint in a single conversation turn.
 
 ## The Three Read-Only Resources
 
-Resources expose graph state without a tool call — the client can read them at any point:
+Resources expose graph state without a tool call. The client can read them at any point:
 
 | URI | Description |
 | :-- | :---------- |
@@ -229,9 +229,9 @@ Resources expose graph state without a tool call — the client can read them at
 
 <Tabs>
 
-<Tab title="Defense — CTI/Threat">
+<Tab title="Defense - CTI/Threat">
 
-The CTI team uses Claude Desktop to correlate new OSINT reports against the existing threat graph, record attribution decisions, and query causal chains — all through natural language, with the graph updated live.
+The CTI team uses Claude Desktop to correlate new OSINT reports against the existing threat graph, record attribution decisions, and query causal chains through natural language, with the graph updated live.
 
 **Analyst prompt:**
 > "Extract entities from this Mandiant report on APT40, add them to the knowledge graph, find any past decisions about APT40 attribution, and record a new attribution decision with confidence 0.84."
@@ -260,9 +260,9 @@ The attribution is now a graph node linked to the OSINT evidence, searchable by 
 
 </Tab>
 
-<Tab title="Security — SOC/Incident">
+<Tab title="Security - SOC/Incident">
 
-During a live incident, the SOC uses Claude to reason over the graph, apply zero-trust policy rules, and record containment decisions with their causal chain — creating a real-time audit trail.
+During a live incident, the SOC uses Claude to reason over the graph, apply zero-trust policy rules, and record containment decisions with their causal chain, creating a real-time audit trail.
 
 **SOC analyst prompt:**
 > "Add WKSTN-047 and DC01 as hosts, add the lateral movement relationship between them, run reasoning to classify the severity, and record a containment decision."
@@ -280,7 +280,7 @@ The containment decision and its downstream effects are captured in the graph fo
 
 </Tab>
 
-<Tab title="Life Science — Clinical/Pharma">
+<Tab title="Life Science - Clinical/Pharma">
 
 Clinical AI assistants use the MCP server to record treatment decisions with provenance, retrieve guideline precedents, and export decision graphs for regulatory submission and MDT review.
 
@@ -291,14 +291,14 @@ Claude calls:
 
 1. `find_precedents(scenario="metformin with eGFR below 30", max_results=5)`
 2. `record_decision(category="treatment_modification", scenario="eGFR 28, current metformin 1000mg BD", reasoning="eGFR 28 is below the 30 mL/min/1.73m2 absolute contraindication threshold per BNF and NICE NG28", outcome="discontinue_metformin_switch_to_gliclazide", confidence=0.97, decision_maker="clinical_ai_v2")`
-3. `get_causal_chain(direction="upstream")` — surfaces the guideline node that drove the decision
-4. `export_graph(format="json-ld")` — produces the decision graph for MDT review
+3. `get_causal_chain(direction="upstream")` surfaces the guideline node that drove the decision
+4. `export_graph(format="json-ld")` produces the decision graph for MDT review
 
-The graph captures the decision, its guideline basis, and the causal chain — all retrievable for regulatory audit.
+The graph captures the decision, its guideline basis, and the causal chain. All are retrievable for regulatory audit.
 
 </Tab>
 
-<Tab title="Banking — Risk/Compliance">
+<Tab title="Banking - Risk/Compliance">
 
 Credit risk teams use the MCP server to record every lending decision with its reasoning chain, surface regulatory precedents, and export compliance graphs for Basel III model governance review.
 
@@ -307,10 +307,10 @@ Credit risk teams use the MCP server to record every lending decision with its r
 
 Claude calls:
 
-1. `record_decision(category="mortgage_origination", scenario="LTV 78%, DSTI 38%, credit score 714, first-time buyer", reasoning="LTV within 80% cap; DSTI 38% under stressed rate scenario breaches 35% guideline — conditional approval with LMI requirement", outcome="approved_conditional_lmi", confidence=0.89, decision_maker="credit_model_v3")`
+1. `record_decision(category="mortgage_origination", scenario="LTV 78%, DSTI 38%, credit score 714, first-time buyer", reasoning="LTV within 80% cap; DSTI 38% under stressed rate scenario breaches 35% guideline - conditional approval with LMI requirement", outcome="approved_conditional_lmi", confidence=0.89, decision_maker="credit_model_v3")`
 2. `find_precedents(scenario="mortgage approval borderline DSTI stress test", max_results=3)`
 3. `get_causal_chain(decision_id="...", direction="upstream", max_depth=5)`
-4. `export_graph(format="turtle")` — produces the decision provenance graph for model governance committee
+4. `export_graph(format="turtle")` produces the decision provenance graph for model governance committee
 
 The result is a fully auditable credit decision trail with precedent links, ready for SR 11-7 model risk governance review.
 
@@ -322,28 +322,28 @@ The result is a fully auditable credit decision trail with precedent links, read
 
 ## Common Pitfalls
 
-- **Treating MCP as an HTTP server**: Do not try to `curl` the MCP server or look for a port number. It communicates via `stdin/stdout` and waits for JSON-RPC messages from the parent AI client.
-- **Using relative paths for `SEMANTICA_KG_PATH`**: Because the AI client spawns the server as a subprocess, the working directory can be unpredictable. Always use absolute paths (e.g., `C:\Users\Name\graph.json` or `/Users/name/graph.json`) to avoid losing your data.
-- **Virtual environment PATH issues**: If you installed Semantica inside a Python virtual environment, Claude Desktop will not automatically find `semantica-mcp` on the global system PATH. You must provide the absolute path to the binary in the `"command"` field.
-- **Expecting remote hosting support**: Stdio-based MCP servers must run on the same local machine as the AI client. Remote execution over a network is not supported.
-- **Confusing MCP integration with `AgentContext`**: If you are writing your own Python code to orchestrate an LLM, do not use the MCP server. Use the `AgentContext` class natively within your code.
+- **Treating MCP as an HTTP server.** Do not try to `curl` the MCP server or look for a port number. It communicates via `stdin/stdout` and waits for JSON-RPC messages from the parent AI client.
+- **Using relative paths for `SEMANTICA_KG_PATH`.** Because the AI client spawns the server as a subprocess, the working directory can be unpredictable. Always use absolute paths (e.g., `C:\Users\Name\graph.json` or `/Users/name/graph.json`) to avoid losing your data.
+- **Virtual environment PATH issues.** If you installed Semantica inside a Python virtual environment, Claude Desktop will not automatically find `semantica-mcp` on the global system PATH. You must provide the absolute path to the binary in the `"command"` field.
+- **Expecting remote hosting support.** Stdio-based MCP servers must run on the same local machine as the AI client. Remote execution over a network is not supported.
+- **Confusing MCP integration with `AgentContext`.** If you are writing your own Python code to orchestrate an LLM, do not use the MCP server. Use the `AgentContext` class natively within your code.
 
 ---
 
 ## Troubleshooting
 
-**Server does not appear in Claude Desktop** — fully quit and reopen Claude Desktop after editing the config (closing the window is not enough). Verify the binary is on PATH: `which semantica-mcp` on Unix, `where semantica-mcp` on Windows. If using a virtualenv, use the absolute binary path in `"command"`. Set `SEMANTICA_LOG_LEVEL=DEBUG` and check stderr for startup errors.
+**Server does not appear in Claude Desktop.** Fully quit and reopen Claude Desktop after editing the config (closing the window is not enough). Verify the binary is on PATH: `which semantica-mcp` on Unix, `where semantica-mcp` on Windows. If using a virtualenv, use the absolute binary path in `"command"`. Set `SEMANTICA_LOG_LEVEL=DEBUG` and check stderr for startup errors.
 
-**Graph data not persisting between sessions** — set `SEMANTICA_KG_PATH` to an absolute file path. Without it, the graph is in-memory only and resets on every server restart.
+**Graph data not persisting between sessions.** Set `SEMANTICA_KG_PATH` to an absolute file path. Without it, the graph is in-memory only and resets on every server restart.
 
-**Tool calls returning empty results** — `get_graph_summary` returning `"node_count": 0` means the graph is empty. Populate it via `add_entity` and `add_relationship`, or run `extract_entities` on text first and then `add_entity` for each result.
+**Tool calls returning empty results.** `get_graph_summary` returning `"node_count": 0` means the graph is empty. Populate it via `add_entity` and `add_relationship`, or run `extract_entities` on text first and then `add_entity` for each result.
 
-**Permission errors on `SEMANTICA_KG_PATH`** — the server process needs read/write access to the file and its parent directory. If running inside Docker, verify the volume mount and file ownership.
+**Permission errors on `SEMANTICA_KG_PATH`.** The server process needs read/write access to the file and its parent directory. If running inside Docker, verify the volume mount and file ownership.
 
 ## Related Guides
 
-- [Reasoning & Rules](reasoning) — the engine behind the `run_reasoning` tool
-- [Decision Intelligence](/guides/decision-intelligence) — how decisions are stored as causal graph nodes
-- [Context Graphs](/guides/context-graphs) — the graph that `add_entity` and `add_relationship` write to
-- [Export & Serialization](export) — all export formats available via `export_graph`
-- [Ontology Management](ontology) — generate OWL ontologies from the graph built via MCP
+- [Reasoning & Rules](/guides/reasoning) - the engine behind the `run_reasoning` tool
+- [Decision Intelligence](/guides/decision-intelligence) - how decisions are stored as causal graph nodes
+- [Context Graphs](/guides/context-graphs) - the graph that `add_entity` and `add_relationship` write to
+- [Export & Serialization](/guides/export) - all export formats available via `export_graph`
+- [Ontology Management](/guides/ontology) - generate OWL ontologies from the graph built via MCP


### PR DESCRIPTION
Closes #1423.

This change touches only documentation, and the sandbox that produced it recognises no build system in this repository, so nothing was compiled or tested.
The patch applies cleanly to the pinned commit (`4568aeba2c00`).

Written by an AI coding agent (Sloppy) and opened under my account.

<!-- sloppy-mission-proof:slp_p_MD_r9VRQUjypopffTeQ5gA -->