### PR TITLE
fix: correct production env var to SEMANTICA_API_KEY (fixes #1429)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1543,7 +1543,7 @@ pip install semantica[watch]                # Directory file watcher
 pip install semantica[explorer]             # Knowledge Explorer dashboard
 ```
 
-For production deployments, use Docker or Kubernetes rather than a local `pip install`. Set `SEMANTICA_SECRET_KEY`, configure a persistent LPG graph store (Neo4j / FalkorDB / Apache AGE / AWS Neptune) and/or RDF triple store (Blazegraph / Apache Jena / Eclipse RDF4J), and point the vector store at a hosted backend (Qdrant / Pinecone). See [ARCHITECTURE.md](ARCHITECTURE.md) for the full deployment topology.
+For production deployments, use Docker or Kubernetes rather than a local `pip install`. Set `SEMANTICA_API_KEY`, configure a persistent LPG graph store (Neo4j / FalkorDB / Apache AGE / AWS Neptune) and/or RDF triple store (Blazegraph / Apache Jena / Eclipse RDF4J), and point the vector store at a hosted backend (Qdrant / Pinecone). See [ARCHITECTURE.md](ARCHITECTURE.md) for the full deployment topology.
 
 ```bash
 # From source


### PR DESCRIPTION
## Problem
Fixes #1429 — README production guidance tells users to set SEMANTICA_SECRET_KEY, which exists nowhere in the codebase.

## Root cause
README.md:1546 references SEMANTICA_SECRET_KEY. The Explorer auth code (semantica/explorer/dependencies.py:30) reads SEMANTICA_API_KEY, with SEMANTICA_ALLOW_ANONYMOUS=true as opt-out. A deploy following the README sets a silently ignored variable, then hits 503s or unintended anonymous mode.

## Fix
README.md: SEMANTICA_SECRET_KEY to SEMANTICA_API_KEY on the production line. 1-line docs-only diff.

## Verification
grep SEMANTICA_SECRET_KEY README.md shows 0 hits after fix. No code touched.