### PR TITLE
Closes #1428: semantica doctor: Note/Hint columns wrap into unreadable fragments at normal terminal width

### DIFF
--- a/semantica/cli.py
+++ b/semantica/cli.py
@@ -921,15 +921,17 @@ def doctor(cli_ctx: CLIContext, local_json: bool, deep_embeddings: bool) -> None
         tbl.add_column("Check",  style=_KEY, no_wrap=True, min_width=16)
         tbl.add_column("Status", no_wrap=True, min_width=6)
         tbl.add_column("Note",   style=_DIM)
-        tbl.add_column("Hint",   style=_DIM)
 
         icons = {"ok": f"[{_SUCCESS}] ✓[/{_SUCCESS}]",
                  "warn": f"[{_WARN_STY}] ⚠[/{_WARN_STY}]",
                  "fail": "[bold red] ✗[/bold red]"}
 
         errors = warns = 0
+        hints = []
         for lbl, st, note, hint in checks:
-            tbl.add_row(lbl, icons.get(st, st), note or "", hint or "")
+            tbl.add_row(lbl, icons.get(st, st), note or "")
+            if hint:
+                hints.append((lbl, hint))
             if st == "fail":
                 errors += 1
             elif st == "warn":
@@ -937,6 +939,13 @@ def doctor(cli_ctx: CLIContext, local_json: bool, deep_embeddings: bool) -> None
 
         console.print()
         console.print(tbl)
+        if hints:
+            console.print()
+            for lbl, hint in hints:
+                line = Text("  ")
+                line.append(f"{lbl}: ", style=_KEY)
+                line.append(hint, style=_DIM)
+                console.print(line)
         console.print()
         summary = (f"[{_SUCCESS}]All checks passed[/{_SUCCESS}]" if not errors and not warns
                    else f"[bold red]{errors} error(s)[/bold red]  [{_WARN_STY}]{warns} warning(s)[/{_WARN_STY}]")

--- a/tests/test_cli_foundation.py
+++ b/tests/test_cli_foundation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import click
 import pytest
 from click.testing import CliRunner, Result
+from rich.console import Console
 
 import semantica.cli as cli_module
 
@@ -379,6 +380,22 @@ def test_doctor_json_log_directory_check_is_not_false_failure(runner, monkeypatc
     checks = json.loads(result.output)
     log_check = next(item for item in checks if item["check"] == "Log directory")
     assert log_check["status"] == "ok"
+
+
+def test_doctor_terminal_output_keeps_remediation_hints_readable(runner, monkeypatch):
+    monkeypatch.setattr(
+        cli_module,
+        "console",
+        Console(width=80, force_terminal=False, color_system=None),
+    )
+    for key in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GROQ_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+
+    result = runner.invoke(cli_module.main, ["doctor"])
+
+    assert result.exit_code == 0
+    assert "OPENAI_API_KEY not set" in result.output
+    assert "export OPENAI_API_KEY=…" in result.output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1428.

Verified against the pinned tree: the patch applies cleanly and the issue's post-fix check passes.
**Scope:** this repository does not build as a whole in the sandbox that produced this, so the check ran over the packages this patch touches and their dependencies. The rest of the repository was not built or tested here - please treat CI as the first check over the whole tree.

Written by an AI coding agent (Sloppy) and opened under my account.

<!-- sloppy-mission-proof:slp_p_Gw5ozOKr_GLECaVUf7QPuw -->