### PR TITLE
fix: correct vector store installation extras

### DIFF
--- a/docs/reference/vector_store.md
+++ b/docs/reference/vector_store.md
@@ -160,7 +160,7 @@ No installation or API key required. FAISS requires `pip install faiss-cpu`.
   <Tab title="Pinecone">
 
 ```bash
-pip install "semantica[pinecone]"
+pip install "semantica[vectorstore-pinecone]"
 ```
 
 ```python
@@ -178,7 +178,7 @@ store = VectorStore(
   <Tab title="Weaviate">
 
 ```bash
-pip install "semantica[weaviate]"
+pip install "semantica[vectorstore-weaviate]"
 ```
 
 ```python
@@ -194,7 +194,7 @@ store = VectorStore(
   <Tab title="Qdrant">
 
 ```bash
-pip install "semantica[qdrant]"
+pip install "semantica[vectorstore-qdrant]"
 ```
 
 ```python
@@ -210,7 +210,7 @@ store = VectorStore(
   <Tab title="PgVector">
 
 ```bash
-pip install "semantica[pgvector]"
+pip install "semantica[vectorstore-pgvector]"
 ```
 
 ```python


### PR DESCRIPTION
## Summary

While working on **Qdrant integration issue #1521**, I reviewed the existing Semantica vector-store documentation to verify the installation command for the Qdrant integration.

During that review, I found that the backend installation examples in `docs/reference/vector_store.md` were using incorrect optional-dependency names.

### Changes

Updated the installation commands to use the actual optional-dependency names defined in `pyproject.toml`:

* `semantica[pinecone]` → `semantica[vectorstore-pinecone]`
* `semantica[weaviate]` → `semantica[vectorstore-weaviate]`
* `semantica[qdrant]` → `semantica[vectorstore-qdrant]`
* `semantica[pgvector]` → `semantica[vectorstore-pgvector]`

### Verification

* Verified the optional-dependency names against `pyproject.toml`.
* Confirmed the Qdrant implementation itself does not require changes.
* Relevant Qdrant tests passed: **31/31**.
* `git diff --check` passed.

This keeps the documentation aligned with the actual package extras and ensures users following the installation instructions can install the intended vector-store integrations.
