### PR TITLE
fix(cli): fail when kg build produces an empty knowledge graph

### DIFF
--- a/semantica/cli.py
+++ b/semantica/cli.py
@@ -328,8 +328,30 @@ def _run_build(cli_ctx: CLIContext, sources: Sequence[str]) -> None:
 
     stats = result.get("statistics", {}) if isinstance(result, dict) else {}
     processed = stats.get("sources_processed")
+
+    # A source count alone does not mean anything was built: with no pipeline
+    # configured the default pipeline passes its input through untouched, so
+    # every source is "processed" and the graph stays empty. Reporting success
+    # there hid the failure completely (#1352).
+    graph = result.get("knowledge_graph", {}) if isinstance(result, dict) else {}
+    entity_count = len(graph.get("entities") or [])
+    relationship_count = len(graph.get("relationships") or [])
+
+    if processed and not entity_count and not relationship_count:
+        raise click.ClickException(
+            f"{processed} source(s) processed but the knowledge graph is empty "
+            "— no entities or relationships were extracted. This usually means "
+            "no pipeline was configured, so the sources were read but never "
+            "parsed or extracted. Supply a pipeline with --config, or use "
+            "'semantica extract' to check the sources yield entities."
+        )
+
     if processed is not None:
-        _ok(cli_ctx, f"Knowledge base built — {processed} source(s) processed.")
+        _ok(
+            cli_ctx,
+            f"Knowledge base built — {processed} source(s) processed, "
+            f"{entity_count} entities, {relationship_count} relationships.",
+        )
     else:
         _ok(cli_ctx, "Knowledge base build completed.")
 


### PR DESCRIPTION
## Description

`semantica kg build --source <file>` printed `✓ Knowledge base built — 1 source(s) processed` and exited 0 while writing nothing, having logged `No entities or relationships found in results` immediately beforehand.

The source count was the only thing checked. With no pipeline configured the default pipeline is a single step with no handler, so the executor returns its input unchanged (`semantica/pipeline/execution_engine.py:692-695`) — every source is counted as "processed" while the graph stays empty.

This makes that state visible instead of reporting success. It does not change what the default pipeline does; that is the separate half of #1352.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Closes #1352

## Changes Made

- `kg build` now inspects the resulting graph, not just the source count. An empty graph after processing raises a `ClickException` naming the likely cause and pointing at `semantica extract` to check the input.
- The success message reports entity and relationship counts, so "1 source processed" can no longer stand in for "something was built".

## Testing

- [x] Tested locally

Before:

```
$ semantica kg build --source neutral.txt
WARNING - No entities or relationships found in results
 ✓ Knowledge base built — 1 source(s) processed.
$ echo $?
0
```

After:

```
$ semantica kg build --source neutral.txt
Error: 1 source(s) processed but the knowledge graph is empty — no entities or
relationships were extracted. This usually means no pipeline was configured, so
the sources were read but never parsed or extracted. Supply a pipeline with
--config, or use 'semantica extract' to check the sources yield entities.
$ echo $?
1
```

`python -m pytest tests/test_cli_commands.py -q`: 290 passed, 2 skipped. flake8 on `semantica/cli.py` unchanged from main.

## Scope

This is the "fail loudly" half. Making the default pipeline actually ingest/parse/extract is the larger behaviour decision raised on #1352 and is not attempted here — happy to follow up once you have picked a direction there.
