### PR TITLE
fix(cli): report the graph backend actually used, not a nonexistent memory one

### DIFF
--- a/semantica/cli.py
+++ b/semantica/cli.py
@@ -465,7 +465,7 @@ def _show_startup(cli_ctx: CLIContext) -> None:
         return
     cfg = cli_ctx.config.to_dict()
     graph_store = (
-        cli_ctx.store_backend or cfg.get("graph_db", {}).get("backend", "memory")
+        cli_ctx.store_backend or cfg.get("graph_db", {}).get("backend", "neo4j")
     )
     vector_store = (
         cli_ctx.vector_store_backend
@@ -851,9 +851,7 @@ def doctor(cli_ctx: CLIContext, local_json: bool, deep_embeddings: bool) -> None
         # Graph store reachability
         def _graph() -> str:
             cfg = cli_ctx.config.to_dict()
-            backend = cli_ctx.store_backend or cfg.get("graph_db", {}).get("backend", "memory")
-            if backend == "memory":
-                return "memory (always available)"
+            backend = cli_ctx.store_backend or cfg.get("graph_db", {}).get("backend", "neo4j")
             gs = _get_graph_store(cli_ctx)
             gs.ping() if hasattr(gs, "ping") else gs.connect()
             return f"{backend} reachable"


### PR DESCRIPTION
## Description

The CLI reported a graph-store backend that `GraphStore` cannot construct, and `doctor` returned a passing check for it:

```
$ semantica
  Graph Store      memory

$ semantica doctor
  Graph store      ✓   memory (always available)

$ semantica decision list
Neo4j is not available. Install it with: pip install neo4j
```

`GraphStore._initialize_store_backend()` only branches on `neo4j`, `falkordb`, `neptune` and `age`; `GraphStore(backend="memory")` raises `ValidationError: Unknown backend: memory`. The two reporting sites got away with claiming `memory` because they special-cased it and never built a store, while `_get_graph_store()` defaulted to `neo4j` and produced the error above.

This aligns the reporting with the backend that is actually used. It deliberately does **not** change `_get_graph_store()`'s default, so no existing setup changes behaviour.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Refs #1481

## Changes Made

- Status panel reports the backend that will actually be used (`neo4j` when unset) rather than `memory`.
- `doctor` no longer short-circuits on `memory` with a green "always available". It probes the resolved backend and reports the real result, so an unusable graph store is surfaced as a failure instead of a pass.

## Testing

- [x] Tested locally

After:

```
$ semantica
  Graph Store      neo4j

$ semantica doctor
  Graph store      ✗   Neo4j is not available
```

`python -m pytest tests/test_cli_commands.py -q`: 290 passed, 2 skipped. flake8 on `semantica/cli.py` unchanged from main.

## Scope

Deliberately partial, per the discussion on #1481. @KaifAhmad1's preference there is a real `MemoryGraphStore` with `_get_graph_store()` defaulting to it, which is the fix that makes all three call sites and the Python API genuinely agree. That needs a decision first — the backend contract includes Cypher (`DecisionQuery` issues `MATCH (d:Decision {category: $category}) RETURN d`, with 16 Cypher statements in that file and 72 `execute_query` call sites across `context/` and `kg/`), so a memory backend needs either an embedded Cypher engine or a subset interpreter.

This PR is the stopgap described in that thread: it stops `doctor` giving a green check for something no command can use, without pre-empting that decision. #1481 should stay open for the real backend.
