### PR TITLE
fix(ci): match pip-audit ignore list against vuln aliases, not just id

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -155,12 +155,20 @@ jobs:
 
           # Vulnerability IDs reviewed and accepted as non-actionable for this
           # project:
-          # - GHSA-4j2p-28q2-5m79: accelerate<=1.14.0 (transitive via docling-slim).
-          #   Path traversal in sharded checkpoint index loading (load_checkpoint_in_model).
-          #   1.14.0 is the latest available PyPI release; no upstream patch exists yet.
-          #   Semantica does not load arbitrary user checkpoints. Re-evaluate once
-          #   accelerate releases a fixed version.
-          IGNORED_VULN_IDS="GHSA-4j2p-28q2-5m79"
+          # - GHSA-4j2p-28q2-5m79 (aka CVE-2026-69112): accelerate<=1.14.0
+          #   (transitive via docling-slim). Path traversal in sharded checkpoint
+          #   index loading (load_checkpoint_in_model). 1.14.0 is the latest
+          #   available PyPI release; no upstream patch exists yet. Semantica does
+          #   not load arbitrary user checkpoints. Re-evaluate once accelerate
+          #   releases a fixed version.
+          #   NOTE: pip-audit's OSV-backed report may surface either identifier as
+          #   the primary `id` (with the other listed under `aliases`) depending on
+          #   which alias the backing database picks as canonical, so both need to
+          #   be listed here and the matching below checks aliases too - see
+          #   https://github.com/semantica-agi/semantica/actions/runs/34296586683
+          #   where this ignore list had only the GHSA id but the report's `id`
+          #   was the CVE, so the gate still failed.
+          IGNORED_VULN_IDS="GHSA-4j2p-28q2-5m79,CVE-2026-69112"
 
           # Exported so the "Comment PR with Security Results" step below can
           # apply the same exclusion list to the raw report - it reads
@@ -176,9 +184,16 @@ jobs:
           # no vulns field at all (see the skip_reason handling above) -
           # without the fallback, iterating `null[]` raises inside jq and
           # this whole computation silently evaluates to empty.
+          #
+          # Matching checks `.id` AND `.aliases` (pip-audit includes aliases by
+          # default for JSON output): the OSV-backed report can surface either
+          # the GHSA or the CVE identifier as the canonical `id` for the same
+          # advisory, with the other one demoted to an alias, so matching on
+          # `.id` alone is not reliable.
           VULNS=$(jq --arg ignored "$IGNORED_VULN_IDS" '
             ($ignored | split(",") | map(select(length > 0))) as $ignore_list
-            | [.dependencies[] | (.vulns // [])[] | select(.id as $id | ($ignore_list | index($id)) | not)]
+            | [.dependencies[] | (.vulns // [])[]
+               | select(([.id] + (.aliases // [])) as $ids | ($ids - $ignore_list | length) == ($ids | length))]
             | length
           ' pip-audit-report.json 2>/dev/null)
 
@@ -199,7 +214,8 @@ jobs:
             jq --arg ignored "$IGNORED_VULN_IDS" -r '
               ($ignored | split(",") | map(select(length > 0))) as $ignore_list
               | .dependencies[] as $dependency
-              | ($dependency.vulns // [])[] | select(.id as $id | ($ignore_list | index($id)) | not)
+              | ($dependency.vulns // [])[]
+              | select(([.id] + (.aliases // [])) as $ids | ($ids - $ignore_list | length) == ($ids | length))
               | "- \($dependency.name)==\($dependency.version): \(.id)"
             ' pip-audit-report.json || true
             exit 1
@@ -345,9 +361,16 @@ jobs:
                   return null;
                 }
 
+                // A vuln's canonical `id` and its `aliases` (e.g. GHSA vs. CVE
+                // for the same advisory) are checked together - mirrors the
+                // shell gate above, which needs the same fallback because
+                // pip-audit's OSV-backed report doesn't consistently pick the
+                // same identifier as canonical across advisories.
                 return data.dependencies.flatMap((dependency) =>
                   (dependency.vulns || [])
-                    .filter((vulnerability) => !ignoredVulnIds.includes(vulnerability.id))
+                    .filter((vulnerability) =>
+                      ![vulnerability.id, ...(vulnerability.aliases || [])].some((id) => ignoredVulnIds.includes(id))
+                    )
                     .map(
                       (vulnerability) => `- \`${dependency.name}==${dependency.version}\`: ${vulnerability.id}` +
                         (vulnerability.fix_versions?.length ? ` (fixed by ${vulnerability.fix_versions.join(', ')})` : '')

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,20 @@
+# OSV-Scanner ignore config (also consumed by OpenSSF Scorecard's
+# "Vulnerabilities" check, which reports advisories found in this repo's
+# dependency manifests via https://osv.dev).
+#
+# See https://github.com/google/osv-scanner#ignore-vulnerabilities-by-id for
+# the file format.
+
+[[IgnoredVulns]]
+id = "GHSA-4j2p-28q2-5m79"
+reason = """
+accelerate<=1.14.0 (transitive dependency via docling-slim, pinned in
+requirements-ci.txt) has an open path traversal / DoS advisory (also tracked
+as CVE-2026-69112) in load_checkpoint_in_model / load_checkpoint_and_dispatch,
+which fail to sanitize weight_map entries from sharded checkpoint indexes.
+1.14.0 is the latest release on PyPI; no patched version exists yet.
+Semantica does not call either function or load arbitrary/untrusted sharded
+checkpoints, so the vulnerable code path is not reachable. Re-evaluate once
+accelerate ships a fix - see .github/workflows/security-scan.yml for the
+matching pip-audit exclusion.
+"""


### PR DESCRIPTION
## Summary
- #1540 added `GHSA-4j2p-28q2-5m79` to `security-scan.yml`'s `IGNORED_VULN_IDS` to suppress the open, unpatched `accelerate<=1.14.0` path traversal advisory ([Dependabot #63](https://github.com/semantica-agi/semantica/security/dependabot/63), [CVE-2026-69112](https://nvd.nist.gov/vuln/detail/CVE-2026-69112)) — Semantica doesn't call `load_checkpoint_in_model`/`load_checkpoint_and_dispatch`, so the vulnerable code path is unreachable, and no patched `accelerate` release exists yet.
- That commit's own CI run still failed ([run 34296586683](https://github.com/semantica-agi/semantica/actions/runs/34296586683)): pip-audit's OSV-backed report picked `CVE-2026-69112` as the vuln's canonical `id` and demoted the GHSA id to an `aliases` entry, but the shell/JS matching only ever compared against `.id`.
- Fixes the gate, the "Vulnerability details" printer, and the PR-comment script to match against `.id` **and** `.aliases` (which pip-audit includes by default for JSON output), and lists both identifiers in `IGNORED_VULN_IDS`, so the exclusion holds regardless of which alias the report surfaces as canonical.
- Adds `osv-scanner.toml` (per the remediation steps on [code scanning alert #5713](https://github.com/semantica-agi/semantica/security/code-scanning/5713)) ignoring the same advisory with the same justification, so the weekly Scorecard "Vulnerabilities" check stops flagging it too.

## Test plan
- [x] Downloaded the actual failing `pip-audit-report.json` from run 34296586683 and re-ran the corrected jq filter against it locally — yields `VULNS = 0` (previously 1).
- [ ] CI (`Security Scan`) passes on this PR.
- [ ] After merge, next Scorecard run no longer reports the vulnerability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)