### PR TITLE
fix(explorer): remove stale 2030 temporal bound

### DIFF
--- a/explorer/src/workspaces/GraphWorkspace/plugins/temporalOverlayPlugin.tsx
+++ b/explorer/src/workspaces/GraphWorkspace/plugins/temporalOverlayPlugin.tsx
@@ -91,7 +91,7 @@ export const temporalOverlayPlugin: GraphPlugin = {
           <div style={detailRowStyle}>
             <span style={detailLabelStyle}>Bounds</span>
             <span style={detailValueStyle}>
-              {(temporal?.minDate ?? "1970")} → {(temporal?.maxDate ?? "2030")}
+              {(temporal?.minDate ?? "1970")} → {(temporal?.maxDate ?? "now")}
             </span>
           </div>
           <div style={detailRowStyle}>


### PR DESCRIPTION
## Description

Remove the stale `2030` fallback from the Temporal Context overlay when the temporal API returns an open-ended `max: null` bound.

The temporal scrubber now correctly treats an open-ended maximum as the present, but the overlay was still displaying `2030`. This changes the display fallback to `now`.

## Changes

* Replace the `2030` fallback with `now` in `temporalOverlayPlugin.tsx`.
* Preserve real `maxDate` values unchanged.
* No temporal timeline or backend behavior is changed.

## Testing

* `npm run test:graph-workspace` — 149/149 passed
* `npm run test:plugin-registry` — 7/7 passed
* `tsc -b --noEmit` — clean

Closes the stale UI representation left behind by the temporal scrubber fix.
