### PR TITLE
fix(explorer): label the graph view control "Focus"

### DIFF
--- a/explorer/src/workspaces/GraphWorkspace/GraphInspectorPanel.tsx
+++ b/explorer/src/workspaces/GraphWorkspace/GraphInspectorPanel.tsx
@@ -346,7 +346,7 @@ export function GraphInspectorPanel({
           <div style={{ color: GRAPH_THEME.ui.text.strong, fontWeight: 600, marginBottom: 6 }}>Selected item is not directly inspectable in the current graph.</div>
           <div style={{ color: GRAPH_THEME.ui.text.body, fontSize: 13, lineHeight: 1.6 }}>
             {canActivateFocused
-              ? "Activate Focused mode to resolve this grouped selection to its canonical node."
+              ? "Use Focus to resolve this grouped selection to its canonical node."
               : (focusedUnavailableReason ?? "Focused mode is unavailable for the current selection.")}
           </div>
         </div>

--- a/explorer/src/workspaces/GraphWorkspace/GraphWorkspace.tsx
+++ b/explorer/src/workspaces/GraphWorkspace/GraphWorkspace.tsx
@@ -2791,7 +2791,7 @@ export function GraphWorkspace({ externalFocusNodeId, externalFocusToken, onDirt
       },
       {
         id: "view-focused",
-        label: "Focused",
+        label: "Focus",
         title: canActivateFocusedMode
           ? "Inspect the selected node in a focused local graph"
           : (focusedSelectionResolution.reason ?? "Focused mode is unavailable for the current selection"),

--- a/explorer/tests/graphColorLegend.e2e.ts
+++ b/explorer/tests/graphColorLegend.e2e.ts
@@ -93,6 +93,11 @@ test("visible legend follows loaded data, reloads, focused views, and distance m
   assert.equal(await legend.getByText("Person", { exact: true }).count(), 0);
   await assertLegendMatchesGraph(page);
 
+  // getByRole matches the accessible name, so the visible text needs its own assertion.
+  const focus = page.getByRole("button", { name: "Focus", exact: true });
+  assert.equal(await focus.locator(".explore-tool-button-label").innerText(), "Focus");
+  assert.equal(await focus.isDisabled(), true, "Focus needs a selected node");
+
   await page.getByPlaceholder("Search command, node, or concept").fill("Alice");
   await page.getByRole("option").filter({ hasText: "Alice" }).click();
   const heatmap = page.getByRole("button", { name: "Heatmap", exact: true });
@@ -101,7 +106,9 @@ test("visible legend follows loaded data, reloads, focused views, and distance m
   await heatmap.click();
   await legend.waitFor();
   await assertLegendMatchesGraph(page);
-  await page.getByRole("button", { name: "Focused", exact: true }).click();
+  assert.equal(await focus.isDisabled(), false, "a selected node must enable Focus");
+  await focus.click();
+  assert.equal(await focus.getAttribute("data-active"), "true");
   await legend.getByText("Document", { exact: true }).waitFor({ state: "hidden" });
   await assertLegendMatchesGraph(page, ["alice", "acme", "research"]);
   assert.equal(await legend.getByText("Researcher", { exact: true }).count(), 1);

--- a/explorer/tests/graphColorLegend.e2e.ts
+++ b/explorer/tests/graphColorLegend.e2e.ts
@@ -93,11 +93,6 @@ test("visible legend follows loaded data, reloads, focused views, and distance m
   assert.equal(await legend.getByText("Person", { exact: true }).count(), 0);
   await assertLegendMatchesGraph(page);
 
-  // getByRole matches the accessible name, so the visible text needs its own assertion.
-  const focus = page.getByRole("button", { name: "Focus", exact: true });
-  assert.equal(await focus.locator(".explore-tool-button-label").innerText(), "Focus");
-  assert.equal(await focus.isDisabled(), true, "Focus needs a selected node");
-
   await page.getByPlaceholder("Search command, node, or concept").fill("Alice");
   await page.getByRole("option").filter({ hasText: "Alice" }).click();
   const heatmap = page.getByRole("button", { name: "Heatmap", exact: true });
@@ -106,9 +101,9 @@ test("visible legend follows loaded data, reloads, focused views, and distance m
   await heatmap.click();
   await legend.waitFor();
   await assertLegendMatchesGraph(page);
-  assert.equal(await focus.isDisabled(), false, "a selected node must enable Focus");
-  await focus.click();
-  assert.equal(await focus.getAttribute("data-active"), "true");
+  const focusButton = page.getByRole("button", { name: "Focus", exact: true });
+  assert.equal(await focusButton.isDisabled(), false, "Focus is enabled once a node is selected");
+  await focusButton.click();
   await legend.getByText("Document", { exact: true }).waitFor({ state: "hidden" });
   await assertLegendMatchesGraph(page, ["alice", "acme", "research"]);
   assert.equal(await legend.getByText("Researcher", { exact: true }).count(), 1);


### PR DESCRIPTION
## Summary

Implements #1551, assigned by @KaifAhmad1. The graph view control read **Focused** before the user had activated it — a state the selection appeared to have already reached, rather than the action available. It now reads **Focus**.

```diff
         id: "view-focused",
-        label: "Focused",
+        label: "Focus",
```

Preserved exactly as the issue asked: the internal `"focused"` view-mode value, the `title` tooltip on both paths, the selection-dependent `disabled` rule, and the `data-active` styling. The accessible name follows automatically — `aria-label={item.ariaLabel ?? item.label}` at `GraphWorkspace.tsx:238`, with no `ariaLabel` set for this item.

I chose **Focus** over **Focused View** per the issue's stated preference, since the control acts on the selected node. Happy to switch if maintainers prefer matching the neighbouring **Full Graph** / **Grouped View** labels.

## One string followed the label

`GraphInspectorPanel.tsx:349` told the reader to *"Activate Focused mode…"* — an instruction to press a control that no longer carries that name. It now reads *"Use Focus to resolve this grouped selection to its canonical node."*

The other six occurrences stay. They describe the *mode*, which is still called focused (`"Focused mode is unavailable for the current selection"`, `"Select a node to inspect in Focused mode."`), and the issue explicitly asked to leave descriptive text alone. The distinction I applied: an imperative naming the control follows the label; prose about the mode does not.

## The test change

`tests/graphColorLegend.e2e.ts` drove this button by accessible name, so the selector had to move with the label. That test runs in CI via `test:graph-legend-e2e`.

```ts
const focusButton = page.getByRole("button", { name: "Focus", exact: true });
assert.equal(await focusButton.isDisabled(), false, "Focus is enabled once a node is selected");
await focusButton.click();
```

The one added assertion turns a 10-second locator timeout into a named failure. I deliberately did **not** add label-text or `data-active` assertions here: `getByRole` already fails when the accessible name is wrong, so those would have been speculative coverage, and a test named for the colour legend should not own the control's contract.

## Verification

- `test:graph-legend-e2e` against real Chromium — passes. Restoring only the old label makes it **fail**, so the coverage is real.
- Ran three times consecutively to rule out flake: 3/3.
- Observed live with a stubbed six-node graph: toolbar reads `["Full Graph", "Grouped View", "Focus", …]`; disabled before selection, enabled after, `aria-label="Focus"`, `data-active="true"` after the click.
- `tsc -b` clean. `test:graph-workspace` 161, `test:graph-store` 1, `test:plugin-registry` 7. `eslint src tests` 75 problems, byte-identical to `main`.
- No test or doc referenced the changed hint string.

## Not changed

This control is a toggle rendered with `data-active` and no `aria-pressed`, so assistive technology cannot read its pressed state. That predates this change and applies to every toolbar toggle, so it does not belong in a wording PR. Happy to file it separately.

## Breaking changes

None. No API, no view-mode value, no behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)