### PR TITLE
docs(readme): note LLM use is optional and vendor-neutral

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ pip install semantica
 
 Most AI agents run on embeddings, not meaning: similarity scores with no structure, no relationships, and no way to explain why a result came back.
 
-Semantica is the semantic/context layer underneath your LLM, vector store, and agent framework: deterministic infrastructure (no LLM required for graph construction, reasoning, or provenance) that turns fragmented enterprise data into a structured, queryable Context Graph and knowledge graph that carries the business context, not just the data structure. Ontologies and controlled vocabularies (OWL, SHACL, SKOS) make what an entity *means* to your business, its definitions, relationships, and rules, as explicit as the data itself, not just its embedding.
+Semantica is the semantic/context layer underneath your LLM, vector store, and agent framework: deterministic infrastructure (no LLM required for graph construction, reasoning, or provenance; where an LLM is used, it's optional and vendor-neutral, every major provider supported, OpenAI, Anthropic, Gemini, and more, via `semantica.llms`) that turns fragmented enterprise data into a structured, queryable Context Graph and knowledge graph that carries the business context, not just the data structure. Ontologies and controlled vocabularies (OWL, SHACL, SKOS) make what an entity *means* to your business, its definitions, relationships, and rules, as explicit as the data itself, not just its embedding.
 
 Decision provenance and audit trails aren't the product. They fall out of that structure for free, and in domains a regulator can question, the same structure that makes your agent smarter also gives you a straight answer to "why."
 


### PR DESCRIPTION
## Summary
- Made explicit in the opening pitch that where Semantica does use an LLM, it's optional and vendor-neutral, every major provider supported (OpenAI, Anthropic, Gemini, and more) via `semantica.llms`, rather than tied to one vendor
- Kept it to a short mention, no LiteLLM name-drop here since it's already credited once in the Features table and once in Integrations

## Test plan
- [x] Visual diff review of README.md
