### PR TITLE
fix(vector-store): train PQ indexes in FAISSIndexBuilder

### DIFF
--- a/semantica/vector_store/faiss_store.py
+++ b/semantica/vector_store/faiss_store.py
@@ -514,9 +514,9 @@ class FAISSIndexBuilder:
         return FAISSIndex(index, self.dimension, index_type)
 
     def train_index(self, index: FAISSIndex, training_vectors: np.ndarray):
-        """Train index on sample vectors."""
-        if not isinstance(index.index, faiss.IndexIVFFlat):
-            return  # Only IVF indices need training
+        """Train IVF and PQ indexes on sample vectors."""
+        if not isinstance(index.index, (faiss.IndexIVFFlat, faiss.IndexPQ)):
+            return
 
         index.index.train(training_vectors.astype(np.float32))
 

--- a/tests/vector_store/test_faiss_index.py
+++ b/tests/vector_store/test_faiss_index.py
@@ -9,6 +9,7 @@ import pytest
 from semantica.utils.exceptions import ProcessingError
 from semantica.vector_store.faiss_store import (
     FAISSIndex,
+    FAISSIndexBuilder,
     FAISSStore,
     _metadata_path,
 )
@@ -583,3 +584,27 @@ def test_loading_index_without_meta_json_warns(tmp_path):
 
     assert loaded.vector_ids == []
     assert loaded.metadata == {}
+
+
+def test_builder_trains_pq_index():
+    faiss = pytest.importorskip("faiss")
+    vectors = np.random.default_rng(42).random((256, 4), dtype=np.float32)
+    builder = FAISSIndexBuilder(dimension=4)
+    index = builder.build_index("pq", m=2, bits=2)
+
+    assert not index.index.is_trained
+
+    previous_threads = faiss.omp_get_max_threads()
+    faiss.omp_set_num_threads(1)
+    try:
+        builder.train_index(index, vectors)
+        assert index.index.is_trained
+
+        index.add_vectors(vectors[:2], ids=["a", "b"])
+        assert index.index.ntotal == 2
+
+        distances, indices = index.search(vectors[:1], k=1)
+        assert distances.shape == (1, 1)
+        assert int(indices[0, 0]) in (0, 1)
+    finally:
+        faiss.omp_set_num_threads(previous_threads)


### PR DESCRIPTION
## Description

`train_index()` skipped PQ indexes, leaving them untrained and causing the next `add_vectors()` call to fail.

This adds `IndexPQ` alongside `IndexIVFFlat` in the training check. The regression test covers training, inserting vectors and searching the PQ index.

## Type of Change

- [x] Bug fix

## Related Issues

Closes #1560

## Testing

- [x] Regression test fails before the fix and passes afterward.
- [x] FAISS index and search schema tests: 32 passed, 11 deselected.
- [x] Source distribution and wheel built successfully from commit `33f8719c` with `python -m build --installer uv`.

Tests were run on Windows using a fresh `--basetemp` directory to avoid a permission error during pytest's default temporary-directory cleanup.

## Documentation

- [x] No documentation changes needed.

## Breaking Changes

No.
