### PR TITLE
feat(ingest): add Power BI connector for REST metadata (#1572)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -108,7 +108,8 @@
               "integrations/snowflake",
               "integrations/databricks",
               "integrations/salesforce",
-              "integrations/redshift"
+              "integrations/redshift",
+              "integrations/powerbi"
             ]
           },
           {

--- a/docs/integrations/powerbi.md
+++ b/docs/integrations/powerbi.md
@@ -10,14 +10,10 @@ icon: "chart-simple"
 ## Installation
 
 ```bash
-# Install with Power BI support
-pip install "semantica[ingest-powerbi]"
-
-# Or install the dependency separately
-pip install "requests>=2.28.0"
+pip install semantica
 ```
 
-`requests` is an optional dependency. A plain `pip install semantica` never pulls it in, and `import semantica.ingest` never loads it eagerly.
+`requests` ships with Semantica as a core dependency, so this connector works as soon as the package is installed — there is no extra to install. The module is a lazy export: `import semantica.ingest` does not load it until you first touch `PowerBIIngestor`.
 
 <Note>
 This connector reads **metadata** — workspaces, datasets, reports and dataflows. It does not execute DAX queries or export dataset rows; the Power BI REST API exposes catalog information, not table data.

--- a/docs/integrations/powerbi.md
+++ b/docs/integrations/powerbi.md
@@ -1,0 +1,97 @@
+---
+title: "Power BI Integration"
+description: "Ingest workspace, dataset, report and dataflow metadata from the Power BI REST API into Semantica's KG pipeline."
+icon: "chart-simple"
+---
+
+> Pull Power BI metadata into Semantica using the REST API with Azure AD OAuth2 client-credentials authentication.
+
+
+## Installation
+
+```bash
+# Install with Power BI support
+pip install "semantica[ingest-powerbi]"
+
+# Or install the dependency separately
+pip install requests>=2.28.0
+```
+
+`requests` is an optional dependency. A plain `pip install semantica` never pulls it in, and `import semantica.ingest` never loads it eagerly.
+
+<Note>
+This connector reads **metadata** — workspaces, datasets, reports and dataflows. It does not execute DAX queries or export dataset rows; the Power BI REST API exposes catalog information, not table data.
+</Note>
+
+
+## Basic Usage
+
+```python
+import os
+from semantica.ingest import PowerBIIngestor
+
+ingestor = PowerBIIngestor(
+    tenant_id=os.getenv("POWERBI_TENANT_ID"),
+    client_id=os.getenv("POWERBI_CLIENT_ID"),
+    client_secret=os.getenv("POWERBI_CLIENT_SECRET"),
+)
+
+data = ingestor.ingest_workspace_metadata()
+documents = ingestor.export_as_documents(data)
+
+print(f"{len(documents)} documents — {data.metadata['dataset_count']} dataset(s)")
+```
+
+<Tip>
+Use environment variables (or a `.env` file with `python-dotenv`) to keep credentials out of source code. `PowerBIIngestor()` with no arguments reads from `POWERBI_*` environment variables automatically.
+</Tip>
+
+
+## Authentication
+
+The connector uses the Azure AD OAuth2 **client-credentials** flow. Register an application in Azure AD, grant it access to the Power BI service, and supply its tenant, client ID and secret.
+
+Required configuration:
+
+| Setting | Argument | Environment variable |
+| --- | --- | --- |
+| Azure AD tenant ID | `tenant_id` | `POWERBI_TENANT_ID` |
+| Application (client) ID | `client_id` | `POWERBI_CLIENT_ID` |
+| Client secret | `client_secret` | `POWERBI_CLIENT_SECRET` |
+| Workspace / group ID (optional) | `workspace_id` | `POWERBI_WORKSPACE_ID` |
+
+Missing any of the first three raises `ValidationError` before any network call is made. Tokens are cached and refreshed automatically shortly before expiry. The client secret is never written to logs.
+
+
+## Scoping to One Workspace
+
+Pass a workspace (group) ID to read a single workspace; omit it to list every workspace the service principal can see.
+
+```python
+data = ingestor.ingest_workspace_metadata(workspace_id="00000000-0000-0000-0000-000000000000")
+```
+
+Select only the resources you need with `include`:
+
+```python
+data = ingestor.ingest_workspace_metadata(include=["datasets", "reports"])
+```
+
+
+## Document Output
+
+`export_as_documents` returns the standard `{"id", "text", "metadata"}` shape, so the output feeds directly into `GraphBuilder`:
+
+```python
+from semantica.kg import GraphBuilder
+
+documents = ingestor.export_as_documents(data)
+graph = GraphBuilder().build(documents)
+```
+
+Each document's `metadata` carries `source: "powerbi"`, a `resource_type` of `workspace`, `dataset`, `report` or `dataflow`, plus the original API fields.
+
+
+## Security
+
+Every outbound HTTP call — including the token request — goes through Semantica's shared SSRF guard, so a user-supplied endpoint cannot reach private, loopback or link-local address space. Set `allow_private_ips=True` only for self-hosted deployments that genuinely need it.

--- a/docs/integrations/powerbi.md
+++ b/docs/integrations/powerbi.md
@@ -14,7 +14,7 @@ icon: "chart-simple"
 pip install "semantica[ingest-powerbi]"
 
 # Or install the dependency separately
-pip install requests>=2.28.0
+pip install "requests>=2.28.0"
 ```
 
 `requests` is an optional dependency. A plain `pip install semantica` never pulls it in, and `import semantica.ingest` never loads it eagerly.
@@ -65,13 +65,13 @@ Missing any of the first three raises `ValidationError` before any network call 
 
 ## Scoping to One Workspace
 
-Pass a workspace (group) ID to read a single workspace; omit it to list every workspace the service principal can see.
+Pass a workspace (group) ID to read a single workspace; omit it to walk every workspace the service principal can see, collecting datasets, reports and dataflows from each and tagging every record with the `workspace_id` it came from. That per-workspace walk is deliberate: the unscoped `myorg` endpoints only cover My workspace, and dataflows have no unscoped endpoint.
 
 ```python
 data = ingestor.ingest_workspace_metadata(workspace_id="00000000-0000-0000-0000-000000000000")
 ```
 
-Select only the resources you need with `include`:
+Select only the resources you need with `include` (an empty list pulls nothing):
 
 ```python
 data = ingestor.ingest_workspace_metadata(include=["datasets", "reports"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,7 @@ ingest-arrow = [
 ]
 ingest-sap = ["requests>=2.28.0"]
 ingest-git = ["GitPython>=3.1.58"]
+ingest-powerbi = ["requests>=2.28.0"]
 
 db-all = [
   "semantica[db-snowflake,db-databricks,db-salesforce,db-redshift,db-arrow]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,6 @@ ingest-arrow = [
 ]
 ingest-sap = ["requests>=2.28.0"]
 ingest-git = ["GitPython>=3.1.58"]
-ingest-powerbi = ["requests>=2.28.0"]
 
 db-all = [
   "semantica[db-snowflake,db-databricks,db-salesforce,db-redshift,db-arrow]"

--- a/semantica/ingest/__init__.py
+++ b/semantica/ingest/__init__.py
@@ -301,10 +301,6 @@ _OPTIONAL_DEPENDENCY_MESSAGES = {
         "Redshift ingestion requires optional dependency 'redshift-connector'. "
         "Install it with: pip install 'semantica[db-redshift]'"
     ),
-    ".powerbi_ingestor": (
-        "Power BI ingestion requires optional dependency 'requests'. "
-        "Install it with: pip install 'semantica[ingest-powerbi]'"
-    ),
 }
 
 
@@ -377,15 +373,6 @@ def __getattr__(name: str) -> Any:
         "RedshiftConnector",
     }:
         if not getattr(module, "REDSHIFT_AVAILABLE", True):
-            message = _OPTIONAL_DEPENDENCY_MESSAGES.get(module_name)
-            if message:
-                raise ImportError(message)
-
-    if module_name == ".powerbi_ingestor" and name in {
-        "PowerBIIngestor",
-        "PowerBIConnector",
-    }:
-        if not getattr(module, "REQUESTS_AVAILABLE", True):
             message = _OPTIONAL_DEPENDENCY_MESSAGES.get(module_name)
             if message:
                 raise ImportError(message)

--- a/semantica/ingest/__init__.py
+++ b/semantica/ingest/__init__.py
@@ -251,6 +251,10 @@ _LAZY_EXPORTS: Dict[str, Tuple[str, str]] = {
     "RedshiftIngestor": (".redshift_ingestor", "RedshiftIngestor"),
     "RedshiftData": (".redshift_ingestor", "RedshiftData"),
     "RedshiftConnector": (".redshift_ingestor", "RedshiftConnector"),
+    # Power BI ingestion
+    "PowerBIIngestor": (".powerbi_ingestor", "PowerBIIngestor"),
+    "PowerBIData": (".powerbi_ingestor", "PowerBIData"),
+    "PowerBIConnector": (".powerbi_ingestor", "PowerBIConnector"),
 }
 
 _OPTIONAL_DEPENDENCY_MESSAGES = {
@@ -296,6 +300,10 @@ _OPTIONAL_DEPENDENCY_MESSAGES = {
     ".redshift_ingestor": (
         "Redshift ingestion requires optional dependency 'redshift-connector'. "
         "Install it with: pip install 'semantica[db-redshift]'"
+    ),
+    ".powerbi_ingestor": (
+        "Power BI ingestion requires optional dependency 'requests'. "
+        "Install it with: pip install 'semantica[ingest-powerbi]'"
     ),
 }
 
@@ -369,6 +377,15 @@ def __getattr__(name: str) -> Any:
         "RedshiftConnector",
     }:
         if not getattr(module, "REDSHIFT_AVAILABLE", True):
+            message = _OPTIONAL_DEPENDENCY_MESSAGES.get(module_name)
+            if message:
+                raise ImportError(message)
+
+    if module_name == ".powerbi_ingestor" and name in {
+        "PowerBIIngestor",
+        "PowerBIConnector",
+    }:
+        if not getattr(module, "REQUESTS_AVAILABLE", True):
             message = _OPTIONAL_DEPENDENCY_MESSAGES.get(module_name)
             if message:
                 raise ImportError(message)
@@ -467,6 +484,10 @@ __all__ = [
     "RedshiftIngestor",
     "RedshiftData",
     "RedshiftConnector",
+    # Power BI ingestion
+    "PowerBIIngestor",
+    "PowerBIData",
+    "PowerBIConnector",
     # Registry and Methods
     "MethodRegistry",
     "method_registry",

--- a/semantica/ingest/powerbi_ingestor.py
+++ b/semantica/ingest/powerbi_ingestor.py
@@ -1,0 +1,740 @@
+"""Power BI ingestion module.
+
+Pulls workspace, dataset, report and dataflow metadata from the Power BI
+REST API and flattens it into document dicts that feed straight into
+``GraphBuilder``.
+
+The Power BI REST API is plain OAuth2 + JSON, so this connector needs
+nothing beyond ``requests`` — the same shape as the SAP connector.
+
+Design notes
+------------
+Three classes, matching the Snowflake/Salesforce/Redshift ingestors:
+
+- ``PowerBIData``: holds one ingestion run's worth of metadata
+  (``workspaces``, ``datasets``, ``reports``, ``dataflows``, ``metadata``,
+  ``ingested_at``).  No network dependency — always importable.
+
+- ``PowerBIConnector``: owns the Azure AD OAuth2 client-credentials token
+  lifecycle and the ``requests`` session.  Raises ``ImportError`` at
+  instantiation time when ``requests`` is absent, and ``ValidationError``
+  when the credentials are incomplete.  Every outbound call goes through
+  ``request_with_ssrf_guard``.
+
+- ``PowerBIIngestor``: orchestrates ingestion and exposes
+  ``export_as_documents``.
+
+Authentication
+--------------
+Azure AD OAuth2 client-credentials::
+
+    connector = PowerBIConnector(
+        tenant_id="00000000-0000-0000-0000-000000000000",
+        client_id="...",
+        client_secret="...",
+    )
+
+Credentials may also come from the environment:
+
+* ``POWERBI_TENANT_ID``
+* ``POWERBI_CLIENT_ID``
+* ``POWERBI_CLIENT_SECRET``
+* ``POWERBI_WORKSPACE_ID`` (optional)
+
+The client secret is kept in a private attribute and is never logged.
+
+Optional dependency
+-------------------
+Install before using ``PowerBIConnector`` or ``PowerBIIngestor``::
+
+    pip install "semantica[ingest-powerbi]"
+
+The top-level ``import semantica.ingest`` never imports ``requests``
+eagerly; it is loaded only when this module is first accessed through the
+lazy-export mechanism in ``__init__.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Sequence
+
+from ..utils.exceptions import ProcessingError, ValidationError
+from ..utils.logging import get_logger
+from ..utils.progress_tracker import get_progress_tracker
+
+# ---------------------------------------------------------------------------
+# Optional-dependency guard
+# ---------------------------------------------------------------------------
+# The module always imports cleanly.  The sentinel fires at instantiation
+# time so that:
+#   - ``from semantica.ingest import PowerBIData`` succeeds with no requests
+#   - ``from semantica.ingest import PowerBIIngestor`` succeeds (lazy)
+#   - ``PowerBIConnector(...)`` raises a clear ImportError when absent
+# ---------------------------------------------------------------------------
+try:
+    import requests
+
+    REQUESTS_AVAILABLE = True
+except (ImportError, OSError):  # pragma: no cover - depends on env
+    requests = None  # type: ignore[assignment]
+    REQUESTS_AVAILABLE = False
+
+try:
+    from .ssrf import request_with_ssrf_guard
+except (ImportError, OSError):  # pragma: no cover - defensive
+    request_with_ssrf_guard = None  # type: ignore[assignment]
+
+__all__ = [
+    "PowerBIData",
+    "PowerBIConnector",
+    "PowerBIIngestor",
+]
+
+_MISSING_EXTRA_HINT = (
+    "requests is required for the Power BI connector. "
+    "Install it with: pip install 'semantica[ingest-powerbi]'"
+)
+
+_DEFAULT_API_BASE = "https://api.powerbi.com/v1.0/myorg"
+_DEFAULT_TOKEN_URL = "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+_DEFAULT_SCOPE = "https://analysis.windows.net/powerbi/api/.default"
+
+# Resources the ingestor can pull, in the order they are exported.
+_RESOURCE_KEYS = ("workspaces", "datasets", "reports", "dataflows")
+
+_logger = get_logger("powerbi_ingestor")
+
+
+# ---------------------------------------------------------------------------
+# PowerBIData
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PowerBIData:
+    """Metadata returned from the Power BI REST API.
+
+    Attributes:
+        workspaces: Workspace (group) summaries, one dict per workspace.
+        datasets: Dataset summaries.
+        reports: Report summaries.
+        dataflows: Dataflow summaries.
+        metadata: Run metadata (API base, workspace, per-resource counts).
+        ingested_at: Timestamp recorded when this object was created.
+    """
+
+    workspaces: List[Dict[str, Any]]
+    datasets: List[Dict[str, Any]]
+    reports: List[Dict[str, Any]]
+    dataflows: List[Dict[str, Any]]
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    ingested_at: datetime = field(default_factory=datetime.now)
+
+
+# ---------------------------------------------------------------------------
+# PowerBIConnector
+# ---------------------------------------------------------------------------
+
+
+class PowerBIConnector:
+    """Manages the Power BI REST client and OAuth2 token lifecycle.
+
+    Responsibilities:
+
+    * Resolves credentials from constructor arguments, falling back to
+      ``POWERBI_*`` environment variables.
+    * Validates that a usable credential set is configured *before* any
+      network call is made.
+    * Acquires and caches an Azure AD client-credentials token, refreshing
+      it shortly before expiry.
+    * Exposes :meth:`test_connection` and :meth:`close`.
+
+    Every outbound HTTP call — including the token request — goes through
+    :func:`~semantica.ingest.ssrf.request_with_ssrf_guard`, so a
+    user-supplied endpoint cannot reach private/loopback/link-local space.
+
+    Raises:
+        ImportError: When ``requests`` is not installed.
+        ValidationError: When required credentials are incomplete.
+    """
+
+    def __init__(
+        self,
+        tenant_id: Optional[str] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        workspace_id: Optional[str] = None,
+        api_base: Optional[str] = None,
+        token_url: Optional[str] = None,
+        scope: Optional[str] = None,
+        allow_private_ips: Optional[bool] = None,
+        timeout: int = 30,
+        **config: Any,
+    ) -> None:
+        """Initialise the connector and validate credentials.
+
+        Args:
+            tenant_id: Azure AD tenant ID. Defaults to ``POWERBI_TENANT_ID``.
+            client_id: Registered application (client) ID. Defaults to
+                ``POWERBI_CLIENT_ID``.
+            client_secret: Application secret. Defaults to
+                ``POWERBI_CLIENT_SECRET``. Never logged.
+            workspace_id: Optional default workspace (group) ID used when a
+                method is called without an explicit workspace.
+            api_base: Power BI API base URL. Defaults to
+                ``https://api.powerbi.com/v1.0/myorg``.
+            token_url: Azure AD token endpoint template. ``{tenant_id}`` is
+                substituted with the configured tenant.
+            scope: OAuth2 scope. Defaults to the Power BI ``.default`` scope.
+            allow_private_ips: Allow requests to private networks (for
+                self-hosted gateways behind a VPN).
+            timeout: Per-request timeout in seconds.
+            **config: Extra configuration kept for callers.
+
+        Raises:
+            ImportError: When ``requests`` is not installed.
+            ValidationError: When required credentials are incomplete.
+        """
+        if not REQUESTS_AVAILABLE:
+            raise ImportError(_MISSING_EXTRA_HINT)
+        if request_with_ssrf_guard is None:  # pragma: no cover - defensive
+            raise ImportError(
+                "Power BI ingestion requires the shared SSRF guard "
+                "(semantica.ingest.ssrf) to be importable."
+            )
+
+        self.logger = _logger
+
+        self.tenant_id = tenant_id or os.getenv("POWERBI_TENANT_ID")
+        self.client_id = client_id or os.getenv("POWERBI_CLIENT_ID")
+        # Secrets stay private and are never included in log messages.
+        self._client_secret = client_secret or os.getenv("POWERBI_CLIENT_SECRET")
+        self.workspace_id = workspace_id or os.getenv("POWERBI_WORKSPACE_ID")
+
+        self.api_base = (api_base or _DEFAULT_API_BASE).rstrip("/")
+        self.token_url_template = token_url or _DEFAULT_TOKEN_URL
+        self.scope = scope or _DEFAULT_SCOPE
+        self.allow_private_ips = allow_private_ips
+        self.timeout = timeout
+        self.config: Dict[str, Any] = config
+
+        self._session: Optional[Any] = requests.Session() if requests else None
+        self._access_token: Optional[str] = None
+        self._token_expiry: float = 0.0
+
+        self._validate_auth()
+
+        self.logger.debug(
+            "Power BI connector initialised (tenant=%s, workspace=%s)",
+            self.tenant_id,
+            self.workspace_id,
+        )
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    def _validate_auth(self) -> None:
+        """Raise when the configured credentials cannot authenticate.
+
+        Raises:
+            ValidationError: If tenant_id, client_id or client_secret is
+                missing.
+        """
+        if not self.tenant_id:
+            raise ValidationError(
+                "Power BI tenant_id is required. Provide via 'tenant_id' or "
+                "POWERBI_TENANT_ID environment variable."
+            )
+        if not self.client_id:
+            raise ValidationError(
+                "Power BI client_id is required. Provide via 'client_id' or "
+                "POWERBI_CLIENT_ID environment variable."
+            )
+        if not self._client_secret:
+            raise ValidationError(
+                "Power BI client_secret is required. Provide via "
+                "'client_secret' or POWERBI_CLIENT_SECRET environment variable."
+            )
+
+    # ------------------------------------------------------------------
+    # Token handling
+    # ------------------------------------------------------------------
+
+    @property
+    def token_url(self) -> str:
+        """Azure AD token endpoint for the configured tenant."""
+        return self.token_url_template.format(tenant_id=self.tenant_id)
+
+    def _request_token(self) -> str:
+        """Acquire an OAuth2 access token via client-credentials.
+
+        Returns:
+            The access token string.
+
+        Raises:
+            ProcessingError: If the token endpoint call fails or returns no
+                token.
+        """
+        data = {
+            "grant_type": "client_credentials",
+            "client_id": self.client_id,
+            "client_secret": self._client_secret,
+            "scope": self.scope,
+        }
+
+        try:
+            response = request_with_ssrf_guard(
+                "POST",
+                self.token_url,
+                session=self._session,
+                allow_private_ips=self.allow_private_ips,
+                data=data,
+                timeout=self.timeout,
+            )
+            body = response.json()
+            if response.status_code >= 400:
+                raise ProcessingError(
+                    f"Power BI token endpoint returned {response.status_code}: "
+                    f"{str(body)[:200]}"
+                )
+            token = body.get("access_token")
+            if not token:
+                raise ProcessingError(
+                    "Power BI token endpoint returned no access_token."
+                )
+            expires_in = int(body.get("expires_in") or 3600)
+            self._access_token = token
+            # Refresh a minute early so an in-flight request cannot race
+            # against expiry.
+            self._token_expiry = time.monotonic() + max(expires_in - 60, 0)
+            return token
+        except ProcessingError:
+            raise
+        except Exception as exc:
+            raise ProcessingError(
+                f"Failed to acquire Power BI access token: {type(exc).__name__}"
+            ) from exc
+
+    def _ensure_token(self) -> str:
+        """Return a valid access token, refreshing when needed."""
+        if self._access_token and time.monotonic() < self._token_expiry:
+            return self._access_token
+        return self._request_token()
+
+    def _auth_headers(self) -> Dict[str, str]:
+        """Build the Authorization header for an API call."""
+        return {
+            "Authorization": f"Bearer {self._ensure_token()}",
+            "Accept": "application/json",
+        }
+
+    # ------------------------------------------------------------------
+    # HTTP
+    # ------------------------------------------------------------------
+
+    def _url(self, path: str) -> str:
+        """Join *path* onto the configured API base."""
+        return f"{self.api_base}/{path.lstrip('/')}"
+
+    def get(
+        self,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """GET a Power BI endpoint and return the decoded JSON body.
+
+        Follows ``@odata.nextLink`` pagination up to a bounded number of
+        hops, unwrapping the ``value`` list the API returns for collections.
+
+        Args:
+            path: Path relative to the API base, e.g. ``"groups"``.
+            params: Optional query parameters for the first request.
+
+        Returns:
+            The decoded JSON body. For collection responses this is the
+            accumulated ``value`` list.
+
+        Raises:
+            ProcessingError: If the request or JSON decoding fails.
+        """
+        headers = self._auth_headers()
+        url = self._url(path)
+        items: List[Any] = []
+        saw_value = False
+        hops = 0
+
+        while url:
+            try:
+                response = request_with_ssrf_guard(
+                    "GET",
+                    url,
+                    session=self._session,
+                    allow_private_ips=self.allow_private_ips,
+                    headers=headers,
+                    params=params if hops == 0 else None,
+                    timeout=self.timeout,
+                )
+                body = response.json()
+                if response.status_code >= 400:
+                    raise ProcessingError(
+                        f"Power BI API returned {response.status_code} for "
+                        f"{path}: {str(body)[:200]}"
+                    )
+            except ProcessingError:
+                raise
+            except Exception as exc:
+                raise ProcessingError(
+                    f"Failed to call Power BI API '{path}': {type(exc).__name__}"
+                ) from exc
+
+            if isinstance(body, dict):
+                if "value" in body:
+                    saw_value = True
+                    items.extend(body.get("value") or [])
+                    url = body.get("@odata.nextLink") or ""
+                else:
+                    return body
+            else:
+                return body
+
+            hops += 1
+            if hops >= 100:  # bounded follow — defensive against loops
+                self.logger.warning(
+                    "Power BI pagination for '%s' exceeded 100 hops; stopping.",
+                    path,
+                )
+                break
+
+        return items if saw_value else []
+
+    # ------------------------------------------------------------------
+    # Resource helpers
+    # ------------------------------------------------------------------
+
+    def _workspace_path(self, resource: str, workspace_id: Optional[str]) -> str:
+        """Return the API path for *resource*, scoped to a workspace if given."""
+        target = workspace_id or self.workspace_id
+        if target:
+            return f"groups/{target}/{resource}"
+        return resource
+
+    def get_workspaces(self) -> List[Dict[str, Any]]:
+        """Return workspace (group) summaries visible to the principal."""
+        return list(self.get("groups") or [])
+
+    def get_datasets(self, workspace_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Return dataset summaries, optionally scoped to one workspace."""
+        path = self._workspace_path("datasets", workspace_id)
+        return list(self.get(path) or [])
+
+    def get_reports(self, workspace_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Return report summaries, optionally scoped to one workspace."""
+        path = self._workspace_path("reports", workspace_id)
+        return list(self.get(path) or [])
+
+    def get_dataflows(self, workspace_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Return dataflow summaries, optionally scoped to one workspace."""
+        path = self._workspace_path("dataflows", workspace_id)
+        return list(self.get(path) or [])
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def test_connection(self) -> bool:
+        """Verify credentials by acquiring a token and listing workspaces.
+
+        Returns:
+            ``True`` when both steps succeed, ``False`` otherwise.
+        """
+        try:
+            self._ensure_token()
+            self.get_workspaces()
+            return True
+        except Exception as exc:
+            self.logger.debug("Power BI connection test failed: %s", type(exc).__name__)
+            return False
+
+    def close(self) -> None:
+        """Close the underlying HTTP session."""
+        if self._session is not None:
+            try:
+                self._session.close()
+            except Exception:  # noqa: BLE001
+                pass
+            self._session = None
+
+
+# ---------------------------------------------------------------------------
+# PowerBIIngestor
+# ---------------------------------------------------------------------------
+
+
+class PowerBIIngestor:
+    """Power BI metadata ingestor for the Semantica framework.
+
+    Wraps :class:`PowerBIConnector` and exposes workspace-metadata ingestion
+    plus document export.
+
+    Args:
+        tenant_id: Azure AD tenant ID.
+        client_id: Registered application (client) ID.
+        client_secret: Application secret.
+        workspace_id: Optional default workspace (group) ID.
+        api_base: Power BI API base URL.
+        allow_private_ips: Allow private-network requests.
+        timeout: Per-request timeout in seconds.
+        connector: An existing :class:`PowerBIConnector` to reuse.
+        config: Optional extra configuration forwarded to the connector.
+        **kwargs: Additional keyword arguments merged into ``config``.
+
+    Example::
+
+        from semantica.ingest import PowerBIIngestor
+
+        ingestor = PowerBIIngestor(
+            tenant_id="...", client_id="...", client_secret="..."
+        )
+        data = ingestor.ingest_workspace_metadata()
+        documents = ingestor.export_as_documents(data)
+    """
+
+    def __init__(
+        self,
+        tenant_id: Optional[str] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        workspace_id: Optional[str] = None,
+        api_base: Optional[str] = None,
+        allow_private_ips: Optional[bool] = None,
+        timeout: int = 30,
+        connector: Optional[PowerBIConnector] = None,
+        config: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        self.logger = _logger
+
+        self.config: Dict[str, Any] = config or {}
+        self.config.update(kwargs)
+
+        self.connector: PowerBIConnector = connector or PowerBIConnector(
+            tenant_id=tenant_id,
+            client_id=client_id,
+            client_secret=client_secret,
+            workspace_id=workspace_id,
+            api_base=api_base,
+            allow_private_ips=allow_private_ips,
+            timeout=timeout,
+            **self.config,
+        )
+
+        self.progress_tracker = get_progress_tracker()
+        if not self.progress_tracker.enabled:
+            self.progress_tracker.enabled = True
+
+        self.logger.debug("Power BI ingestor initialised.")
+
+    # ------------------------------------------------------------------
+    # Context manager
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> "PowerBIIngestor":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Close the underlying connector."""
+        self.connector.close()
+
+    # ------------------------------------------------------------------
+    # Ingestion
+    # ------------------------------------------------------------------
+
+    def ingest_workspace_metadata(
+        self,
+        workspace_id: Optional[str] = None,
+        include: Optional[Sequence[str]] = None,
+    ) -> PowerBIData:
+        """Pull workspace, dataset, report and dataflow metadata.
+
+        Args:
+            workspace_id: Workspace (group) to read. Defaults to the
+                connector's configured workspace; when that is unset the
+                workspaces themselves are listed instead.
+            include: Subset of ``("workspaces", "datasets", "reports",
+                "dataflows")`` to pull. Defaults to all four.
+
+        Returns:
+            :class:`PowerBIData` with the requested collections populated.
+
+        Raises:
+            ValidationError: If *include* names an unknown resource.
+            ProcessingError: If any API call fails.
+        """
+        wanted = tuple(include) if include else _RESOURCE_KEYS
+        unknown = [name for name in wanted if name not in _RESOURCE_KEYS]
+        if unknown:
+            raise ValidationError(
+                f"Unknown Power BI resource(s): {', '.join(unknown)}. "
+                f"Expected any of: {', '.join(_RESOURCE_KEYS)}."
+            )
+
+        tracking_id = self.progress_tracker.start_tracking(
+            file=workspace_id or self.connector.workspace_id or "myorg",
+            module="ingest",
+            submodule="PowerBIIngestor",
+            message="Pulling Power BI metadata",
+        )
+
+        collected: Dict[str, List[Dict[str, Any]]] = {key: [] for key in _RESOURCE_KEYS}
+
+        try:
+            if "workspaces" in wanted:
+                if workspace_id or self.connector.workspace_id:
+                    # A single workspace was requested — describe just it.
+                    target = workspace_id or self.connector.workspace_id
+                    workspace = self.connector.get(f"groups/{target}")
+                    collected["workspaces"] = [workspace] if workspace else []
+                else:
+                    collected["workspaces"] = self.connector.get_workspaces()
+
+            if "datasets" in wanted:
+                collected["datasets"] = self.connector.get_datasets(workspace_id)
+            if "reports" in wanted:
+                collected["reports"] = self.connector.get_reports(workspace_id)
+            if "dataflows" in wanted:
+                collected["dataflows"] = self.connector.get_dataflows(workspace_id)
+
+            data = PowerBIData(
+                workspaces=collected["workspaces"],
+                datasets=collected["datasets"],
+                reports=collected["reports"],
+                dataflows=collected["dataflows"],
+                metadata={
+                    "api_base": self.connector.api_base,
+                    "workspace_id": workspace_id or self.connector.workspace_id,
+                    "workspace_count": len(collected["workspaces"]),
+                    "dataset_count": len(collected["datasets"]),
+                    "report_count": len(collected["reports"]),
+                    "dataflow_count": len(collected["dataflows"]),
+                },
+            )
+
+            self.progress_tracker.stop_tracking(
+                tracking_id,
+                status="completed",
+                message=(
+                    f"Pulled {len(data.workspaces)} workspace(s), "
+                    f"{len(data.datasets)} dataset(s), "
+                    f"{len(data.reports)} report(s), "
+                    f"{len(data.dataflows)} dataflow(s)"
+                ),
+            )
+            self.logger.info(
+                "Power BI ingestion completed: %d workspace(s), %d dataset(s), "
+                "%d report(s), %d dataflow(s)",
+                len(data.workspaces),
+                len(data.datasets),
+                len(data.reports),
+                len(data.dataflows),
+            )
+            return data
+
+        except (ValidationError, ProcessingError):
+            self.progress_tracker.stop_tracking(
+                tracking_id, status="failed", message="Power BI ingestion failed"
+            )
+            raise
+        except Exception as exc:
+            self.progress_tracker.stop_tracking(
+                tracking_id, status="failed", message=str(exc)
+            )
+            self.logger.error(
+                "Failed to ingest Power BI metadata: %s", type(exc).__name__
+            )
+            raise ProcessingError(
+                f"Failed to ingest Power BI metadata: {type(exc).__name__}"
+            ) from exc
+
+    # ------------------------------------------------------------------
+    # Document export
+    # ------------------------------------------------------------------
+
+    def export_as_documents(
+        self,
+        data: PowerBIData,
+    ) -> List[Dict[str, Any]]:
+        """Convert :class:`PowerBIData` to the Semantica document format.
+
+        Produces the same ``{"id", "text", "metadata"}`` shape used by the
+        Snowflake and Redshift ingestors, so the result is directly usable
+        with ``GraphBuilder``.
+
+        Args:
+            data: A :class:`PowerBIData` returned by
+                :meth:`ingest_workspace_metadata`.
+
+        Returns:
+            List of document dictionaries::
+
+                [
+                    {
+                        "id": str,
+                        "text": str,
+                        "metadata": {
+                            "source": "powerbi",
+                            "resource_type": "dataset" | "report" | ...,
+                            ...original fields...
+                        },
+                    },
+                    ...
+                ]
+        """
+        documents: List[Dict[str, Any]] = []
+
+        for resource_type in _RESOURCE_KEYS:
+            singular = resource_type[:-1]  # datasets -> dataset
+            for index, item in enumerate(getattr(data, resource_type) or []):
+                if not isinstance(item, dict):
+                    continue
+                text = self._describe(item, singular)
+                metadata: Dict[str, Any] = {
+                    "source": "powerbi",
+                    "resource_type": singular,
+                }
+                metadata.update(item)
+                documents.append(
+                    {
+                        "id": str(item.get("id") or f"{singular}-{index}"),
+                        "text": text,
+                        "metadata": metadata,
+                    }
+                )
+
+        self.logger.debug(
+            "export_as_documents: exported %d document(s)", len(documents)
+        )
+        return documents
+
+    @staticmethod
+    def _describe(item: Dict[str, Any], resource_type: str) -> str:
+        """Build a one-paragraph text description of a Power BI object."""
+        name = item.get("name") or item.get("displayName") or item.get("id")
+        parts = [f"{name} (Power BI {resource_type})"]
+
+        description = item.get("description")
+        if description:
+            parts.append(str(description))
+
+        for key in ("workspaceId", "datasetId", "reportType", "configuredBy"):
+            if item.get(key) is not None:
+                parts.append(f"{key}: {item[key]}")
+
+        return "\n".join(parts)

--- a/semantica/ingest/powerbi_ingestor.py
+++ b/semantica/ingest/powerbi_ingestor.py
@@ -61,6 +61,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Sequence
+from urllib.parse import urlparse
 
 from ..utils.exceptions import ProcessingError, ValidationError
 from ..utils.logging import get_logger
@@ -107,6 +108,18 @@ _DEFAULT_SCOPE = "https://analysis.windows.net/powerbi/api/.default"
 _RESOURCE_KEYS = ("workspaces", "datasets", "reports", "dataflows")
 
 _logger = get_logger("powerbi_ingestor")
+
+
+def _origin(url: str) -> tuple:
+    """Return the ``(scheme, host, effective port)`` triple for *url*.
+
+    Used to keep pagination on one origin: every hop re-sends the bearer
+    token, so a next link must not be allowed to move it elsewhere.
+    """
+    parsed = urlparse(url or "")
+    scheme = (parsed.scheme or "").lower()
+    default_port = 443 if scheme == "https" else 80
+    return scheme, (parsed.hostname or "").lower(), parsed.port or default_port
 
 
 # ---------------------------------------------------------------------------
@@ -341,6 +354,10 @@ class PowerBIConnector:
         """Join *path* onto the configured API base."""
         return f"{self.api_base}/{path.lstrip('/')}"
 
+    def _same_origin(self, url: str) -> bool:
+        """True when *url* shares the origin of the configured API base."""
+        return _origin(url) == _origin(self.api_base)
+
     def get(
         self,
         path: str,
@@ -396,7 +413,14 @@ class PowerBIConnector:
                 if "value" in body:
                     saw_value = True
                     items.extend(body.get("value") or [])
-                    url = body.get("@odata.nextLink") or ""
+                    next_url = body.get("@odata.nextLink") or ""
+                    if next_url and not self._same_origin(next_url):
+                        raise ProcessingError(
+                            f"Power BI pagination for '{path}' returned a next "
+                            f"link on another origin ({_origin(next_url)[1]}); "
+                            "refusing to send the access token there."
+                        )
+                    url = next_url
                 else:
                     return body
             else:
@@ -557,6 +581,16 @@ class PowerBIIngestor:
     # Ingestion
     # ------------------------------------------------------------------
 
+    def _fetch_child(
+        self, resource: str, workspace_id: Optional[str]
+    ) -> List[Dict[str, Any]]:
+        """Call the connector helper matching *resource* for one workspace."""
+        if resource == "datasets":
+            return self.connector.get_datasets(workspace_id)
+        if resource == "reports":
+            return self.connector.get_reports(workspace_id)
+        return self.connector.get_dataflows(workspace_id)
+
     def ingest_workspace_metadata(
         self,
         workspace_id: Optional[str] = None,
@@ -567,9 +601,12 @@ class PowerBIIngestor:
         Args:
             workspace_id: Workspace (group) to read. Defaults to the
                 connector's configured workspace; when that is unset the
-                workspaces themselves are listed instead.
+                workspaces themselves are listed and datasets, reports and
+                dataflows are collected across each of them, each record
+                tagged with the ``workspace_id`` it came from.
             include: Subset of ``("workspaces", "datasets", "reports",
-                "dataflows")`` to pull. Defaults to all four.
+                "dataflows")`` to pull. Defaults to all four; pass an empty
+                sequence to pull nothing.
 
         Returns:
             :class:`PowerBIData` with the requested collections populated.
@@ -578,7 +615,7 @@ class PowerBIIngestor:
             ValidationError: If *include* names an unknown resource.
             ProcessingError: If any API call fails.
         """
-        wanted = tuple(include) if include else _RESOURCE_KEYS
+        wanted = _RESOURCE_KEYS if include is None else tuple(include)
         unknown = [name for name in wanted if name not in _RESOURCE_KEYS]
         if unknown:
             raise ValidationError(
@@ -596,21 +633,40 @@ class PowerBIIngestor:
         collected: Dict[str, List[Dict[str, Any]]] = {key: [] for key in _RESOURCE_KEYS}
 
         try:
+            scope = workspace_id or self.connector.workspace_id
+
             if "workspaces" in wanted:
-                if workspace_id or self.connector.workspace_id:
+                if scope:
                     # A single workspace was requested — describe just it.
-                    target = workspace_id or self.connector.workspace_id
-                    workspace = self.connector.get(f"groups/{target}")
+                    workspace = self.connector.get(f"groups/{scope}")
                     collected["workspaces"] = [workspace] if workspace else []
                 else:
                     collected["workspaces"] = self.connector.get_workspaces()
 
-            if "datasets" in wanted:
-                collected["datasets"] = self.connector.get_datasets(workspace_id)
-            if "reports" in wanted:
-                collected["reports"] = self.connector.get_reports(workspace_id)
-            if "dataflows" in wanted:
-                collected["dataflows"] = self.connector.get_dataflows(workspace_id)
+            children = [k for k in ("datasets", "reports", "dataflows") if k in wanted]
+            if children:
+                if scope:
+                    for key in children:
+                        collected[key] = self._fetch_child(key, scope)
+                else:
+                    # With no workspace configured the unscoped endpoints only
+                    # cover "My workspace", and dataflows have no unscoped
+                    # endpoint at all. Walk the visible workspaces instead and
+                    # tag each record with the workspace it came from.
+                    workspaces = collected["workspaces"]
+                    if not workspaces and "workspaces" not in wanted:
+                        workspaces = self.connector.get_workspaces()
+                    for workspace in workspaces:
+                        if not isinstance(workspace, dict):
+                            continue
+                        group_id = workspace.get("id")
+                        if not group_id:
+                            continue
+                        for key in children:
+                            for item in self._fetch_child(key, group_id):
+                                if isinstance(item, dict):
+                                    item.setdefault("workspace_id", group_id)
+                                collected[key].append(item)
 
             data = PowerBIData(
                 workspaces=collected["workspaces"],

--- a/semantica/ingest/powerbi_ingestor.py
+++ b/semantica/ingest/powerbi_ingestor.py
@@ -16,9 +16,8 @@ Three classes, matching the Snowflake/Salesforce/Redshift ingestors:
   ``ingested_at``).  No network dependency — always importable.
 
 - ``PowerBIConnector``: owns the Azure AD OAuth2 client-credentials token
-  lifecycle and the ``requests`` session.  Raises ``ImportError`` at
-  instantiation time when ``requests`` is absent, and ``ValidationError``
-  when the credentials are incomplete.  Every outbound call goes through
+  lifecycle and the ``requests`` session.  Raises ``ValidationError`` when
+  the credentials are incomplete.  Every outbound call goes through
   ``request_with_ssrf_guard``.
 
 - ``PowerBIIngestor``: orchestrates ingestion and exposes
@@ -43,15 +42,15 @@ Credentials may also come from the environment:
 
 The client secret is kept in a private attribute and is never logged.
 
-Optional dependency
--------------------
-Install before using ``PowerBIConnector`` or ``PowerBIIngestor``::
+Dependencies
+------------
+``requests`` is a core Semantica dependency, so no extra is needed::
 
-    pip install "semantica[ingest-powerbi]"
+    pip install semantica
 
-The top-level ``import semantica.ingest`` never imports ``requests``
-eagerly; it is loaded only when this module is first accessed through the
-lazy-export mechanism in ``__init__.py``.
+The module is registered as a lazy export in ``__init__.py``, so a
+top-level ``import semantica.ingest`` does not import it until one of the
+classes below is first accessed.
 """
 
 from __future__ import annotations
@@ -63,42 +62,18 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Sequence
 from urllib.parse import urlparse
 
+import requests
+
 from ..utils.exceptions import ProcessingError, ValidationError
 from ..utils.logging import get_logger
 from ..utils.progress_tracker import get_progress_tracker
-
-# ---------------------------------------------------------------------------
-# Optional-dependency guard
-# ---------------------------------------------------------------------------
-# The module always imports cleanly.  The sentinel fires at instantiation
-# time so that:
-#   - ``from semantica.ingest import PowerBIData`` succeeds with no requests
-#   - ``from semantica.ingest import PowerBIIngestor`` succeeds (lazy)
-#   - ``PowerBIConnector(...)`` raises a clear ImportError when absent
-# ---------------------------------------------------------------------------
-try:
-    import requests
-
-    REQUESTS_AVAILABLE = True
-except (ImportError, OSError):  # pragma: no cover - depends on env
-    requests = None  # type: ignore[assignment]
-    REQUESTS_AVAILABLE = False
-
-try:
-    from .ssrf import request_with_ssrf_guard
-except (ImportError, OSError):  # pragma: no cover - defensive
-    request_with_ssrf_guard = None  # type: ignore[assignment]
+from .ssrf import request_with_ssrf_guard
 
 __all__ = [
     "PowerBIData",
     "PowerBIConnector",
     "PowerBIIngestor",
 ]
-
-_MISSING_EXTRA_HINT = (
-    "requests is required for the Power BI connector. "
-    "Install it with: pip install 'semantica[ingest-powerbi]'"
-)
 
 _DEFAULT_API_BASE = "https://api.powerbi.com/v1.0/myorg"
 _DEFAULT_TOKEN_URL = "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
@@ -212,14 +187,6 @@ class PowerBIConnector:
             ImportError: When ``requests`` is not installed.
             ValidationError: When required credentials are incomplete.
         """
-        if not REQUESTS_AVAILABLE:
-            raise ImportError(_MISSING_EXTRA_HINT)
-        if request_with_ssrf_guard is None:  # pragma: no cover - defensive
-            raise ImportError(
-                "Power BI ingestion requires the shared SSRF guard "
-                "(semantica.ingest.ssrf) to be importable."
-            )
-
         self.logger = _logger
 
         self.tenant_id = tenant_id or os.getenv("POWERBI_TENANT_ID")

--- a/tests/ingest/test_powerbi_ingestor.py
+++ b/tests/ingest/test_powerbi_ingestor.py
@@ -5,11 +5,8 @@ ingestor module.  Tests assert on the *call signature* (method first, url
 second) so a mistake in argument order fails here instead of at runtime.
 """
 
-import sys
 import unittest
 from unittest.mock import patch
-
-sys.path.insert(0, r"D:\Vaults\Projects\semantica-1572")
 
 from semantica.ingest import powerbi_ingestor as pbi  # noqa: E402
 from semantica.ingest.powerbi_ingestor import (  # noqa: E402
@@ -157,7 +154,10 @@ class TestApiCalls(unittest.TestCase):
         self.assertEqual(result, {"id": "ws-9", "name": "Only"})
 
     def test_pagination_follows_next_link(self):
-        first = {"value": [{"id": "a"}], "@odata.nextLink": "https://next/1"}
+        first = {
+            "value": [{"id": "a"}],
+            "@odata.nextLink": "https://api.powerbi.com/v1.0/myorg/datasets?skip=1",
+        }
         second = {"value": [{"id": "b"}]}
         with patch(GUARD) as guard:
             guard.side_effect = [
@@ -168,6 +168,17 @@ class TestApiCalls(unittest.TestCase):
             result = self.connector.get("datasets")
         self.assertEqual([item["id"] for item in result], ["a", "b"])
         self.assertEqual(guard.call_count, 3)
+
+    def test_pagination_rejects_cross_origin_next_link(self):
+        first = {
+            "value": [{"id": "a"}],
+            "@odata.nextLink": "https://evil.example.com/next",
+        }
+        with patch(GUARD) as guard:
+            guard.side_effect = [token_response(), FakeResponse(first)]
+            with self.assertRaises(Exception):
+                self.connector.get("datasets")
+        self.assertEqual(guard.call_count, 2)  # token + first page only
 
     def test_workspace_scoped_paths(self):
         with patch(GUARD) as guard:
@@ -242,11 +253,57 @@ class TestIngestor(unittest.TestCase):
     def test_include_subset_skips_unwanted_calls(self):
         self.guard.side_effect = [
             token_response(),
+            FakeResponse({"value": [{"id": "ws-1", "name": "Sales"}]}),
             FakeResponse({"value": [{"id": "ds-1", "name": "Orders"}]}),
         ]
         data = self.ingestor.ingest_workspace_metadata(include=["datasets"])
         self.assertEqual(len(data.datasets), 1)
         self.assertEqual(data.workspaces, [])
+        self.assertEqual(data.reports, [])
+        self.assertEqual(data.dataflows, [])
+
+    def test_empty_include_pulls_nothing(self):
+        self.guard.side_effect = [token_response()]
+        data = self.ingestor.ingest_workspace_metadata(include=[])
+        self.assertEqual(data.workspaces, [])
+        self.assertEqual(data.datasets, [])
+        self.assertEqual(data.reports, [])
+        self.assertEqual(data.dataflows, [])
+        self.assertEqual(self.guard.call_count, 0)  # not even a token fetch
+
+    def test_unscoped_ingest_walks_each_workspace(self):
+        self.guard.side_effect = [
+            token_response(),
+            FakeResponse({"value": [{"id": "ws-1"}, {"id": "ws-2"}]}),
+            FakeResponse({"value": [{"id": "ds-1"}]}),
+            FakeResponse({"value": [{"id": "rp-1"}]}),
+            FakeResponse({"value": [{"id": "df-1"}]}),
+            FakeResponse({"value": [{"id": "ds-2"}]}),
+            FakeResponse({"value": [{"id": "rp-2"}]}),
+            FakeResponse({"value": [{"id": "df-2"}]}),
+        ]
+        data = self.ingestor.ingest_workspace_metadata()
+        self.assertEqual([d["id"] for d in data.datasets], ["ds-1", "ds-2"])
+        self.assertEqual(data.datasets[0]["workspace_id"], "ws-1")
+        self.assertEqual(data.dataflows[1]["workspace_id"], "ws-2")
+        urls = [call.args[1] for call in self.guard.call_args_list[1:]]
+        self.assertIn("https://api.powerbi.com/v1.0/myorg/groups/ws-1/dataflows", urls)
+        self.assertIn("https://api.powerbi.com/v1.0/myorg/groups/ws-2/dataflows", urls)
+
+    def test_scoped_ingest_uses_group_paths(self):
+        self.guard.side_effect = [
+            token_response(),
+            FakeResponse({"id": "ws-9", "name": "Only"}),
+            FakeResponse({"value": [{"id": "ds-9"}]}),
+            FakeResponse({"value": []}),
+            FakeResponse({"value": []}),
+        ]
+        data = self.ingestor.ingest_workspace_metadata(workspace_id="ws-9")
+        self.assertEqual(len(data.workspaces), 1)
+        self.assertEqual([d["id"] for d in data.datasets], ["ds-9"])
+        urls = [call.args[1] for call in self.guard.call_args_list[1:]]
+        self.assertIn("https://api.powerbi.com/v1.0/myorg/groups/ws-9/datasets", urls)
+        self.assertIn("https://api.powerbi.com/v1.0/myorg/groups/ws-9/dataflows", urls)
 
     def test_unknown_include_raises(self):
         with self.assertRaises(Exception):

--- a/tests/ingest/test_powerbi_ingestor.py
+++ b/tests/ingest/test_powerbi_ingestor.py
@@ -1,0 +1,296 @@
+"""Unit tests for the Power BI ingestor.
+
+The HTTP layer is mocked by patching ``request_with_ssrf_guard`` in the
+ingestor module.  Tests assert on the *call signature* (method first, url
+second) so a mistake in argument order fails here instead of at runtime.
+"""
+
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, r"D:\Vaults\Projects\semantica-1572")
+
+from semantica.ingest import powerbi_ingestor as pbi  # noqa: E402
+from semantica.ingest.powerbi_ingestor import (  # noqa: E402
+    PowerBIConnector,
+    PowerBIData,
+    PowerBIIngestor,
+)
+
+GUARD = "semantica.ingest.powerbi_ingestor.request_with_ssrf_guard"
+
+CREDS = {
+    "tenant_id": "tenant-1",
+    "client_id": "client-1",
+    "client_secret": "secret-1",
+}
+
+
+class FakeResponse:
+    """Minimal stand-in for ``requests.Response``."""
+
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+
+def token_response():
+    return FakeResponse({"access_token": "tok-123", "expires_in": 3600})
+
+
+class TestLazyExports(unittest.TestCase):
+    def test_classes_are_importable_without_requests(self):
+        self.assertTrue(hasattr(pbi, "PowerBIData"))
+        self.assertTrue(hasattr(pbi, "PowerBIConnector"))
+        self.assertTrue(hasattr(pbi, "PowerBIIngestor"))
+
+    def test_module_all_lists_three_classes(self):
+        self.assertEqual(
+            set(pbi.__all__),
+            {"PowerBIData", "PowerBIConnector", "PowerBIIngestor"},
+        )
+
+    def test_lazy_export_resolves_via_package(self):
+        import semantica.ingest as ingest_pkg
+
+        self.assertIs(ingest_pkg.PowerBIIngestor, PowerBIIngestor)
+        self.assertIs(ingest_pkg.PowerBIData, PowerBIData)
+
+
+class TestCredentialValidation(unittest.TestCase):
+    def test_missing_tenant_raises(self):
+        with self.assertRaises(Exception):
+            PowerBIConnector(client_id="c", client_secret="s")
+
+    def test_missing_client_id_raises(self):
+        with self.assertRaises(Exception):
+            PowerBIConnector(tenant_id="t", client_secret="s")
+
+    def test_missing_client_secret_raises(self):
+        with self.assertRaises(Exception):
+            PowerBIConnector(tenant_id="t", client_id="c")
+
+    def test_full_credentials_construct(self):
+        connector = PowerBIConnector(**CREDS)
+        self.assertEqual(connector.tenant_id, "tenant-1")
+        connector.close()
+
+    def test_secret_not_exposed_as_public_attribute(self):
+        connector = PowerBIConnector(**CREDS)
+        self.assertNotIn("secret-1", str(vars(connector).get("client_id", "")))
+        self.assertIsNone(vars(connector).get("client_secret"))
+        connector.close()
+
+
+class TestTokenAcquisition(unittest.TestCase):
+    def test_token_request_uses_post_and_token_url(self):
+        connector = PowerBIConnector(**CREDS)
+        with patch(GUARD, return_value=token_response()) as guard:
+            token = connector._request_token()
+        self.assertEqual(token, "tok-123")
+        args, kwargs = guard.call_args
+        self.assertEqual(args[0], "POST")
+        self.assertIn("oauth2/v2.0/token", args[1])
+        self.assertEqual(kwargs["data"]["grant_type"], "client_credentials")
+        self.assertEqual(kwargs["data"]["client_id"], "client-1")
+        self.assertEqual(kwargs["data"]["client_secret"], "secret-1")
+        connector.close()
+
+    def test_token_is_cached(self):
+        connector = PowerBIConnector(**CREDS)
+        with patch(GUARD, return_value=token_response()) as guard:
+            connector._ensure_token()
+            connector._ensure_token()
+        self.assertEqual(guard.call_count, 1)
+        connector.close()
+
+    def test_token_endpoint_error_raises(self):
+        connector = PowerBIConnector(**CREDS)
+        with patch(GUARD, return_value=FakeResponse({"error": "nope"}, 401)):
+            with self.assertRaises(Exception):
+                connector._request_token()
+        connector.close()
+
+    def test_token_missing_field_raises(self):
+        connector = PowerBIConnector(**CREDS)
+        with patch(GUARD, return_value=FakeResponse({"expires_in": 3600})):
+            with self.assertRaises(Exception):
+                connector._request_token()
+        connector.close()
+
+
+class TestApiCalls(unittest.TestCase):
+    def setUp(self):
+        self.connector = PowerBIConnector(**CREDS)
+
+    def tearDown(self):
+        self.connector.close()
+
+    def test_get_uses_get_method_and_full_url(self):
+        with patch(GUARD) as guard:
+            guard.side_effect = [token_response(), FakeResponse({"value": []})]
+            self.connector.get("groups")
+        args, kwargs = guard.call_args
+        self.assertEqual(args[0], "GET")
+        self.assertEqual(args[1], "https://api.powerbi.com/v1.0/myorg/groups")
+        self.assertIn("Authorization", kwargs["headers"])
+        self.assertTrue(kwargs["headers"]["Authorization"].startswith("Bearer "))
+
+    def test_collection_response_is_unwrapped(self):
+        payload = {"value": [{"id": "ws-1", "name": "Sales"}]}
+        with patch(GUARD) as guard:
+            guard.side_effect = [token_response(), FakeResponse(payload)]
+            result = self.connector.get_workspaces()
+        self.assertEqual(result, [{"id": "ws-1", "name": "Sales"}])
+
+    def test_object_response_returned_as_dict(self):
+        with patch(GUARD) as guard:
+            guard.side_effect = [
+                token_response(),
+                FakeResponse({"id": "ws-9", "name": "Only"}),
+            ]
+            result = self.connector.get("groups/ws-9")
+        self.assertEqual(result, {"id": "ws-9", "name": "Only"})
+
+    def test_pagination_follows_next_link(self):
+        first = {"value": [{"id": "a"}], "@odata.nextLink": "https://next/1"}
+        second = {"value": [{"id": "b"}]}
+        with patch(GUARD) as guard:
+            guard.side_effect = [
+                token_response(),
+                FakeResponse(first),
+                FakeResponse(second),
+            ]
+            result = self.connector.get("datasets")
+        self.assertEqual([item["id"] for item in result], ["a", "b"])
+        self.assertEqual(guard.call_count, 3)
+
+    def test_workspace_scoped_paths(self):
+        with patch(GUARD) as guard:
+            guard.side_effect = [
+                token_response(),
+                FakeResponse({"value": []}),
+            ]
+            self.connector.get_datasets("ws-42")
+        args, _ = guard.call_args
+        self.assertEqual(
+            args[1], "https://api.powerbi.com/v1.0/myorg/groups/ws-42/datasets"
+        )
+
+    def test_unscoped_paths(self):
+        with patch(GUARD) as guard:
+            guard.side_effect = [token_response(), FakeResponse({"value": []})]
+            self.connector.get_reports()
+        args, _ = guard.call_args
+        self.assertEqual(args[1], "https://api.powerbi.com/v1.0/myorg/reports")
+
+    def test_http_error_raises(self):
+        with patch(GUARD) as guard:
+            guard.side_effect = [
+                token_response(),
+                FakeResponse({"error": "boom"}, 403),
+            ]
+            with self.assertRaises(Exception):
+                self.connector.get_workspaces()
+
+    def test_test_connection_true(self):
+        with patch(GUARD) as guard:
+            guard.side_effect = [token_response(), FakeResponse({"value": []})]
+            self.assertTrue(self.connector.test_connection())
+
+    def test_test_connection_false_on_error(self):
+        with patch(GUARD) as guard:
+            guard.side_effect = [token_response(), FakeResponse({}, 500)]
+            self.assertFalse(self.connector.test_connection())
+
+
+class TestIngestor(unittest.TestCase):
+    def setUp(self):
+        self.patcher = patch(GUARD)
+        self.guard = self.patcher.start()
+        self.guard.side_effect = [
+            token_response(),
+            FakeResponse({"value": [{"id": "ws-1", "name": "Sales"}]}),
+            FakeResponse({"value": [{"id": "ds-1", "name": "Orders"}]}),
+            FakeResponse({"value": [{"id": "rp-1", "name": "Q3"}]}),
+            FakeResponse({"value": []}),
+        ]
+        self.ingestor = PowerBIIngestor(**CREDS)
+
+    def tearDown(self):
+        self.ingestor.close()
+        self.patcher.stop()
+
+    def test_ingest_returns_powerbi_data(self):
+        data = self.ingestor.ingest_workspace_metadata()
+        self.assertIsInstance(data, PowerBIData)
+        self.assertEqual(len(data.workspaces), 1)
+        self.assertEqual(len(data.datasets), 1)
+        self.assertEqual(len(data.reports), 1)
+        self.assertEqual(len(data.dataflows), 0)
+
+    def test_metadata_counts(self):
+        data = self.ingestor.ingest_workspace_metadata()
+        self.assertEqual(data.metadata["dataset_count"], 1)
+        self.assertEqual(data.metadata["report_count"], 1)
+        self.assertEqual(data.metadata["dataflow_count"], 0)
+
+    def test_include_subset_skips_unwanted_calls(self):
+        self.guard.side_effect = [
+            token_response(),
+            FakeResponse({"value": [{"id": "ds-1", "name": "Orders"}]}),
+        ]
+        data = self.ingestor.ingest_workspace_metadata(include=["datasets"])
+        self.assertEqual(len(data.datasets), 1)
+        self.assertEqual(data.workspaces, [])
+
+    def test_unknown_include_raises(self):
+        with self.assertRaises(Exception):
+            self.ingestor.ingest_workspace_metadata(include=["nope"])
+
+    def test_export_documents_shape(self):
+        data = self.ingestor.ingest_workspace_metadata()
+        documents = self.ingestor.export_as_documents(data)
+        self.assertEqual(len(documents), 3)
+        for doc in documents:
+            self.assertIn("id", doc)
+            self.assertIn("text", doc)
+            self.assertIn("metadata", doc)
+            self.assertEqual(doc["metadata"]["source"], "powerbi")
+
+    def test_export_documents_resource_types(self):
+        data = self.ingestor.ingest_workspace_metadata()
+        documents = self.ingestor.export_as_documents(data)
+        types = {doc["metadata"]["resource_type"] for doc in documents}
+        self.assertEqual(types, {"workspace", "dataset", "report"})
+
+    def test_export_document_text_mentions_name(self):
+        data = self.ingestor.ingest_workspace_metadata()
+        documents = self.ingestor.export_as_documents(data)
+        dataset_doc = [
+            d for d in documents if d["metadata"]["resource_type"] == "dataset"
+        ][0]
+        self.assertIn("Orders", dataset_doc["text"])
+
+    def test_missing_id_falls_back_to_index(self):
+        data = PowerBIData(
+            workspaces=[],
+            datasets=[{"name": "Nameless"}],
+            reports=[],
+            dataflows=[],
+        )
+        documents = self.ingestor.export_as_documents(data)
+        self.assertEqual(documents[0]["id"], "dataset-0")
+
+    def test_context_manager_closes(self):
+        with PowerBIIngestor(**CREDS) as ingestor:
+            self.assertIsNotNone(ingestor.connector)
+        self.assertIsNone(ingestor.connector._session)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ingest/test_powerbi_ingestor.py
+++ b/tests/ingest/test_powerbi_ingestor.py
@@ -8,8 +8,8 @@ second) so a mistake in argument order fails here instead of at runtime.
 import unittest
 from unittest.mock import patch
 
-from semantica.ingest import powerbi_ingestor as pbi  # noqa: E402
-from semantica.ingest.powerbi_ingestor import (  # noqa: E402
+from semantica.ingest import powerbi_ingestor as pbi
+from semantica.ingest.powerbi_ingestor import (
     PowerBIConnector,
     PowerBIData,
     PowerBIIngestor,
@@ -40,7 +40,7 @@ def token_response():
 
 
 class TestLazyExports(unittest.TestCase):
-    def test_classes_are_importable_without_requests(self):
+    def test_classes_are_module_level_attributes(self):
         self.assertTrue(hasattr(pbi, "PowerBIData"))
         self.assertTrue(hasattr(pbi, "PowerBIConnector"))
         self.assertTrue(hasattr(pbi, "PowerBIIngestor"))


### PR DESCRIPTION
## Description

Adds a Power BI connector that pulls workspace, dataset, report and dataflow metadata from the Power BI REST API and exports it as documents for `GraphBuilder`.

Authentication is Azure AD OAuth2 client-credentials. The API is plain JSON over HTTPS, so `requests` is the only dependency — the same shape as the SAP connector.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues

Closes #1572

## Changes Made

- `semantica/ingest/powerbi_ingestor.py` with `PowerBIData`, `PowerBIConnector` and `PowerBIIngestor`, following the Snowflake / Salesforce / Redshift three-class layout:
  - `PowerBIConnector` acquires and caches an Azure AD client-credentials token, refreshing 60 seconds before expiry. The secret lives in a private attribute and is never written to logs.
  - Workspace, dataset, report and dataflow metadata can be pulled together or selected with `include=`. Passing a workspace scopes the child resources to it; omitting one walks every workspace the service principal can see, because the unscoped `myorg` endpoints only cover My workspace.
  - `@odata.nextLink` pagination is followed up to a bounded number of hops, and a next link pointing at another origin is rejected rather than handed the bearer token.
  - Every outbound call, the token request included, goes through `request_with_ssrf_guard`.
- Lazy-import registration for the three classes in `semantica/ingest/__init__.py`. Importing `semantica.ingest` does not load the connector eagerly.
- No new optional dependency: `requests` is already a core dependency and `semantica/ingest/api_ingestor.py` imports it unconditionally, so `pyproject.toml` is untouched.
- `docs/integrations/powerbi.md` plus the matching `docs/docs.json` navigation entry.
- `tests/ingest/test_powerbi_ingestor.py` with 34 unit tests, HTTP layer mocked.

## Testing

- [x] Tested locally
- [x] Added tests for new functionality
- [x] Package builds successfully (`python -m build`)

### Test Commands

```bash
python -m build
pytest tests/ingest/test_powerbi_ingestor.py
black semantica/ingest/powerbi_ingestor.py tests/ingest/test_powerbi_ingestor.py
isort semantica/ingest/powerbi_ingestor.py tests/ingest/test_powerbi_ingestor.py
```

34 tests pass. The full `tests/ingest/` suite fails on exactly the same tests as a clean `origin/main` checkout (web, feed, repo and notebook ingestors, all network-dependent); this change adds none.

Tests assert on the guard's call arguments, not just that it was called, so the `request_with_ssrf_guard(method, url, ...)` argument order is covered.

## Documentation

- [x] Updated relevant documentation
- [x] Added code examples if applicable
- [ ] Updated API reference if adding new APIs
- [ ] Updated cookbook if adding new examples
- [ ] No documentation changes needed

## Breaking Changes

**Breaking Changes**: No

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Package builds successfully

## Additional Notes

Scope note: this reads catalog metadata only. It does not execute DAX or export dataset rows, which the REST API does not expose.
